### PR TITLE
Refactored Subscription

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -485,18 +485,16 @@ class Client:
         :param handler: Class instance with data_change and/or event methods (see `SubHandler`
         base class for details). Remember not to block the main event loop inside the handler methods.
         """
-
         if isinstance(period, ua.CreateSubscriptionParameters):
-            subscription = Subscription(self.uaclient, period, handler)
-            await subscription.init()
-            return subscription
-        params = ua.CreateSubscriptionParameters()
-        params.RequestedPublishingInterval = period
-        params.RequestedLifetimeCount = 10000
-        params.RequestedMaxKeepAliveCount = 3000
-        params.MaxNotificationsPerPublish = 10000
-        params.PublishingEnabled = True
-        params.Priority = 0
+            params = period
+        else:
+            params = ua.CreateSubscriptionParameters()
+            params.RequestedPublishingInterval = period
+            params.RequestedLifetimeCount = 10000
+            params.RequestedMaxKeepAliveCount = 3000
+            params.MaxNotificationsPerPublish = 10000
+            params.PublishingEnabled = True
+            params.Priority = 0
         subscription = Subscription(self.uaclient, params, handler)
         await subscription.init()
         return subscription

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -471,24 +471,19 @@ class Client:
 
     def get_node(self, nodeid: Union[ua.NodeId, str]) -> Node:
         """
-        Get node using NodeId object or a string representing a NodeId
+        Get node using NodeId object or a string representing a NodeId.
         """
         return Node(self.uaclient, nodeid)
 
     async def create_subscription(self, period, handler):
         """
         Create a subscription.
-        returns a Subscription object which allow
-        to subscribe to events or data on server
-        handler argument is a class with data_change and/or event methods.
-        period argument is either a publishing interval in milliseconds or a
-        CreateSubscriptionParameters instance. The second option should be used,
-        if the asyncua-server has problems with the default options.
-        These methods will be called when notfication from server are received.
-        See example-client.py.
-        Do not do expensive/slow or network operation from these methods
-        since they are called directly from receiving thread. This is a design choice,
-        start another thread if you need to do such a thing.
+        Returns a Subscription object which allows to subscribe to events or data changes on server.
+
+        :param period: Either a publishing interval in milliseconds or a `CreateSubscriptionParameters` instance.
+        The second option should be used, if the asyncua-server has problems with the default options.
+        :param handler: Class instance with data_change and/or event methods (see `SubHandler`
+        base class for details). Remember not to block the main event loop inside the handler methods.
         """
 
         if isinstance(period, ua.CreateSubscriptionParameters):

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -7,12 +7,8 @@ from typing import Dict, List
 from asyncua import ua
 from typing import Optional
 from ..ua.ua_binary import struct_from_binary, uatcp_to_binary, struct_to_binary, nodeid_from_binary, header_from_binary
-from ..ua.uaerrors import BadTimeout, BadNoSubscription, BadSessionClosed
+from ..ua.uaerrors import BadTimeout, BadNoSubscription, BadSessionClosed, UaStructParsingError
 from ..common.connection import SecureConnection
-
-
-class ResponseParseError(ValueError):
-    """Error while parsing responses."""
 
 
 class UASocketProtocol(asyncio.Protocol):
@@ -426,7 +422,7 @@ class UaClient:
         self.logger.info("create_subscription success SubscriptionId %s", response.Parameters.SubscriptionId)
         if not self._publish_task or self._publish_task.done():
             # Start the publish cycle if it is not yet running
-            self._publish_task = self.loop.create_task(self._publish_cycle())
+            self._publish_task = self.loop.create_task(self._publish_loop())
         return response.Parameters
 
     async def delete_subscriptions(self, subscription_ids):
@@ -457,10 +453,10 @@ class UaClient:
             response = struct_from_binary(ua.PublishResponse, data)
         except Exception:
             self.logger.exception("Error parsing notification from server")
-            raise ResponseParseError
+            raise UaStructParsingError
         return response
 
-    async def _publish_cycle(self):
+    async def _publish_loop(self):
         """
         Start publish cycle that sends a publish request and waits for the publish response in an endless loop.
         Forward the `PublishResult` to the matching `Subscription` by callback.
@@ -489,7 +485,7 @@ class UaClient:
                 self.logger.info("BadNoSubscription received, ignoring because it's probably valid.")
                 # End task
                 return
-            except ResponseParseError:
+            except UaStructParsingError:
                 ack = None
                 continue
             subscription_id = response.Parameters.SubscriptionId

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -138,12 +138,14 @@ class UASocketProtocol(asyncio.Protocol):
         return True
 
     def _call_callback(self, request_id, body):
-        future = self._callbackmap.pop(request_id, None)
-        if future is None:
+        try:
+            self._callbackmap[request_id].set_result(body)
+        except KeyError:
             raise ua.UaError(
-                f"No request found for requestid: {request_id}, callbacks in list are {self._callbackmap.keys()}"
+                f"No request found for request id: {request_id}, pending are {self._callbackmap.keys()}"
             )
-        future.set_result(body)
+        except asyncio.InvalidStateError:
+            raise ua.UaError(f"Future for request id {request_id} is already done")
 
     def _create_request_header(self, timeout=1000):
         hdr = ua.RequestHeader()
@@ -215,12 +217,11 @@ class UaClient:
     def __init__(self, timeout=1, loop=None):
         self.logger = logging.getLogger(f'{__name__}.UaClient')
         self.loop = loop or asyncio.get_event_loop()
-        self._publish_callbacks = {}
+        self._subscription_callbacks = {}
         self._timeout = timeout
         self.security_policy = ua.SecurityPolicy()
         self.protocol: Optional[UASocketProtocol] = None
-        self._sub_cond = asyncio.Condition()
-        self._sub_data_queue = []
+        self._publish_task = None
 
     def set_security(self, policy: ua.SecurityPolicy):
         self.security_policy = policy
@@ -279,6 +280,8 @@ class UaClient:
 
     async def close_session(self, delete_subscriptions):
         self.logger.info("close_session")
+        if self._publish_task and not self._publish_task.done():
+            self._publish_task.cancel()
         if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
             self.logger.warning("close_session was called but connection is closed")
             return
@@ -306,7 +309,7 @@ class UaClient:
         return response.Results
 
     async def browse_next(self, parameters):
-        self.logger.info("browse next")
+        self.logger.debug("browse next")
         request = ua.BrowseNextRequest()
         request.Parameters = parameters
         data = await self.protocol.send_request(request)
@@ -316,7 +319,7 @@ class UaClient:
         return response.Parameters.Results
 
     async def read(self, parameters):
-        self.logger.info("read")
+        self.logger.debug("read")
         request = ua.ReadRequest()
         request.Parameters = parameters
         data = await self.protocol.send_request(request)
@@ -336,7 +339,7 @@ class UaClient:
         return response.Results
 
     async def write(self, params):
-        self.logger.info("read")
+        self.logger.debug("write")
         request = ua.WriteRequest()
         request.Parameters = params
         data = await self.protocol.send_request(request)
@@ -346,7 +349,7 @@ class UaClient:
         return response.Results
 
     async def get_endpoints(self, params):
-        self.logger.info("get_endpoint")
+        self.logger.debug("get_endpoint")
         request = ua.GetEndpointsRequest()
         request.Parameters = params
         data = await self.protocol.send_request(request)
@@ -356,7 +359,7 @@ class UaClient:
         return response.Endpoints
 
     async def find_servers(self, params):
-        self.logger.info("find_servers")
+        self.logger.debug("find_servers")
         request = ua.FindServersRequest()
         request.Parameters = params
         data = await self.protocol.send_request(request)
@@ -366,7 +369,7 @@ class UaClient:
         return response.Servers
 
     async def find_servers_on_network(self, params):
-        self.logger.info("find_servers_on_network")
+        self.logger.debug("find_servers_on_network")
         request = ua.FindServersOnNetworkRequest()
         request.Parameters = params
         data = await self.protocol.send_request(request)
@@ -376,7 +379,7 @@ class UaClient:
         return response.Parameters
 
     async def register_server(self, registered_server):
-        self.logger.info("register_server")
+        self.logger.debug("register_server")
         request = ua.RegisterServerRequest()
         request.Server = registered_server
         data = await self.protocol.send_request(request)
@@ -386,7 +389,7 @@ class UaClient:
         # nothing to return for this service
 
     async def register_server2(self, params):
-        self.logger.info("register_server2")
+        self.logger.debug("register_server2")
         request = ua.RegisterServer2Request()
         request.Parameters = params
         data = await self.protocol.send_request(request)
@@ -396,7 +399,7 @@ class UaClient:
         return response.ConfigurationResults
 
     async def translate_browsepaths_to_nodeids(self, browse_paths):
-        self.logger.info("translate_browsepath_to_nodeid")
+        self.logger.debug("translate_browsepath_to_nodeid")
         request = ua.TranslateBrowsePathsToNodeIdsRequest()
         request.Parameters.BrowsePaths = browse_paths
         data = await self.protocol.send_request(request)
@@ -406,7 +409,7 @@ class UaClient:
         return response.Results
 
     async def create_subscription(self, params, callback):
-        self.logger.info("create_subscription")
+        self.logger.debug("create_subscription")
         request = ua.CreateSubscriptionRequest()
         request.Parameters = params
         data = await self.protocol.send_request(request)
@@ -414,14 +417,16 @@ class UaClient:
             ua.CreateSubscriptionResponse,
             data
         )
-        self.logger.info("create subscription callback")
-        self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
-        self._publish_callbacks[response.Parameters.SubscriptionId] = callback
+        self._subscription_callbacks[response.Parameters.SubscriptionId] = callback
+        self.logger.info("create_subscription success SubscriptionId %s", response.Parameters.SubscriptionId)
+        if not self._publish_task or self._publish_task.done():
+            # Start the publish cycle on the first subscription
+            self._publish_task = self.loop.create_task(self._publish())
         return response.Parameters
 
     async def delete_subscriptions(self, subscription_ids):
-        self.logger.info("delete_subscription")
+        self.logger.debug("delete_subscriptions %r", subscription_ids)
         request = ua.DeleteSubscriptionsRequest()
         request.Parameters.SubscriptionIds = subscription_ids
         data = await self.protocol.send_request(request)
@@ -429,94 +434,87 @@ class UaClient:
             ua.DeleteSubscriptionsResponse,
             data
         )
-        self.logger.info("delete subscriptions callback")
-        self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
+        self.logger.info("remove subscription callbacks")
         for sid in subscription_ids:
-            self._publish_callbacks.pop(sid)
+            self._subscription_callbacks.pop(sid)
         return response.Results
 
-    async def publish(self, acks=None):
-        self.logger.info("publish")
-        if acks is None:
-            acks = []
-        request = ua.PublishRequest()
-        request.Parameters.SubscriptionAcknowledgements = acks
-        # We do not want to wait for publish response in this task
-        self.loop.create_task(self._send_publish_request(request))
+    def publish(self):
+        """
+        This is just for maintaining symmetry.
+        This client takes care of sending PublishRequest internally.
+        """
+        pass
 
