### PR TITLE
removed async_contextmanager dependency, use sqlite3 shortcut methods

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     packages=find_packages(),
     provides=["asyncua"],
     license="GNU Lesser General Public License v3 or later",
-    install_requires=["aiofiles", "asyncio-contextmanager", "python-dateutil", "pytz", "lxml", 'cryptography'],
+    install_requires=["aiofiles", "python-dateutil", "pytz", "lxml", 'cryptography'],
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Fixes #28 
I removed the contextmanager dependency. Using the sqlite3 shortcut methods described here [https://docs.python.org/3/library/sqlite3.html#using-sqlite3-efficiently](https://docs.python.org/3/library/sqlite3.html#using-sqlite3-efficiently) i removed explicit creation of the cursor altogether.