### PR TITLE
UaClient refactoring

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -586,10 +586,10 @@ class Client:
             node.nodeid = node.basenodeid
             node.basenodeid = None
 
-    def get_values(self, nodes):
+    async def get_values(self, nodes):
         """
         Read the value of multiple nodes in one roundtrip.
         """
         nodes = [node.nodeid for node in nodes]
-        results = self.uaclient.get_attribute(nodes, ua.AttributeIds.Value)
+        results = await self.uaclient.get_attribute(nodes, ua.AttributeIds.Value)
         return [result.Value.Value for result in results]

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -105,7 +105,7 @@ class UASocketProtocol(asyncio.Protocol):
             self._request_handle -= 1
             raise
         self._request_id += 1
-        future = asyncio.Future()
+        future = self.loop.create_future()
         self._callbackmap[self._request_id] = future
         msg = self._connection.message_to_binary(binreq, message_type=message_type, request_id=self._request_id)
         self.transport.write(msg)
@@ -440,7 +440,7 @@ class UaClient:
             acks = []
         request = ua.PublishRequest()
         request.Parameters.SubscriptionAcknowledgements = acks
-        # We do not wait for publish response in this task
+        # We do not want to wait for publish response in this task
         self.loop.create_task(self._send_publish_request(request))
 
     """

--- a/examples/server-minimal.py
+++ b/examples/server-minimal.py
@@ -1,10 +1,13 @@
-import sys
-sys.path.insert(0, "..")
+
 import logging
 import asyncio
 
 from asyncua import ua, Server
 from asyncua.common.methods import uamethod
+
+
+logging.basicConfig(level=logging.INFO)
+_logger = logging.getLogger('asyncua')
 
 
 @uamethod
@@ -16,38 +19,33 @@ async def main():
     # setup our server
     server = Server()
     await server.init()
-    server.set_endpoint('opc.tcp://*:4840/freeopcua/server/') #4840
+    server.set_endpoint('opc.tcp://0.0.0.0:4840/freeopcua/server/')
     # setup our own namespace, not really necessary but should as spec
     uri = 'http://examples.freeopcua.github.io'
     idx = await server.register_namespace(uri)
     # get Objects node, this is where we should put our nodes
     objects = server.get_objects_node()
-
     # populating our address space
     myobj = await objects.add_object(idx, 'MyObject')
     myvar = await myobj.add_variable(idx, 'MyVariable', 6.7)
-    await myvar.set_writable()  # Set MyVariable to be writable by clients
-
+    # Set MyVariable to be writable by clients
+    await myvar.set_writable()
     await objects.add_method(
-        ua.NodeId("ServerMethod", 2), ua.QualifiedName('ServerMethod', 2),
+        ua.NodeId('ServerMethod', 2), ua.QualifiedName('ServerMethod', 2),
         func, [ua.VariantType.Int64], [ua.VariantType.Int64]
     )
-
-    # starting!
+    _logger.info('Starting server!')
     async with server:
         count = 0
         while True:
             await asyncio.sleep(1)
             count += 0.1
-            print("SET VALUE", myvar, count)
+            _logger.info('Set value of %s to %.1f', myvar, count)
             await myvar.set_value(count)
 
 
 if __name__ == '__main__':
-    logging.basicConfig(level=logging.WARNING)
     loop = asyncio.get_event_loop()
-    #loop.set_debug(True)
+    # loop.set_debug(True)
     loop.run_until_complete(main())
     loop.close()
-
-


### PR DESCRIPTION
I removed the callback parameter from UASocketProtocol._send_request(). Now only the returned `Future` can be used which simplifies the code.
Fixed some bugs in untested methods e.g. `UaClient.register_nodes`.
Cleaned up the server-minimal example. We should not use the `*` binding for host names as it does not work on windows. `0.0.0.0` should work for both platforms?