-    """
-    # to avoid fire and forget of task we could use a loop:
-    def _sub_data_received(self, future):
-        data = future.result()
-        self.loop.create_task(self._enqueue_sub_data(data))
-
-    async def _enqueue_sub_data(self, data):
-        self._sub_data_queue.append(data)
-        with self._sub_cond:
-            self._sub_cond.notify()
-
-    async def _subscribtion_loop(self):
+    async def _publish(self):
+        """
+        Cyclically send publish request and wait for the publish response.
+        Send the `PublishResult` to the matching `Subscription`.
+        """
+        ack = None
         while True:
-            async with self._sub_cond:
-                await self._sub_cond.wait()
-                data = self._sub_data_queue.pop(0)
-                await self._call_publish_callback(data)
-    """
-
-    async def _send_publish_request(self, request):
-        """
-        Send publish request and wait for publish response.
-        :param request:
-        :return:
-        """
-        data = await self.protocol.send_request(request, timeout=0)
-        try:
-            self.protocol.check_answer(data, "while waiting for publish response")
-        except BadTimeout:
-            # Spec Part 4, 7.28
-            await self.publish()
-            return
-        except BadNoSubscription:  # Spec Part 5, 13.8.1
-            # BadNoSubscription is expected after deleting the last subscription.
-            #
-            # We should therefore also check for len(self._publishcallbacks) == 0, but
-            # this gets us into trouble if a Publish response arrives before the
-            # DeleteSubscription response.
-            #
-            # We could remove the callback already when sending the DeleteSubscription request,
-            # but there are some legitimate reasons to keep them around, such as when the server
-            # responds with "BadTimeout" and we should try again later instead of just removing
-            # the subscription client-side.
-            #
-            # There are a variety of ways to act correctly, but the most practical solution seems
-            # to be to just ignore any BadNoSubscription responses.
-            self.logger.info("BadNoSubscription received, ignoring because it's probably valid.")
-            return
-        # parse publish response
-        try:
-            response = struct_from_binary(ua.PublishResponse, data)
-            self.logger.debug(response)
-        except Exception:
-            # INFO: catching the exception here might be obsolete because we already
-            #       catch BadTimeout above. However, it's not really clear what this code
-            #       does so it stays in, doesn't seem to hurt.
-            self.logger.exception("Error parsing notification from server")
-            # send publish request ot server so he does stop sending notifications
-            await self.publish([])
-            return
-        # look for callback
-        try:
-            callback = self._publish_callbacks[response.Parameters.SubscriptionId]
-        except KeyError:
-            self.logger.warning("Received data for unknown subscription: %s ", response.Parameters.SubscriptionId)
-            return
-        # do callback
-        try:
-            await callback(response.Parameters)
-        except Exception:
-            # we call client code, catch everything!
-            self.logger.exception("Exception while calling user callback: %s")
+            if not self._subscription_callbacks:
+                # End Task if there are no more subscriptions
+                break
+            self.logger.debug("publish")
+            request = ua.PublishRequest()
+            request.Parameters.SubscriptionAcknowledgements = [ack] if ack else []
+            data = await self.protocol.send_request(request, timeout=0)
+            try:
+                self.protocol.check_answer(data, "while waiting for publish response")
+            except BadTimeout:
+                # Spec Part 4, 7.28
+                # Repeat without Acknowledgement
+                ack = None
+                continue
+            except BadNoSubscription:  # Spec Part 5, 13.8.1
+                # BadNoSubscription is expected after deleting the last subscription.
+                #
+                # We should therefore also check for len(self._publishcallbacks) == 0, but
+                # this gets us into trouble if a Publish response arrives before the
+                # DeleteSubscription response.
+                #
+                # We could remove the callback already when sending the DeleteSubscription request,
+                # but there are some legitimate reasons to keep them around, such as when the server
+                # responds with "BadTimeout" and we should try again later instead of just removing
+                # the subscription client-side.
+                #
+                # There are a variety of ways to act correctly, but the most practical solution seems
+                # to be to just ignore any BadNoSubscription responses.
+                self.logger.info("BadNoSubscription received, ignoring because it's probably valid.")
+                ack = None
+                continue
+            # parse publish response
+            try:
+                response = struct_from_binary(ua.PublishResponse, data)
+                self.logger.debug(response)
+            except Exception:
+                # INFO: catching the exception here might be obsolete because we already
+                #       catch BadTimeout above. However, it's not really clear what this code
+                #       does so it stays in, doesn't seem to hurt.
+                self.logger.exception("Error parsing notification from server")
+                # send publish request to server so he does stop sending notifications
+                ack = None
+                continue
+            # look for matching subscription callback
+            subscription_id = response.Parameters.SubscriptionId
+            try:
+                callback = self._subscription_callbacks[subscription_id]
+            except KeyError:
+                self.logger.warning("Received data for unknown subscription %s active are %s", subscription_id,
+                                    self._subscription_callbacks.keys())
+            else:
+                # do callback
+                try:
+                    callback(response.Parameters)
+                except Exception:
+                    # we call client code, catch everything!
+                    self.logger.exception("Exception while calling user callback: %s")
+            # Repeat with acknowledgement
+            ack = ua.SubscriptionAcknowledgement()
+            ack.SubscriptionId = subscription_id
+            ack.SequenceNumber = response.Parameters.NotificationMessage.SequenceNumber
 
     async def create_monitored_items(self, params):
         self.logger.info("create_monitored_items")

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -421,7 +421,7 @@ class UaClient:
         self._subscription_callbacks[response.Parameters.SubscriptionId] = callback
         self.logger.info("create_subscription success SubscriptionId %s", response.Parameters.SubscriptionId)
         if not self._publish_task or self._publish_task.done():
-            # Start the publish cycle on the first subscription
+            # Start the publish cycle if it is not yet running
             self._publish_task = self.loop.create_task(self._publish())
         return response.Parameters
 
@@ -435,7 +435,7 @@ class UaClient:
             data
         )
         response.ResponseHeader.ServiceResult.check()
-        self.logger.info("remove subscription callbacks")
+        self.logger.info("remove subscription callbacks for %r", subscription_ids)
         for sid in subscription_ids:
             self._subscription_callbacks.pop(sid)
         return response.Results
@@ -449,31 +449,25 @@ class UaClient:
 
     async def _publish(self):
         """
-        Cyclically send publish request and wait for the publish response.
-        Send the `PublishResult` to the matching `Subscription`.
+        Send publish request and wait for the publish response in an endless loop.
+        Forward the `PublishResult` to the matching `Subscription` by callback.
         """
         ack = None
         while True:
-            if not self._subscription_callbacks:
-                # End Task if there are no more subscriptions
-                break
-            self.logger.debug("publish")
             request = ua.PublishRequest()
             request.Parameters.SubscriptionAcknowledgements = [ack] if ack else []
             data = await self.protocol.send_request(request, timeout=0)
             try:
                 self.protocol.check_answer(data, "while waiting for publish response")
-            except BadTimeout:
-                # Spec Part 4, 7.28
-                # Repeat without Acknowledgement
+            except BadTimeout:  # See Spec. Part 4, 7.28
+                # Repeat without acknowledgement
                 ack = None
                 continue
-            except BadNoSubscription:  # Spec Part 5, 13.8.1
-                # BadNoSubscription is expected after deleting the last subscription.
-                #
-                # We should therefore also check for len(self._publishcallbacks) == 0, but
-                # this gets us into trouble if a Publish response arrives before the
-                # DeleteSubscription response.
+            except BadNoSubscription:  # See Spec. Part 5, 13.8.1
+                # BadNoSubscription is expected to be received after deleting the last subscription.
+                # We use this as a signal to exit this task and stop sending PublishRequests. This is easier then
+                # checking if there are no more subscriptions registered in this client (). A Publish response
+                # could still arrive before the DeleteSubscription response.
                 #
                 # We could remove the callback already when sending the DeleteSubscription request,
                 # but there are some legitimate reasons to keep them around, such as when the server
@@ -481,14 +475,13 @@ class UaClient:
                 # the subscription client-side.
                 #
                 # There are a variety of ways to act correctly, but the most practical solution seems
-                # to be to just ignore any BadNoSubscription responses.
+                # to be to just silently ignore any BadNoSubscription responses.
                 self.logger.info("BadNoSubscription received, ignoring because it's probably valid.")
-                ack = None
-                continue
+                # End task
+                return
             # parse publish response
             try:
                 response = struct_from_binary(ua.PublishResponse, data)
-                self.logger.debug(response)
             except Exception:
                 # INFO: catching the exception here might be obsolete because we already
                 #       catch BadTimeout above. However, it's not really clear what this code
@@ -505,11 +498,9 @@ class UaClient:
                 self.logger.warning("Received data for unknown subscription %s active are %s", subscription_id,
                                     self._subscription_callbacks.keys())
             else:
-                # do callback
                 try:
                     callback(response.Parameters)
-                except Exception:
-                    # we call client code, catch everything!
+                except Exception:  # we call client code, catch everything!
                     self.logger.exception("Exception while calling user callback: %s")
             # Repeat with acknowledgement
             ack = ua.SubscriptionAcknowledgement()

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -3,12 +3,16 @@ Low level binary client
 """
 import asyncio
 import logging
-from typing import Dict
+from typing import Dict, List
 from asyncua import ua
 from typing import Optional
 from ..ua.ua_binary import struct_from_binary, uatcp_to_binary, struct_to_binary, nodeid_from_binary, header_from_binary
 from ..ua.uaerrors import BadTimeout, BadNoSubscription, BadSessionClosed
 from ..common.connection import SecureConnection
+
+
+class ResponseParseError(ValueError):
+    """Error while parsing responses."""
 
 
 class UASocketProtocol(asyncio.Protocol):
@@ -422,7 +426,7 @@ class UaClient:
         self.logger.info("create_subscription success SubscriptionId %s", response.Parameters.SubscriptionId)
         if not self._publish_task or self._publish_task.done():
             # Start the publish cycle if it is not yet running
-            self._publish_task = self.loop.create_task(self._publish())
+            self._publish_task = self.loop.create_task(self._publish_cycle())
         return response.Parameters
 
     async def delete_subscriptions(self, subscription_ids):
@@ -440,25 +444,30 @@ class UaClient:
             self._subscription_callbacks.pop(sid)
         return response.Results
 
-    def publish(self):
+    async def publish(self, acks: List[ua.SubscriptionAcknowledgement]) -> ua.PublishResponse:
         """
-        This is just for maintaining symmetry.
-        This client takes care of sending PublishRequest internally.
+        Send a PublishRequest to the server.
         """
-        pass
+        request = ua.PublishRequest()
+        request.Parameters.SubscriptionAcknowledgements = acks if acks else []
+        data = await self.protocol.send_request(request, timeout=0)
+        self.protocol.check_answer(data, "while waiting for publish response")
+        try:
+            response = struct_from_binary(ua.PublishResponse, data)
+        except Exception:
+            self.logger.exception("Error parsing notification from server")
+            raise ResponseParseError
+        return response
 
-    async def _publish(self):
+    async def _publish_cycle(self):
         """
