### PR TITLE
refactored subscription.modify_monitored_item

### DIFF
--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -403,7 +403,7 @@ class InternalSession:
                                                          ServerItemCallback(params, subscription_result))
         return subscription_result
 
-    def modify_monitored_items(self, params):
+    async def modify_monitored_items(self, params):
         subscription_result = self.subscription_service.modify_monitored_items(params)
         self.iserver.server_callback_dispatcher.dispatch(CallbackType.ItemSubscriptionModified,
                                                          ServerItemCallback(params, subscription_result))


### PR DESCRIPTION
relates to #25 
Refactoring of common.subscription.modify_monitored_item - Scrutinizer reported that `item_to_change` was not defined for all paths.
New test for `modify_monitored_item`.
Fixes a bug in internal_server.modify_monitored_items (has to be a coroutine).