-        Send publish request and wait for the publish response in an endless loop.
+        Start publish cycle that sends a publish request and waits for the publish response in an endless loop.
         Forward the `PublishResult` to the matching `Subscription` by callback.
         """
         ack = None
         while True:
-            request = ua.PublishRequest()
-            request.Parameters.SubscriptionAcknowledgements = [ack] if ack else []
-            data = await self.protocol.send_request(request, timeout=0)
             try:
-                self.protocol.check_answer(data, "while waiting for publish response")
+                response = await self.publish([ack] if ack else [])
             except BadTimeout:  # See Spec. Part 4, 7.28
                 # Repeat without acknowledgement
                 ack = None
@@ -479,14 +488,7 @@ class UaClient:
                 self.logger.info("BadNoSubscription received, ignoring because it's probably valid.")
                 # End task
                 return
-            # parse publish response
-            try:
-                response = struct_from_binary(ua.PublishResponse, data)
-            except Exception:
-                # INFO: catching the exception here might be obsolete because we already
-                #       catch BadTimeout above. However, it's not really clear what this code
-                #       does so it stays in, doesn't seem to hurt.
-                self.logger.exception("Error parsing notification from server")
+            except ResponseParseError:
                 # send publish request to server so he does stop sending notifications
                 ack = None
                 continue

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -448,6 +448,7 @@ class UaClient:
         """
         Send a PublishRequest to the server.
         """
+        self.logger.debug('publish %r', acks)
         request = ua.PublishRequest()
         request.Parameters.SubscriptionAcknowledgements = acks if acks else []
         data = await self.protocol.send_request(request, timeout=0)
@@ -489,16 +490,21 @@ class UaClient:
                 # End task
                 return
             except ResponseParseError:
-                # send publish request to server so he does stop sending notifications
                 ack = None
                 continue
-            # look for matching subscription callback
             subscription_id = response.Parameters.SubscriptionId
+            if not subscription_id:
+                # The value 0 is used to indicate that there were no Subscriptions defined for which a
+                # response could be sent. See Spec. Part 4 - Section 5.13.5 "Publish"
+                # End task
+                return
             try:
                 callback = self._subscription_callbacks[subscription_id]
             except KeyError:
-                self.logger.warning("Received data for unknown subscription %s active are %s", subscription_id,
-                                    self._subscription_callbacks.keys())
+                self.logger.warning(
+                    "Received data for unknown subscription %s active are %s", subscription_id,
+                    self._subscription_callbacks.keys()
+                )
             else:
                 try:
                     callback(response.Parameters)

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -421,7 +421,10 @@ class UaClient:
         self._subscription_callbacks[response.Parameters.SubscriptionId] = callback
         self.logger.info("create_subscription success SubscriptionId %s", response.Parameters.SubscriptionId)
         if not self._publish_task or self._publish_task.done():
-            # Start the publish cycle if it is not yet running
+            # Start the publish loop if it is not yet running
+            # The current strategy is to have only one open publish request per UaClient. This might not be enough
+            # in high latency networks or in case many subscriptions are created. A Set of Tasks of `_publish_loop`
+            # could be used if necessary.
             self._publish_task = self.loop.create_task(self._publish_loop())
         return response.Parameters
 
@@ -458,7 +461,7 @@ class UaClient:
 
     async def _publish_loop(self):
         """
-        Start publish cycle that sends a publish request and waits for the publish response in an endless loop.
+        Start a loop that sends a publish requests and waits for the publish responses.
         Forward the `PublishResult` to the matching `Subscription` by callback.
         """
         ack = None

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -163,7 +163,7 @@ class Subscription:
 
         :param nodes: One Node or an Iterable of Nodes
         :param attr: The Node attribute you want to subscribe to
-        :param queuesize: 0 or 1 for default queue size (shall be 1 - noe queuing), n for FIFO queue
+        :param queuesize: 0 or 1 for default queue size (shall be 1 - no queuing), n for FIFO queue
         :return: Handle for changing/cancelling of the subscription
         """
         return await self._subscribe(nodes, attr, queuesize=queuesize)

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -38,7 +38,7 @@ class SubHandler:
 
 class SubscriptionItemData:
     """
-    To store useful data from a monitored item
+    To store useful data from a monitored item.
     """
 
     def __init__(self):
@@ -51,7 +51,7 @@ class SubscriptionItemData:
 
 class DataChangeNotif:
     """
-    To be send to clients for every datachange notification from server
+    To be send to clients for every datachange notification from server.
     """
 
     def __init__(self, subscription_data, monitored_item):
@@ -59,7 +59,7 @@ class DataChangeNotif:
         self.subscription_data = subscription_data
 
     def __str__(self):
-        return "DataChangeNotification({0}, {1})".format(self.subscription_data, self.monitored_item)
+        return f"DataChangeNotification({self.subscription_data}, {self.monitored_item})"
 
     __repr__ = __str__
 
@@ -73,13 +73,13 @@ class Subscription:
     :param server: `InternalSession` or `UAClient`
     """
 
-    def __init__(self, server, params, handler, loop=None):
+    def __init__(self, server, params: ua.CreateSubscriptionParameters, handler: SubHandler, loop=None):
         self.loop = loop or asyncio.get_event_loop()
         self.logger = logging.getLogger(__name__)
         self.server = server
         self._client_handle = 200
-        self._handler = handler
-        self.parameters = params  # move to data class
+        self._handler: SubHandler = handler
+        self.parameters: ua.CreateSubscriptionParameters = params  # move to data class
         self._monitored_items = {}
         self.subscription_id = None
 

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -152,13 +152,14 @@ class Subscription:
                                     attr=ua.AttributeIds.Value,
                                     queuesize=0) -> Union[int, List[Union[int, ua.StatusCode]]]:
         """
-        Subscribe for data change events for one ore multiple nodes.
+        Subscribe to data change events of one or multiple nodes.
         The default attribute used for the subscription is `Value`.
         Return value is a handle which can be used to modify/cancel the subscription.
-        The handle is either an integer value for single Nodes. If the subscription failes an `UaStatusCodeError`
-        will be raises.
-        If multiple Nodes were supplied a List of integers or ua.StatusCode objects is returned. StatusCode objects
-        are returned to indicate that the subscription has failed (no exception will be raises in this case).
+        The handle is an integer value for single Nodes. If the creation of the subscription fails an
+        `UaStatusCodeError` is raised.
+        If multiple Nodes are supplied, a List of integers or ua.StatusCode objects is returned. A list of
+        StatusCode objects are returned to indicate that the subscription has failed (no exception will be
+        raised in this case).
         If more control is necessary the `create_monitored_items` method can be used directly.
 
         :param nodes: One Node or an Iterable of Nodes

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -87,7 +87,6 @@ class Subscription:
         response = await self.server.create_subscription(self.parameters, callback=self.publish_callback)
         self.subscription_id = response.SubscriptionId  # move to data class
         self.logger.info('Subscription created %s', self.subscription_id)
-        #self.server.publish()
 
     def publish_callback(self, publish_result: ua.PublishResult):
         """

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -17,12 +17,6 @@ class SubHandler:
     This class is just a sample class. Whatever class having these methods can be used
     """
 
-    def data_change(self, handle, node, val, attr):
-        """
-        Deprecated, use datachange_notification
-        """
-        pass
-
     def datachange_notification(self, node, val, data):
         """
         called for every datachange notification from server
@@ -138,13 +132,6 @@ class Subscription:
                     self._handler.datachange_notification(data.node, item.Value.Value.Value, event_data)
                 except Exception:
                     self.logger.exception("Exception calling data change handler")
-            elif hasattr(self._handler, "data_change"):
-                # deprecated API
-                self.logger.warning("data_change method is deprecated, use datachange_notification")
-                try:
-                    self._handler.data_change(data.server_handle, data.node, item.Value.Value.Value, data.attribute)
-                except Exception:
-                    self.logger.exception("Exception calling deprecated data change handler")
             else:
                 self.logger.error("DataChange subscription created but handler has no datachange_notification method")
 
@@ -158,12 +145,6 @@ class Subscription:
                     self._handler.event_notification(result)
                 except Exception:
                     self.logger.exception("Exception calling event handler")
-            elif hasattr(self._handler, "event"):
-                # depcrecated API
-                try:
-                    self._handler.event(data.server_handle, result)
-                except Exception:
-                    self.logger.exception("Exception calling deprecated event handler")
             else:
                 self.logger.error("Event subscription created but handler has no event_notification method")
 

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -18,12 +18,12 @@ class AttributeValue(object):
         self.datachange_callbacks = {}
 
     def __str__(self):
-        return "AttributeValue({0})".format(self.value)
+        return f"AttributeValue({self.value})"
 
     __repr__ = __str__
 
 
-class NodeData(object):
+class NodeData:
 
     def __init__(self, nodeid):
         self.nodeid = nodeid
@@ -32,16 +32,16 @@ class NodeData(object):
         self.call = None
 
     def __str__(self):
-        return "NodeData(id:{0}, attrs:{1}, refs:{2})".format(self.nodeid, self.attributes, self.references)
+        return f"NodeData(id:{self.nodeid}, attrs:{self.attributes}, refs:{self.references})"
 
     __repr__ = __str__
 
 
-class AttributeService(object):
+class AttributeService:
 
-    def __init__(self, aspace):
+    def __init__(self, aspace: "AddressSpace"):
         self.logger = logging.getLogger(__name__)
-        self._aspace = aspace
+        self._aspace: "AddressSpace" = aspace
 
     def read(self, params):
         self.logger.debug("read %s", params)
@@ -60,8 +60,9 @@ class AttributeService(object):
                     continue
                 al = self._aspace.get_attribute_value(writevalue.NodeId, ua.AttributeIds.AccessLevel)
                 ual = self._aspace.get_attribute_value(writevalue.NodeId, ua.AttributeIds.UserAccessLevel)
-                if not al.StatusCode.is_good() or not ua.ua_binary.test_bit(al.Value.Value, ua.AccessLevel.CurrentWrite) or not ua.ua_binary.test_bit(
-                        ual.Value.Value, ua.AccessLevel.CurrentWrite):
+                if not al.StatusCode.is_good() or not ua.ua_binary.test_bit(
+                        al.Value.Value, ua.AccessLevel.CurrentWrite) or not ua.ua_binary.test_bit(
+                    ual.Value.Value, ua.AccessLevel.CurrentWrite):
                     res.append(ua.StatusCode(ua.StatusCodes.BadUserAccessDenied))
                     continue
             res.append(self._aspace.set_attribute_value(writevalue.NodeId, writevalue.AttributeId, writevalue.Value))
@@ -70,9 +71,9 @@ class AttributeService(object):
 
 class ViewService(object):
 
-    def __init__(self, aspace):
+    def __init__(self, aspace: "AddressSpace"):
         self.logger = logging.getLogger(__name__)
-        self._aspace = aspace
+        self._aspace: "AddressSpace" = aspace
 
     def browse(self, params):
         self.logger.debug("browse %s", params)
@@ -177,11 +178,11 @@ class ViewService(object):
         return None
 
 
-class NodeManagementService(object):
+class NodeManagementService:
 
-    def __init__(self, aspace):
+    def __init__(self, aspace: "AddressSpace"):
         self.logger = logging.getLogger(__name__)
-        self._aspace = aspace
+        self._aspace: "AddressSpace" = aspace
 
     def add_nodes(self, addnodeitems, user=User.Admin):
         results = []
@@ -216,8 +217,8 @@ class NodeManagementService(object):
                 return result
 
         if item.ParentNodeId.is_null():
-            #self.logger.info("add_node: while adding node %s, requested parent node is null %s %s",
-                #item.RequestedNewNodeId, item.ParentNodeId, item.ParentNodeId.is_null())
+            # self.logger.info("add_node: while adding node %s, requested parent node is null %s %s",
+            # item.RequestedNewNodeId, item.ParentNodeId, item.ParentNodeId.is_null())
             if check:
                 result.StatusCode = ua.StatusCode(ua.StatusCodes.BadParentNodeIdInvalid)
                 return result
@@ -366,7 +367,8 @@ class NodeManagementService(object):
         rdesc.IsForward = addref.IsForward
         rdesc.NodeId = addref.TargetNodeId
         if addref.TargetNodeClass == ua.NodeClass.Unspecified:
-            rdesc.NodeClass = self._aspace.get_attribute_value(addref.TargetNodeId, ua.AttributeIds.NodeClass).Value.Value
+            rdesc.NodeClass = self._aspace.get_attribute_value(
+                addref.TargetNodeId, ua.AttributeIds.NodeClass).Value.Value
         else:
             rdesc.NodeClass = addref.TargetNodeClass
         bname = self._aspace.get_attribute_value(addref.TargetNodeId, ua.AttributeIds.BrowseName).Value.Value
@@ -443,11 +445,11 @@ class NodeManagementService(object):
         self._add_node_attr(item, nodedata, "Value", add_timestamps=add_timestamps)
 
 
-class MethodService(object):
+class MethodService:
 
-    def __init__(self, aspace):
+    def __init__(self, aspace: "AddressSpace"):
         self.logger = logging.getLogger(__name__)
-        self._aspace = aspace
+        self._aspace: "AddressSpace" = aspace
 
     async def call(self, methods):
         results = []
@@ -480,10 +482,9 @@ class MethodService(object):
         return res
 
 
-class AddressSpace(object):
+class AddressSpace:
     """
-    The address space object stores all the nodes of the OPC-UA server
-    and helper methods.
+    The address space object stores all the nodes of the OPC-UA server and helper methods.
     The methods are thread safe
     """
 
@@ -517,9 +518,12 @@ class AddressSpace(object):
             self._nodeid_counter[idx] += 1
         else:
             # get the biggest identifier number from the existed nodes in address space
-            identifier_list = sorted([nodeid.Identifier for nodeid in self._nodes.keys()
-                                      if nodeid.NamespaceIndex == idx and nodeid.NodeIdType
-                                      in (ua.NodeIdType.Numeric, ua.NodeIdType.TwoByte, ua.NodeIdType.FourByte)])
+            identifier_list = sorted([
+                nodeid.Identifier for nodeid in self._nodes.keys()
+                if nodeid.NamespaceIndex == idx and nodeid.NodeIdType in (
+                    ua.NodeIdType.Numeric, ua.NodeIdType.TwoByte, ua.NodeIdType.FourByte
+                )
+            ])
             if identifier_list:
                 self._nodeid_counter[idx] = identifier_list[-1]
             else:

--- a/asyncua/server/binary_server_asyncio.py
+++ b/asyncua/server/binary_server_asyncio.py
@@ -3,10 +3,12 @@ Socket server forwarding request to internal server
 """
 import logging
 import asyncio
+from typing import Optional
 
 from ..ua.ua_binary import header_from_binary
 from ..common.utils import Buffer, NotEnoughData
 from .uaprocessor import UaProcessor
+from .internal_server import InternalServer
 
 logger = logging.getLogger(__name__)
 
@@ -16,12 +18,12 @@ class OPCUAProtocol(asyncio.Protocol):
     Instantiated for every connection.
     """
 
-    def __init__(self, iserver, policies, clients):
+    def __init__(self, iserver: InternalServer, policies, clients):
         self.peer_name = None
         self.transport = None
         self.processor = None
         self._buffer = b''
-        self.iserver = iserver
+        self.iserver: InternalServer = iserver
         self.policies = policies
         self.clients = clients
         self.messages = asyncio.Queue()
@@ -98,12 +100,12 @@ class OPCUAProtocol(asyncio.Protocol):
 
 
 class BinaryServer:
-    def __init__(self, internal_server, hostname, port):
+    def __init__(self, internal_server: InternalServer, hostname, port):
         self.logger = logging.getLogger(__name__)
         self.hostname = hostname
         self.port = port
-        self.iserver = internal_server
-        self._server = None
+        self.iserver: InternalServer = internal_server
+        self._server: Optional[asyncio.AbstractServer] = None
         self._policies = []
         self.clients = []
 

--- a/asyncua/server/event_generator.py
+++ b/asyncua/server/event_generator.py
@@ -1,10 +1,10 @@
 import logging
 from datetime import datetime
 import uuid
+from typing import Optional
 
 from asyncua import ua
-from asyncua import Node
-from ..common import events, event_objects
+from ..common import events, event_objects, Node
 
 
 class EventGenerator:
@@ -22,8 +22,8 @@ class EventGenerator:
     def __init__(self, isession):
         self.logger = logging.getLogger(__name__)
         self.isession = isession
-        self.event = None
-        self.emitting_node = None
+        self.event: Optional[event_objects.BaseEvent] = None
+        self.emitting_node: Optional[Node] = None
 
     async def init(self, etype=None, emitting_node=ua.ObjectIds.Server):
         node = None

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -1,0 +1,161 @@
+import asyncio
+import logging
+from enum import Enum
+from typing import Coroutine
+
+from asyncua import ua
+from ..common.callback import CallbackType, ServerItemCallback
+from ..common.utils import create_nonce, ServiceError
+from .users import User
+from .subscription_service import SubscriptionService
+
+
+class SessionState(Enum):
+    Created = 0
+    Activated = 1
+    Closed = 2
+
+
+class InternalSession:
+    """
+
+    """
+    _counter = 10
+    _auth_counter = 1000
+
+    def __init__(self, internal_server, aspace, submgr: SubscriptionService, name, user=User.Anonymous, external=False):
+        self.logger = logging.getLogger(__name__)
+        self.iserver = internal_server
+        # define if session is external, we need to copy some objects if it is internal
+        self.external = external
+        self.aspace = aspace
+        self.subscription_service: SubscriptionService = submgr
+        self.name = name
+        self.user = user
+        self.nonce = None
+        self.state = SessionState.Created
+        self.session_id = ua.NodeId(self._counter)
+        InternalSession._counter += 1
+        self.authentication_token = ua.NodeId(self._auth_counter)
+        InternalSession._auth_counter += 1
+        self.logger.info('Created internal session %s', self.name)
+
+    def __str__(self):
+        return 'InternalSession(name:{0}, user:{1}, id:{2}, auth_token:{3})'.format(
+            self.name, self.user, self.session_id, self.authentication_token)
+
+    async def get_endpoints(self, params=None, sockname=None):
+        return await self.iserver.get_endpoints(params, sockname)
+
+    async def create_session(self, params, sockname=None):
+        self.logger.info('Create session request')
+
+        result = ua.CreateSessionResult()
+        result.SessionId = self.session_id
+        result.AuthenticationToken = self.authentication_token
+        result.RevisedSessionTimeout = params.RequestedSessionTimeout
+        result.MaxRequestMessageSize = 65536
+        self.nonce = create_nonce(32)
+        result.ServerNonce = self.nonce
+        result.ServerEndpoints = await self.get_endpoints(sockname=sockname)
+
+        return result
+
+    async def close_session(self, delete_subs=True):
+        self.logger.info('close session %s')
+        self.state = SessionState.Closed
+        await self.delete_subscriptions(list(self.subscription_service.subscriptions.keys()))
+
+    def activate_session(self, params):
+        self.logger.info('activate session')
+        result = ua.ActivateSessionResult()
+        if self.state != SessionState.Created:
+            raise ServiceError(ua.StatusCodes.BadSessionIdInvalid)
+        self.nonce = create_nonce(32)
+        result.ServerNonce = self.nonce
+        for _ in params.ClientSoftwareCertificates:
+            result.Results.append(ua.StatusCode())
+        self.state = SessionState.Activated
+        id_token = params.UserIdentityToken
+        if isinstance(id_token, ua.UserNameIdentityToken):
+            if self.iserver.check_user_token(self, id_token) is False:
+                raise ServiceError(ua.StatusCodes.BadUserAccessDenied)
+        self.logger.info("Activated internal session %s for user %s", self.name, self.user)
+        return result
+
+    async def read(self, params):
+        results = self.iserver.attribute_service.read(params)
+        return results
+
+    def history_read(self, params) -> Coroutine:
+        return self.iserver.history_manager.read_history(params)
+
+    async def write(self, params):
+        return self.iserver.attribute_service.write(params, self.user)
+
+    async def browse(self, params):
+        return self.iserver.view_service.browse(params)
+
+    async def translate_browsepaths_to_nodeids(self, params):
+        return self.iserver.view_service.translate_browsepaths_to_nodeids(params)
+
+    async def add_nodes(self, params):
+        return self.iserver.node_mgt_service.add_nodes(params, self.user)
+
+    async def delete_nodes(self, params):
+        return self.iserver.node_mgt_service.delete_nodes(params, self.user)
+
+    async def add_references(self, params):
+        return self.iserver.node_mgt_service.add_references(params, self.user)
+
+    async def delete_references(self, params):
+        return self.iserver.node_mgt_service.delete_references(params, self.user)
+
+    async def add_method_callback(self, methodid, callback):
+        return self.aspace.add_method_callback(methodid, callback)
+
+    def call(self, params):
+        """COROUTINE"""
+        return self.iserver.method_service.call(params)
+
+    async def create_subscription(self, params, callback=None):
+        result = await self.subscription_service.create_subscription(params, callback)
+        return result
+
+    async def create_monitored_items(self, params):
+        """Returns Future"""
+        subscription_result = await self.subscription_service.create_monitored_items(params)
+        self.iserver.server_callback_dispatcher.dispatch(CallbackType.ItemSubscriptionCreated,
+                                                         ServerItemCallback(params, subscription_result))
+        return subscription_result
+
+    async def modify_monitored_items(self, params):
+        subscription_result = self.subscription_service.modify_monitored_items(params)
+        self.iserver.server_callback_dispatcher.dispatch(CallbackType.ItemSubscriptionModified,
+                                                         ServerItemCallback(params, subscription_result))
+        return subscription_result
+
+    def republish(self, params):
+        return self.subscription_service.republish(params)
+
+    async def delete_subscriptions(self, ids):
+        # This is an async method, dues to symmetry with client code
+        return await self.subscription_service.delete_subscriptions(ids)
+
+    async def delete_monitored_items(self, params):
+        # This is an async method, dues to symmetry with client code
+        subscription_result = self.subscription_service.delete_monitored_items(params)
+        self.iserver.server_callback_dispatcher.dispatch(CallbackType.ItemSubscriptionDeleted,
+                                                         ServerItemCallback(params, subscription_result))
+        return subscription_result
+
+    def publish(self, acks=None):
+        """
+        ???
+        """
+        #
+        if acks is None:
+            acks = []
+        return self.subscription_service.publish(acks)
+
+

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -59,7 +59,7 @@ class InternalSession:
         return result
 
     async def close_session(self, delete_subs=True):
-        self.logger.info('close session %s')
+        self.logger.info('close session %s', self.name)
         self.state = SessionState.Closed
         await self.delete_subscriptions(list(self.subscription_service.subscriptions.keys()))
 

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -5,6 +5,7 @@ from typing import Coroutine, Iterable, Optional
 from asyncua import ua
 from ..common.callback import CallbackType, ServerItemCallback
 from ..common.utils import create_nonce, ServiceError
+from .address_space import AddressSpace
 from .users import User
 from .subscription_service import SubscriptionService
 
@@ -22,12 +23,13 @@ class InternalSession:
     _counter = 10
     _auth_counter = 1000
 
-    def __init__(self, internal_server, aspace, submgr: SubscriptionService, name, user=User.Anonymous, external=False):
+    def __init__(self, internal_server, aspace: AddressSpace, submgr: SubscriptionService, name, user=User.Anonymous,
+                 external=False):
         self.logger = logging.getLogger(__name__)
         self.iserver = internal_server
         # define if session is external, we need to copy some objects if it is internal
         self.external = external
-        self.aspace = aspace
+        self.aspace: AddressSpace = aspace
         self.subscription_service: SubscriptionService = submgr
         self.name = name
         self.user = user
@@ -119,7 +121,7 @@ class InternalSession:
         result = await self.subscription_service.create_subscription(params, callback)
         return result
 
-    async def create_monitored_items(self, params):
+    async def create_monitored_items(self, params: ua.CreateMonitoredItemsParameters):
         """Returns Future"""
         subscription_result = await self.subscription_service.create_monitored_items(params)
         self.iserver.server_callback_dispatcher.dispatch(CallbackType.ItemSubscriptionCreated,

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -48,11 +48,17 @@ class InternalSubscription:
         self.monitored_item_srv.delete_all_monitored_items()
 
     def _trigger_publish(self):
-        if self._task and self.data.RevisedPublishingInterval <= 0.0:  # ToDo: check against Spec.
+        """
+        Trigger immediate publication (if requested by the PublishingInterval).
+        """
+        if self._task and self.data.RevisedPublishingInterval <= 0.0:
+            # Publish immediately (as fast as possible)
             self.publish_results()
 
     async def _subscription_loop(self):
-        """Publication cycle."""
+        """
+        Start the publication loop running at the RevisedPublishingInterval.
+        """
         try:
             while True:
                 await asyncio.sleep(self.data.RevisedPublishingInterval / 1000.0)

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -4,244 +4,21 @@ server side implementation of a subscription object
 
 import logging
 import asyncio
-import inspect
 
 from asyncua import ua
-
-
-class MonitoredItemData:
-    def __init__(self):
-        self.client_handle = None
-        self.callback_handle = None
-        self.monitored_item_id = None
-        self.mode = None
-        self.filter = None
-        self.mvalue = MonitoredItemValues()
-        self.where_clause_evaluator = None
-        self.queue_size = 0
-
-
-class MonitoredItemValues:
-    def __init__(self):
-        self.current_value = None
-        self.old_value = None
-
-    def set_current_value(self, cur_val):
-        self.old_value = self.current_value
-        self.current_value = cur_val
-
-    def get_current_value(self):
-        return self.current_value
-
-    def get_old_value(self):
-        return self.old_value
-
-
-class MonitoredItemService:
-    """
-    implement monitored item service for one subscription
-    """
-
-    def __init__(self, isub, aspace):
-        self.logger = logging.getLogger(__name__ + "." + str(isub.data.SubscriptionId))
-        self.isub = isub
-        self.aspace = aspace
-        self._monitored_items = {}
-        self._monitored_events = {}
-        self._monitored_datachange = {}
-        self._monitored_item_counter = 111
-
-    def delete_all_monitored_items(self):
-        self.delete_monitored_items([mdata.monitored_item_id for mdata in self._monitored_items.values()])
-
-    async def create_monitored_items(self, params):
-        results = []
-        for item in params.ItemsToCreate:
-            # with self._lock:
-            if item.ItemToMonitor.AttributeId == ua.AttributeIds.EventNotifier:
-                result = self._create_events_monitored_item(item)
-            else:
-                result = self._create_data_change_monitored_item(item)
-            results.append(result)
-        return results
-
-    def modify_monitored_items(self, params):
-        results = []
-        for item in params.ItemsToModify:
-            results.append(self._modify_monitored_item(item))
-        return results
-
-    def trigger_datachange(self, handle, nodeid, attr):
-        self.logger.debug("triggering datachange for handle %s, nodeid %s, and attribute %s", handle, nodeid, attr)
-        variant = self.aspace.get_attribute_value(nodeid, attr)
-        self.datachange_callback(handle, variant)
-
-    def _modify_monitored_item(self, params):
-        for mdata in self._monitored_items.values():
-            result = ua.MonitoredItemModifyResult()
-            if mdata.monitored_item_id == params.MonitoredItemId:
-                result.RevisedSamplingInterval = params.RequestedParameters.SamplingInterval
-                result.RevisedQueueSize = params.RequestedParameters.QueueSize
-                if params.RequestedParameters.Filter is not None:
-                    mdata.filter = params.RequestedParameters.Filter
-                mdata.queue_size = params.RequestedParameters.QueueSize
-                return result
-        result = ua.MonitoredItemModifyResult()
-        result.StatusCode(ua.StatusCodes.BadMonitoredItemIdInvalid)
-        return result
-
-    def _commit_monitored_item(self, result, mdata):
-        if result.StatusCode.is_good():
-            self._monitored_items[result.MonitoredItemId] = mdata
-            self._monitored_item_counter += 1
-
-    def _make_monitored_item_common(self, params):
-        result = ua.MonitoredItemCreateResult()
-        result.RevisedSamplingInterval = self.isub.data.RevisedPublishingInterval
-        result.RevisedQueueSize = params.RequestedParameters.QueueSize
-        self._monitored_item_counter += 1
-        result.MonitoredItemId = self._monitored_item_counter
-        self.logger.debug("Creating MonitoredItem with id %s", result.MonitoredItemId)
-
-        mdata = MonitoredItemData()
-        mdata.mode = params.MonitoringMode
-        mdata.client_handle = params.RequestedParameters.ClientHandle
-        mdata.monitored_item_id = result.MonitoredItemId
-        mdata.queue_size = params.RequestedParameters.QueueSize
-        mdata.filter = params.RequestedParameters.Filter
-
-        return result, mdata
-
-    def _create_events_monitored_item(self, params):
-        self.logger.info("request to subscribe to events for node %s and attribute %s", params.ItemToMonitor.NodeId,
-                         params.ItemToMonitor.AttributeId)
-
-        result, mdata = self._make_monitored_item_common(params)
-        ev_notify_byte = self.aspace.get_attribute_value(params.ItemToMonitor.NodeId,
-                                                         ua.AttributeIds.EventNotifier).Value.Value
-
-        if ev_notify_byte is None or not ua.ua_binary.test_bit(ev_notify_byte, ua.EventNotifier.SubscribeToEvents):
-            result.StatusCode = ua.StatusCode(ua.StatusCodes.BadServiceUnsupported)
-            return result
-        # result.FilterResult = ua.EventFilterResult()  # spec says we can ignore if not error
-        mdata.where_clause_evaluator = WhereClauseEvaluator(self.logger, self.aspace, mdata.filter.WhereClause)
-        self._commit_monitored_item(result, mdata)
-        if params.ItemToMonitor.NodeId not in self._monitored_events:
-            self._monitored_events[params.ItemToMonitor.NodeId] = []
-        self._monitored_events[params.ItemToMonitor.NodeId].append(result.MonitoredItemId)
-        return result
-
-    def _create_data_change_monitored_item(self, params):
-        self.logger.info("request to subscribe to datachange for node %s and attribute %s", params.ItemToMonitor.NodeId,
-                         params.ItemToMonitor.AttributeId)
-
-        result, mdata = self._make_monitored_item_common(params)
-        result.FilterResult = params.RequestedParameters.Filter
-        result.StatusCode, handle = self.aspace.add_datachange_callback(
-            params.ItemToMonitor.NodeId, params.ItemToMonitor.AttributeId, self.datachange_callback)
-
-        self.logger.debug("adding callback return status %s and handle %s", result.StatusCode, handle)
-        mdata.callback_handle = handle
-        self._commit_monitored_item(result, mdata)
-        if result.StatusCode.is_good():
-            self._monitored_datachange[handle] = result.MonitoredItemId
-            # force data change event generation
-            self.trigger_datachange(handle, params.ItemToMonitor.NodeId, params.ItemToMonitor.AttributeId)
-        return result
-
-    def delete_monitored_items(self, ids):
-        self.logger.debug("delete monitored items %s", ids)
-        # with self._lock:
-        results = []
-        for mid in ids:
-            results.append(self._delete_monitored_items(mid))
-        return results
-
-    def _delete_monitored_items(self, mid):
-        if mid not in self._monitored_items:
-            return ua.StatusCode(ua.StatusCodes.BadMonitoredItemIdInvalid)
-        for k, v in self._monitored_events.items():
-            if mid in v:
-                v.remove(mid)
-                if not v:
-                    self._monitored_events.pop(k)
-                break
-        for k, v in self._monitored_datachange.items():
-            if v == mid:
-                self.aspace.delete_datachange_callback(k)
-                self._monitored_datachange.pop(k)
-                break
-        self._monitored_items.pop(mid)
-        return ua.StatusCode()
-
-    def datachange_callback(self, handle, value, error=None):
-        if error:
-            self.logger.info("subscription %s: datachange callback called with handle '%s' and erorr '%s'", self,
-                             handle, error)
-            self.trigger_statuschange(error)
-        else:
-            self.logger.info("subscription %s: datachange callback called with handle '%s' and value '%s'", self,
-                             handle, value.Value)
-            event = ua.MonitoredItemNotification()
-            # with self._lock:
-            mid = self._monitored_datachange[handle]
-            mdata = self._monitored_items[mid]
-            mdata.mvalue.set_current_value(value.Value.Value)
-            if mdata.filter:
-                deadband_flag_pass = self.deadband_callback(mdata.mvalue, mdata.filter)
-            else:
-                deadband_flag_pass = True
-            if deadband_flag_pass:
-                event.ClientHandle = mdata.client_handle
-                event.Value = value
-                self.isub.enqueue_datachange_event(mid, event, mdata.queue_size)
-
-    def deadband_callback(self, values, flt):
-        if flt.DeadbandType == ua.DeadbandType.None_ or values.get_old_value() is None:
-            return True
-        if flt.DeadbandType == ua.DeadbandType.Absolute and \
-                ((abs(values.get_current_value() - values.get_old_value())) > flt.DeadbandValue):
-            return True
-        if flt.DeadbandType == ua.DeadbandType.Percent:
-            self.logger.warning("DeadbandType Percent is not implemented !")
-            return True
-        return False
-
-    def trigger_event(self, event):
-        if event.emitting_node not in self._monitored_events:
-            self.logger.debug("%s has no subscription for events %s from node: %s", self, event, event.emitting_node)
-            return False
-        self.logger.debug("%s has subscription for events %s from node: %s", self, event, event.emitting_node)
-        mids = self._monitored_events[event.emitting_node]
-        for mid in mids:
-            self._trigger_event(event, mid)
-        return True
-
-    def _trigger_event(self, event, mid):
-        if mid not in self._monitored_items:
-            self.logger.debug("Could not find monitored items for id %s for event %s in subscription %s", mid, event,
-                              self)
-            return
-        mdata = self._monitored_items[mid]
-        if not mdata.where_clause_evaluator.eval(event):
-            self.logger.info("%s, %s, Event %s does not fit WhereClause, not generating event", self, mid, event)
-            return
-        fieldlist = ua.EventFieldList()
-        fieldlist.ClientHandle = mdata.client_handle
-        fieldlist.EventFields = event.to_event_fields(mdata.filter.SelectClauses)
-        self.isub.enqueue_event(mid, fieldlist, mdata.queue_size)
-
-    def trigger_statuschange(self, code):
-        self.isub.enqueue_statuschange(code)
+from .monitored_item_service import MonitoredItemService
 
 
 class InternalSubscription:
-    def __init__(self, subservice, data, addressspace, callback):
+    """
+
+    """
+    def __init__(self, subservice, data, addressspace, callback=None):
         self.logger = logging.getLogger(__name__)
         self.aspace = addressspace
         self.subservice = subservice
         self.data = data
-        self.callback = callback
+        self.pub_result_callback = callback
         self.monitored_item_srv = MonitoredItemService(self, addressspace)
         self.task = None
         self._triggered_datachanges = {}
@@ -255,7 +32,7 @@ class InternalSubscription:
         self._task = None
 
     def __str__(self):
-        return "Subscription(id:{0})".format(self.data.SubscriptionId)
+        return f"Subscription(id:{self.data.SubscriptionId})"
 
     async def start(self):
         self.logger.debug("starting subscription %s", self.data.SubscriptionId)
@@ -263,7 +40,7 @@ class InternalSubscription:
             self._task = self.subservice.loop.create_task(self._subscription_loop())
 
     async def stop(self):
-        self.logger.debug("stopping subscription %s", self.data.SubscriptionId)
+        self.logger.info("stopping internal subscription %s", self.data.SubscriptionId)
         self._task.cancel()
         await self._task
         self.monitored_item_srv.delete_all_monitored_items()
@@ -278,6 +55,7 @@ class InternalSubscription:
                 await asyncio.sleep(self.data.RevisedPublishingInterval / 1000.0)
                 self.publish_results()
         except asyncio.CancelledError:
+            self.logger.info('exiting _subscription_loop for %s', self.data.SubscriptionId)
             pass
         except Exception:
             # seems this except is necessary to print errors
@@ -305,10 +83,8 @@ class InternalSubscription:
             self._publish_cycles_count += 1
             result = self._pop_publish_result()
         if result is not None:
-            if inspect.iscoroutinefunction(self.callback):
-                self.subservice.loop.create_task(self.callback(result))
-            else:
-                self.callback(result)
+            self.logger.info('publish_results for %s', self.data.SubscriptionId)
+            self.pub_result_callback(result)
 
     def _pop_publish_result(self):
         result = ua.PublishResult()
@@ -350,6 +126,10 @@ class InternalSubscription:
             self.logger.debug("sending event notification %s", notif.Status)
 
     def publish(self, acks):
+        """
+        :param acks:
+        :return:
+        """
         self.logger.info("publish request with acks %s", acks)
         self._publish_cycles_count = 0
         for nb in acks:
@@ -384,82 +164,3 @@ class InternalSubscription:
                 queue[mid].pop(0)
         queue[mid].append(eventdata)
 
-
-class WhereClauseEvaluator:
-    def __init__(self, logger, aspace, whereclause):
-        self.logger = logger
-        self.elements = whereclause.Elements
-        self._aspace = aspace
-
-    def eval(self, event):
-        if not self.elements:
-            return True
-        # spec says we should only evaluate first element, which may use other elements
-        try:
-            res = self._eval_el(0, event)
-        except Exception as ex:
-            self.logger.exception("Exception while evaluating WhereClause %s for event %s: %s", self.elements, event,
-                                  ex)
-            return False
-        return res
-
-    def _eval_el(self, index, event):
-        el = self.elements[index]
-        # ops = [self._eval_op(op, event) for op in el.FilterOperands]
-        ops = el.FilterOperands  # just to make code more readable
-        if el.FilterOperator == ua.FilterOperator.Equals:
-            return self._eval_op(ops[0], event) == self._eval_el(ops[1], event)
-        if el.FilterOperator == ua.FilterOperator.IsNull:
-            return self._eval_op(ops[0], event) is None  # FIXME: might be too strict
-        if el.FilterOperator == ua.FilterOperator.GreaterThan:
-            return self._eval_op(ops[0], event) > self._eval_el(ops[1], event)
-        if el.FilterOperator == ua.FilterOperator.LessThan:
-            return self._eval_op(ops[0], event) < self._eval_el(ops[1], event)
-        if el.FilterOperator == ua.FilterOperator.GreaterThanOrEqual:
-            return self._eval_op(ops[0], event) >= self._eval_el(ops[1], event)
-        if el.FilterOperator == ua.FilterOperator.LessThanOrEqual:
-            return self._eval_op(ops[0], event) <= self._eval_el(ops[1], event)
-        if el.FilterOperator == ua.FilterOperator.Like:
-            return self._like_operator(self._eval_op(ops[0], event), self._eval_el(ops[1], event))
-        if el.FilterOperator == ua.FilterOperator.Not:
-            return not self._eval_op(ops[0], event)
-        if el.FilterOperator == ua.FilterOperator.Between:
-            return self._eval_el(ops[2], event) >= self._eval_op(ops[0], event) >= self._eval_el(ops[1], event)
-        if el.FilterOperator == ua.FilterOperator.InList:
-            return self._eval_op(ops[0], event) in [self._eval_op(op, event) for op in ops[1:]]
-        if el.FilterOperator == ua.FilterOperator.And:
-            self.elements(ops[0].Index)
-            return self._eval_op(ops[0], event) and self._eval_op(ops[1], event)
-        if el.FilterOperator == ua.FilterOperator.Or:
-            return self._eval_op(ops[0], event) or self._eval_el(ops[1], event)
-        if el.FilterOperator == ua.FilterOperator.Cast:
-            self.logger.warn("Cast operand not implemented, assuming True")
-            return True
-        if el.FilterOperator == ua.FilterOperator.OfType:
-            return event.EventType == self._eval_op(ops[0], event)
-        # TODO: implement missing operators
-        self.logger.warning("WhereClause not implemented for element: %s", el)
-        raise NotImplementedError
-
-    def _like_operator(self, string, pattern):
-        raise NotImplementedError
-
-    def _eval_op(self, op, event):
-        # seems spec says we should return Null if issues
-        if isinstance(op, ua.ElementOperand):
-            return self._eval_el(op.Index, event)
-        if isinstance(op, ua.AttributeOperand):
-            if op.BrowsePath:
-                return getattr(event, op.BrowsePath.Elements[0].TargetName.Name)
-            return self._aspace.get_attribute_value(event.EventType, op.AttributeId).Value.Value
-            # FIXME: check, this is probably broken
-        if isinstance(op, ua.SimpleAttributeOperand):
-            if op.BrowsePath:
-                # we only support depth of 1
-                return getattr(event, op.BrowsePath[0].Name)
-            # TODO: write code for index range.... but doe it make any sense
-            return self._aspace.get_attribute_value(event.EventType, op.AttributeId).Value.Value
-        if isinstance(op, ua.LiteralOperand):
-            return op.Value.Value
-        self.logger.warning("Where clause element % is not of a known type", op)
-        raise NotImplementedError

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -22,7 +22,6 @@ class InternalSubscription:
         self.data: ua.CreateSubscriptionResult = data
         self.pub_result_callback = callback
         self.monitored_item_srv = MonitoredItemService(self, addressspace)
-        self.task = None
         self._triggered_datachanges: Dict[int, List[ua.MonitoredItemNotification]] = {}
         self._triggered_events: Dict[int, List[ua.EventFieldList]] = {}
         self._triggered_statuschanges: list = []
@@ -45,10 +44,11 @@ class InternalSubscription:
         self.logger.info("stopping internal subscription %s", self.data.SubscriptionId)
         self._task.cancel()
         await self._task
+        self._task = None
         self.monitored_item_srv.delete_all_monitored_items()
 
     def _trigger_publish(self):
-        if self._task and self.data.RevisedPublishingInterval <= 0.0:
+        if self._task and self.data.RevisedPublishingInterval <= 0.0:  # ToDo: check against Spec.
             self.publish_results()
 
     async def _subscription_loop(self):

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -5,7 +5,7 @@ server side implementation of a subscription object
 import logging
 import asyncio
 
-from typing import Union
+from typing import Union, Iterable, Dict, List
 from asyncua import ua
 from .monitored_item_service import MonitoredItemService
 
@@ -23,11 +23,11 @@ class InternalSubscription:
         self.pub_result_callback = callback
         self.monitored_item_srv = MonitoredItemService(self, addressspace)
         self.task = None
-        self._triggered_datachanges = {}
-        self._triggered_events = {}
-        self._triggered_statuschanges = []
+        self._triggered_datachanges: Dict[int, List[ua.MonitoredItemNotification]] = {}
+        self._triggered_events: Dict[int, List[ua.EventFieldList]] = {}
+        self._triggered_statuschanges: list = []
         self._notification_seq = 1
-        self._not_acknowledged_results = {}
+        self._not_acknowledged_results: Dict[int, ua.PublishResult] = {}
         self._startup = True
         self._keep_alive_count = 0
         self._publish_cycles_count = 0
@@ -137,10 +137,10 @@ class InternalSubscription:
             result.NotificationMessage.NotificationData.append(notif)
             self.logger.debug("sending event notification %s", notif.Status)
 
-    def publish(self, acks):
+    def publish(self, acks: Iterable[int]):
         """
-        :param acks:
-        :return:
+        Reset publish cycle count, acknowledge PublishResults.
+        :param acks: Sequence number of the PublishResults to acknowledge
         """
         self.logger.info("publish request with acks %s", acks)
         self._publish_cycles_count = 0

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -52,6 +52,7 @@ class InternalSubscription:
             self.publish_results()
 
     async def _subscription_loop(self):
+        """Publication cycle."""
         try:
             while True:
                 await asyncio.sleep(self.data.RevisedPublishingInterval / 1000.0)
@@ -60,7 +61,7 @@ class InternalSubscription:
             self.logger.info('exiting _subscription_loop for %s', self.data.SubscriptionId)
             pass
         except Exception:
-            # seems this except is necessary to print errors
+            # seems this except is necessary to log errors
             self.logger.exception("Exception in subscription loop")
 
     def has_published_results(self):

--- a/asyncua/server/monitored_item_service.py
+++ b/asyncua/server/monitored_item_service.py
@@ -4,6 +4,7 @@ server side implementation of a subscription object
 
 import logging
 from asyncua import ua
+from .address_space import AddressSpace
 
 
 class MonitoredItemData:
@@ -39,10 +40,10 @@ class MonitoredItemService:
     Implements monitored item service for one subscription
     """
 
-    def __init__(self, isub, aspace):
+    def __init__(self, isub, aspace: AddressSpace):
         self.logger = logging.getLogger(f"{__name__}.{isub.data.SubscriptionId}")
         self.isub = isub
-        self.aspace = aspace
+        self.aspace: AddressSpace = aspace
         self._monitored_items = {}
         self._monitored_events = {}
         self._monitored_datachange = {}
@@ -57,7 +58,6 @@ class MonitoredItemService:
     async def create_monitored_items(self, params):
         results = []
         for item in params.ItemsToCreate:
-            # with self._lock:
             if item.ItemToMonitor.AttributeId == ua.AttributeIds.EventNotifier:
                 result = self._create_events_monitored_item(item)
             else:
@@ -102,14 +102,12 @@ class MonitoredItemService:
         self._monitored_item_counter += 1
         result.MonitoredItemId = self._monitored_item_counter
         self.logger.debug("Creating MonitoredItem with id %s", result.MonitoredItemId)
-
         mdata = MonitoredItemData()
         mdata.mode = params.MonitoringMode
         mdata.client_handle = params.RequestedParameters.ClientHandle
         mdata.monitored_item_id = result.MonitoredItemId
         mdata.queue_size = params.RequestedParameters.QueueSize
         mdata.filter = params.RequestedParameters.Filter
-
         return result, mdata
 
     def _create_events_monitored_item(self, params):

--- a/asyncua/server/monitored_item_service.py
+++ b/asyncua/server/monitored_item_service.py
@@ -1,0 +1,314 @@
+"""
+server side implementation of a subscription object
+"""
+
+import logging
+from asyncua import ua
+
+
+class MonitoredItemData:
+    def __init__(self):
+        self.client_handle = None
+        self.callback_handle = None
+        self.monitored_item_id = None
+        self.mode = None
+        self.filter = None
+        self.mvalue = MonitoredItemValues()
+        self.where_clause_evaluator = None
+        self.queue_size = 0
+
+
+class MonitoredItemValues:
+    def __init__(self):
+        self.current_value = None
+        self.old_value = None
+
+    def set_current_value(self, cur_val):
+        self.old_value = self.current_value
+        self.current_value = cur_val
+
+    def get_current_value(self):
+        return self.current_value
+
+    def get_old_value(self):
+        return self.old_value
+
+
+class MonitoredItemService:
+    """
+    Implements monitored item service for one subscription
+    """
+
+    def __init__(self, isub, aspace):
+        self.logger = logging.getLogger(f"{__name__}.{isub.data.SubscriptionId}")
+        self.isub = isub
+        self.aspace = aspace
+        self._monitored_items = {}
+        self._monitored_events = {}
+        self._monitored_datachange = {}
+        self._monitored_item_counter = 111
+
+    def __str__(self):
+        return f"MonitoredItemService({self.isub.data.SubscriptionId})"
+
+    def delete_all_monitored_items(self):
+        self.delete_monitored_items([mdata.monitored_item_id for mdata in self._monitored_items.values()])
+
+    async def create_monitored_items(self, params):
+        results = []
+        for item in params.ItemsToCreate:
+            # with self._lock:
+            if item.ItemToMonitor.AttributeId == ua.AttributeIds.EventNotifier:
+                result = self._create_events_monitored_item(item)
+            else:
+                result = self._create_data_change_monitored_item(item)
+            results.append(result)
+        return results
+
+    def modify_monitored_items(self, params):
+        results = []
+        for item in params.ItemsToModify:
+            results.append(self._modify_monitored_item(item))
+        return results
+
+    def trigger_datachange(self, handle, nodeid, attr):
+        self.logger.debug("triggering datachange for handle %s, nodeid %s, and attribute %s", handle, nodeid, attr)
+        variant = self.aspace.get_attribute_value(nodeid, attr)
+        self.datachange_callback(handle, variant)
+
+    def _modify_monitored_item(self, params):
+        for mdata in self._monitored_items.values():
+            result = ua.MonitoredItemModifyResult()
+            if mdata.monitored_item_id == params.MonitoredItemId:
+                result.RevisedSamplingInterval = params.RequestedParameters.SamplingInterval
+                result.RevisedQueueSize = params.RequestedParameters.QueueSize
+                if params.RequestedParameters.Filter is not None:
+                    mdata.filter = params.RequestedParameters.Filter
+                mdata.queue_size = params.RequestedParameters.QueueSize
+                return result
+        result = ua.MonitoredItemModifyResult()
+        result.StatusCode(ua.StatusCodes.BadMonitoredItemIdInvalid)
+        return result
+
+    def _commit_monitored_item(self, result, mdata):
+        if result.StatusCode.is_good():
+            self._monitored_items[result.MonitoredItemId] = mdata
+            self._monitored_item_counter += 1
+
+    def _make_monitored_item_common(self, params):
+        result = ua.MonitoredItemCreateResult()
+        result.RevisedSamplingInterval = self.isub.data.RevisedPublishingInterval
+        result.RevisedQueueSize = params.RequestedParameters.QueueSize
+        self._monitored_item_counter += 1
+        result.MonitoredItemId = self._monitored_item_counter
+        self.logger.debug("Creating MonitoredItem with id %s", result.MonitoredItemId)
+
+        mdata = MonitoredItemData()
+        mdata.mode = params.MonitoringMode
+        mdata.client_handle = params.RequestedParameters.ClientHandle
+        mdata.monitored_item_id = result.MonitoredItemId
+        mdata.queue_size = params.RequestedParameters.QueueSize
+        mdata.filter = params.RequestedParameters.Filter
+
+        return result, mdata
+
+    def _create_events_monitored_item(self, params):
+        self.logger.info("request to subscribe to events for node %s and attribute %s", params.ItemToMonitor.NodeId,
+                         params.ItemToMonitor.AttributeId)
+
+        result, mdata = self._make_monitored_item_common(params)
+        ev_notify_byte = self.aspace.get_attribute_value(params.ItemToMonitor.NodeId,
+                                                         ua.AttributeIds.EventNotifier).Value.Value
+
+        if ev_notify_byte is None or not ua.ua_binary.test_bit(ev_notify_byte, ua.EventNotifier.SubscribeToEvents):
+            result.StatusCode = ua.StatusCode(ua.StatusCodes.BadServiceUnsupported)
+            return result
+        # result.FilterResult = ua.EventFilterResult()  # spec says we can ignore if not error
+        mdata.where_clause_evaluator = WhereClauseEvaluator(self.logger, self.aspace, mdata.filter.WhereClause)
+        self._commit_monitored_item(result, mdata)
+        if params.ItemToMonitor.NodeId not in self._monitored_events:
+            self._monitored_events[params.ItemToMonitor.NodeId] = []
+        self._monitored_events[params.ItemToMonitor.NodeId].append(result.MonitoredItemId)
+        return result
+
+    def _create_data_change_monitored_item(self, params):
+        self.logger.info("request to subscribe to datachange for node %s and attribute %s", params.ItemToMonitor.NodeId,
+                         params.ItemToMonitor.AttributeId)
+
+        result, mdata = self._make_monitored_item_common(params)
+        result.FilterResult = params.RequestedParameters.Filter
+        result.StatusCode, handle = self.aspace.add_datachange_callback(
+            params.ItemToMonitor.NodeId, params.ItemToMonitor.AttributeId, self.datachange_callback)
+
+        self.logger.debug("adding callback return status %s and handle %s", result.StatusCode, handle)
+        mdata.callback_handle = handle
+        self._commit_monitored_item(result, mdata)
+        if result.StatusCode.is_good():
+            self._monitored_datachange[handle] = result.MonitoredItemId
+            # force data change event generation
+            self.trigger_datachange(handle, params.ItemToMonitor.NodeId, params.ItemToMonitor.AttributeId)
+        return result
+
+    def delete_monitored_items(self, ids):
+        self.logger.debug("delete monitored items %s", ids)
+        # with self._lock:
+        results = []
+        for mid in ids:
+            results.append(self._delete_monitored_items(mid))
+        return results
+
+    def _delete_monitored_items(self, mid):
+        if mid not in self._monitored_items:
+            return ua.StatusCode(ua.StatusCodes.BadMonitoredItemIdInvalid)
+        for k, v in self._monitored_events.items():
+            if mid in v:
+                v.remove(mid)
+                if not v:
+                    self._monitored_events.pop(k)
+                break
+        for k, v in self._monitored_datachange.items():
+            if v == mid:
+                self.aspace.delete_datachange_callback(k)
+                self._monitored_datachange.pop(k)
+                break
+        self._monitored_items.pop(mid)
+        return ua.StatusCode()
+
+    def datachange_callback(self, handle, value, error=None):
+        if error:
+            self.logger.info("subscription %s: datachange callback called with handle '%s' and error '%s'", self,
+                             handle, error)
+            self.trigger_statuschange(error)
+        else:
+            self.logger.info("subscription %s: datachange callback called with handle '%s' and value '%s'", self,
+                             handle, value.Value)
+            event = ua.MonitoredItemNotification()
+            mid = self._monitored_datachange[handle]
+            mdata = self._monitored_items[mid]
+            mdata.mvalue.set_current_value(value.Value.Value)
+            if mdata.filter:
+                deadband_flag_pass = self.deadband_callback(mdata.mvalue, mdata.filter)
+            else:
+                deadband_flag_pass = True
+            if deadband_flag_pass:
+                event.ClientHandle = mdata.client_handle
+                event.Value = value
+                self.isub.enqueue_datachange_event(mid, event, mdata.queue_size)
+
+    def deadband_callback(self, values, flt):
+        if flt.DeadbandType == ua.DeadbandType.None_ or values.get_old_value() is None:
+            return True
+        if flt.DeadbandType == ua.DeadbandType.Absolute and \
+                ((abs(values.get_current_value() - values.get_old_value())) > flt.DeadbandValue):
+            return True
+        if flt.DeadbandType == ua.DeadbandType.Percent:
+            self.logger.warning("DeadbandType Percent is not implemented !")
+            return True
+        return False
+
+    def trigger_event(self, event):
+        if event.emitting_node not in self._monitored_events:
+            self.logger.debug("%s has no subscription for events %s from node: %s", self, event, event.emitting_node)
+            return False
+        self.logger.debug("%s has subscription for events %s from node: %s", self, event, event.emitting_node)
+        mids = self._monitored_events[event.emitting_node]
+        for mid in mids:
+            self._trigger_event(event, mid)
+        return True
+
+    def _trigger_event(self, event, mid):
+        if mid not in self._monitored_items:
+            self.logger.debug("Could not find monitored items for id %s for event %s in subscription %s", mid, event,
+                              self)
+            return
+        mdata = self._monitored_items[mid]
+        if not mdata.where_clause_evaluator.eval(event):
+            self.logger.info("%s, %s, Event %s does not fit WhereClause, not generating event", self, mid, event)
+            return
+        fieldlist = ua.EventFieldList()
+        fieldlist.ClientHandle = mdata.client_handle
+        fieldlist.EventFields = event.to_event_fields(mdata.filter.SelectClauses)
+        self.isub.enqueue_event(mid, fieldlist, mdata.queue_size)
+
+    def trigger_statuschange(self, code):
+        self.isub.enqueue_statuschange(code)
+
+
+class WhereClauseEvaluator:
+    def __init__(self, logger, aspace, whereclause):
+        self.logger = logger
+        self.elements = whereclause.Elements
+        self._aspace = aspace
+
+    def eval(self, event):
+        if not self.elements:
+            return True
+        # spec says we should only evaluate first element, which may use other elements
+        try:
+            res = self._eval_el(0, event)
+        except Exception as ex:
+            self.logger.exception("Exception while evaluating WhereClause %s for event %s: %s", self.elements, event,
+                                  ex)
+            return False
+        return res
+
+    def _eval_el(self, index, event):
+        el = self.elements[index]
+        # ops = [self._eval_op(op, event) for op in el.FilterOperands]
+        ops = el.FilterOperands  # just to make code more readable
+        if el.FilterOperator == ua.FilterOperator.Equals:
+            return self._eval_op(ops[0], event) == self._eval_el(ops[1], event)
+        if el.FilterOperator == ua.FilterOperator.IsNull:
+            return self._eval_op(ops[0], event) is None  # FIXME: might be too strict
+        if el.FilterOperator == ua.FilterOperator.GreaterThan:
+            return self._eval_op(ops[0], event) > self._eval_el(ops[1], event)
+        if el.FilterOperator == ua.FilterOperator.LessThan:
+            return self._eval_op(ops[0], event) < self._eval_el(ops[1], event)
+        if el.FilterOperator == ua.FilterOperator.GreaterThanOrEqual:
+            return self._eval_op(ops[0], event) >= self._eval_el(ops[1], event)
+        if el.FilterOperator == ua.FilterOperator.LessThanOrEqual:
+            return self._eval_op(ops[0], event) <= self._eval_el(ops[1], event)
+        if el.FilterOperator == ua.FilterOperator.Like:
+            return self._like_operator(self._eval_op(ops[0], event), self._eval_el(ops[1], event))
+        if el.FilterOperator == ua.FilterOperator.Not:
+            return not self._eval_op(ops[0], event)
+        if el.FilterOperator == ua.FilterOperator.Between:
+            return self._eval_el(ops[2], event) >= self._eval_op(ops[0], event) >= self._eval_el(ops[1], event)
+        if el.FilterOperator == ua.FilterOperator.InList:
+            return self._eval_op(ops[0], event) in [self._eval_op(op, event) for op in ops[1:]]
+        if el.FilterOperator == ua.FilterOperator.And:
+            self.elements(ops[0].Index)
+            return self._eval_op(ops[0], event) and self._eval_op(ops[1], event)
+        if el.FilterOperator == ua.FilterOperator.Or:
+            return self._eval_op(ops[0], event) or self._eval_el(ops[1], event)
+        if el.FilterOperator == ua.FilterOperator.Cast:
+            self.logger.warn("Cast operand not implemented, assuming True")
+            return True
+        if el.FilterOperator == ua.FilterOperator.OfType:
+            return event.EventType == self._eval_op(ops[0], event)
+        # TODO: implement missing operators
+        self.logger.warning("WhereClause not implemented for element: %s", el)
+        raise NotImplementedError
+
+    def _like_operator(self, string, pattern):
+        raise NotImplementedError
+
+    def _eval_op(self, op, event):
+        # seems spec says we should return Null if issues
+        if isinstance(op, ua.ElementOperand):
+            return self._eval_el(op.Index, event)
+        if isinstance(op, ua.AttributeOperand):
+            if op.BrowsePath:
+                return getattr(event, op.BrowsePath.Elements[0].TargetName.Name)
+            return self._aspace.get_attribute_value(event.EventType, op.AttributeId).Value.Value
+            # FIXME: check, this is probably broken
+        if isinstance(op, ua.SimpleAttributeOperand):
+            if op.BrowsePath:
+                # we only support depth of 1
+                return getattr(event, op.BrowsePath[0].Name)
+            # TODO: write code for index range.... but doe it make any sense
+            return self._aspace.get_attribute_value(event.EventType, op.AttributeId).Value.Value
+        if isinstance(op, ua.LiteralOperand):
+            return op.Value.Value
+        self.logger.warning("Where clause element % is not of a known type", op)
+        raise NotImplementedError

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -6,10 +6,9 @@ import asyncio
 import logging
 from datetime import timedelta, datetime
 from urllib.parse import urlparse
-from typing import Coroutine
+from typing import Coroutine, Optional
 
 from asyncua import ua
-# from asyncua.binary_server import BinaryServer
 from .binary_server_asyncio import BinaryServer
 from .internal_server import InternalServer
 from .event_generator import EventGenerator
@@ -65,8 +64,8 @@ class Server:
     :ivar nodes: shortcuts to common nodes - `Shortcuts` instance
     """
 
-    def __init__(self, iserver: InternalServer = None, loop=None):
-        self.loop = loop or asyncio.get_event_loop()
+    def __init__(self, iserver: InternalServer = None, loop: asyncio.AbstractEventLoop = None):
+        self.loop: asyncio.AbstractEventLoop = loop or asyncio.get_event_loop()
         self.logger = logging.getLogger(__name__)
         self.endpoint = urlparse("opc.tcp://0.0.0.0:4840/freeopcua/server/")
         self._application_uri = "urn:freeopcua:python:server"
@@ -76,7 +75,7 @@ class Server:
         self.application_type = ua.ApplicationType.ClientAndServer
         self.default_timeout: int = 60 * 60 * 1000
         self.iserver = iserver if iserver else InternalServer(self.loop)
-        self.bserver: BinaryServer = None
+        self.bserver: Optional[BinaryServer] = None
         self._discovery_clients = {}
         self._discovery_period = 60
         self._policies = []

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -52,19 +52,17 @@ class Server:
     cache file or the file will be created if it does not exist yet.
     As a result the first startup will be even slower due to the cache file
     generation but all further start ups will be significantly faster.
+    ┌────────┐
+    │ Server │ ── BinaryServer ── OPCUAProtocol ── UaProcessor
+    │        │ ── InternalServer ── InternalSession
+    └────────┘                   ── SubscriptionService
 
     :ivar product_uri:
-    :vartype product_uri: uri
     :ivar name:
-    :vartype name: string
     :ivar default_timeout: timeout in milliseconds for sessions and secure channel
-    :vartype default_timeout: int
-    :ivar iserver: internal server object
-    :vartype default_timeout: InternalServer
-    :ivar bserver: binary protocol server
-    :vartype bserver: BinaryServer
-    :ivar nodes: shortcuts to common nodes
-    :vartype nodes: Shortcuts
+    :ivar iserver: `InternalServer` instance
+    :ivar bserver: binary protocol server `BinaryServer`
+    :ivar nodes: shortcuts to common nodes - `Shortcuts` instance
     """
 
     def __init__(self, iserver: InternalServer = None, loop=None):
@@ -73,10 +71,10 @@ class Server:
         self.endpoint = urlparse("opc.tcp://0.0.0.0:4840/freeopcua/server/")
         self._application_uri = "urn:freeopcua:python:server"
         self.product_uri = "urn:freeopcua.github.io:python:server"
-        self.name = "FreeOpcUa Python Server"
+        self.name: str = "FreeOpcUa Python Server"
         self.manufacturer_name = "FreeOpcUa"
         self.application_type = ua.ApplicationType.ClientAndServer
-        self.default_timeout = 60 * 60 * 1000
+        self.default_timeout: int = 60 * 60 * 1000
         self.iserver = iserver if iserver else InternalServer(self.loop)
         self.bserver: BinaryServer = None
         self._discovery_clients = {}
@@ -363,13 +361,9 @@ class Server:
     async def create_subscription(self, period, handler):
         """
         Create a subscription.
-        returns a Subscription object which allow
-        to subscribe to events or data on server
-        period is in milliseconds
-        handler is a python object with following methods:
-            def datachange_notification(self, node, val, data):
-            def event_notification(self, event):
-            def status_change_notification(self, status):
+        Returns a Subscription object which allow to subscribe to events or data changes on server
+        :param period: Period in milliseconds
+        :param handler: A class instance - see `SubHandler` base class for details
         """
         params = ua.CreateSubscriptionParameters()
         params.RequestedPublishingInterval = period

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -4,7 +4,7 @@ server side implementation of subscription service
 
 import asyncio
 import logging
-from typing import Dict
+from typing import Dict, Iterable
 
 from asyncua import ua
 from .internal_subscription import InternalSubscription
@@ -54,7 +54,7 @@ class SubscriptionService:
         await asyncio.gather(*[sub.stop() for sub in existing_subs])
         return res
 
-    def publish(self, acks):
+    def publish(self, acks: Iterable[ua.SubscriptionAcknowledgement]):
         self.logger.info("publish request with acks %s", acks)
         for subid, sub in self.subscriptions.items():
             sub.publish([ack.SequenceNumber for ack in acks if ack.SubscriptionId == subid])

--- a/asyncua/server/users.py
+++ b/asyncua/server/users.py
@@ -1,5 +1,5 @@
 """
-Implement user managent here
+Implement user management here.
 """
 
 from enum import Enum

--- a/asyncua/ua/ua_binary.py
+++ b/asyncua/ua/ua_binary.py
@@ -453,7 +453,7 @@ def extensionobject_to_binary(obj):
 
 def from_binary(uatype, data):
     """
-    unpack data given an uatype as a string or a python class having a ua_types memeber
+    unpack data given an uatype as a string or a python class having a ua_types member
     """
     if isinstance(uatype, str) and uatype.startswith("ListOf"):
         utype = uatype[6:]
@@ -481,7 +481,7 @@ def struct_from_binary(objtype, data):
         return objtype(Primitives.UInt32.unpack(data))
     obj = objtype()
     for name, uatype in obj.ua_types:
-        # if our member has a swtich and it is not set we skip it
+        # if our member has a switch and it is not set we skip it
         if hasattr(obj, "ua_switches") and name in obj.ua_switches:
             container_name, idx = obj.ua_switches[name]
             val = getattr(obj, container_name)

--- a/asyncua/ua/uaerrors/_base.py
+++ b/asyncua/ua/uaerrors/_base.py
@@ -84,3 +84,7 @@ class UaStatusCodeError(_AutoRegister("Meta", (UaError,), {})):
 
 class UaStringParsingError(UaError):
     pass
+
+
+class UaStructParsingError(UaError):
+    pass

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -337,36 +337,34 @@ async def test_create_delete_subscription(opc):
 
 async def test_unsubscribe_two_objects_simultaneously(opc):
     """
-    Test the subscription/unsub. of the `CurrentTime` and `Server_ServerStatus_State` objects.
+    Test the subscription/unsub. of the `ServerStatus_StartTime` and `ServerStatus_State` objects.
     Unsubscribe from both Nodes simultaneously.
     """
     handler = MySubHandler2(limit=1)
     nodes = [
-        opc.opc.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime)),
+        opc.opc.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_StartTime)),
         opc.opc.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_State)),
     ]
-    sub = await opc.opc.create_subscription(200, handler)
+    sub = await opc.opc.create_subscription(100, handler)
     handles = await sub.subscribe_data_change(nodes)
     await handler.done.wait()
     assert handler.results[0][0] == nodes[0]
-    assert (datetime.utcnow() - handler.results[0][1]) < timedelta(seconds=2)
     assert handler.results[1][0] == nodes[1]
-    assert handler.results[1][1] == 0
     await sub.unsubscribe(handles)
     await sub.delete()
 
 
 async def test_unsubscribe_two_objects_consecutively(opc):
     """
-    Test the subscription/unsub. of the `CurrentTime` and `Server_ServerStatus_State` objects.
+    Test the subscription/unsub. of the `ServerStatus_StartTime` and `ServerStatus_State` objects.
     Unsubscribe from both Nodes consecutively.
     """
-    handler = MySubHandler2(limit=2)
+    handler = MySubHandler2(limit=1)
     nodes = [
-        opc.opc.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime)),
+        opc.opc.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_StartTime)),
         opc.opc.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_State)),
     ]
-    sub = await opc.opc.create_subscription(200, handler)
+    sub = await opc.opc.create_subscription(100, handler)
     handles = await sub.subscribe_data_change(nodes)
     assert type(handles) is list
     await handler.done.wait()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -9,7 +9,7 @@ from asyncua import ua
 @pytest.fixture
 def server():
     s = Server()
-    s.set_endpoint('opc.tcp://*:8840/freeopcua/server/')
+    s.set_endpoint('opc.tcp://0.0.0.0:8840/freeopcua/server/')
     uri = "http://examples.freeopcua.github.io"
     idx = s.register_namespace(uri)
     myobj = s.nodes.objects.add_object(idx, "MyObject")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -17,10 +17,9 @@ from asyncua.ua.ua_binary import extensionobject_to_binary
 from asyncua.ua.ua_binary import nodeid_to_binary, variant_to_binary, _reshape, variant_from_binary, nodeid_from_binary
 from asyncua.ua.ua_binary import struct_to_binary, struct_from_binary
 from asyncua.ua import flatten, get_shape
-from asyncua.server.internal_subscription import WhereClauseEvaluator
+from asyncua.server.monitored_item_service import WhereClauseEvaluator
 from asyncua.common.event_objects import BaseEvent
-from asyncua.common.ua_utils import string_to_variant, variant_to_string, string_to_val, val_to_string
-from asyncua.common.xmlimporter import XmlImporter
+from asyncua.common.ua_utils import string_to_val, val_to_string
 from asyncua.ua.uatypes import _MaskEnum
 from asyncua.common.structures import StructGenerator
 from asyncua.common.connection import MessageChunk


### PR DESCRIPTION
**preliminary - do not merge yet**

I worked on the client subscription publish mechanism. There is now less _fire and forget_ but the changes affect the  symmetry between client and server a bit (internally).
The `UaClient` now has a task that cyclically issues PublishRequests. `Subscription` no longer has to call the `publish()` method.
There is much more potential for simplification in the workings of `InternalSession`, `SubscriptionService`, `InternalSubscription`, `MonitoredItemService` ...
But before that i would like to try and draw a UML diagram, it is hard for me to keep that level of complexity in my mind.
This branch needs further testing and discussion. I may try to use it for some productive systems at work for testing.