### PR TITLE
Only remove subscriptions specific to a client when closing a session

### DIFF
--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -37,6 +37,7 @@ class InternalSession:
         self.state = SessionState.Created
         self.session_id = ua.NodeId(self._counter)
         InternalSession._counter += 1
+        self.subscriptions = []
         self.auth_token = ua.NodeId(self._auth_counter)
         InternalSession._auth_counter += 1
         self.logger.info('Created internal session %s', self.name)
@@ -63,7 +64,7 @@ class InternalSession:
     async def close_session(self, delete_subs=True):
         self.logger.info('close session %s', self.name)
         self.state = SessionState.Closed
-        await self.delete_subscriptions(list(self.subscription_service.subscriptions.keys()))
+        await self.delete_subscriptions(self.subscriptions)
 
     def activate_session(self, params):
         self.logger.info('activate session')
@@ -119,6 +120,7 @@ class InternalSession:
 
     async def create_subscription(self, params, callback=None):
         result = await self.subscription_service.create_subscription(params, callback)
+        self.subscriptions.append(result.SubscriptionId)
         return result
 
     async def create_monitored_items(self, params: ua.CreateMonitoredItemsParameters):

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-asyncio
 coverage
+pytest-cov

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -126,11 +126,13 @@ async def test_multiple_clients_with_subscriptions(server):
             sub2 = await client2.create_subscription(100, sub_handler)
             await sub1.subscribe_data_change(var)
             await sub2.subscribe_data_change(var)
-            assert len(server.iserver.subscription_service.subscriptions) == 2
-        # When client2 disconnects, client1 should still keep it's subscription.
-        assert len(server.iserver.subscription_service.subscriptions) == 1
-    assert len(server.iserver.subscription_service.subscriptions) == 0
-
+            assert sub1.subscription_id in server.iserver.subscription_service.subscriptions
+            assert sub2.subscription_id in server.iserver.subscription_service.subscriptions
+        # When client2 disconnects, client1 should still keep its subscription.
+        assert sub1.subscription_id in server.iserver.subscription_service.subscriptions
+        assert sub2.subscription_id not in server.iserver.subscription_service.subscriptions
+    assert sub1.subscription_id not in server.iserver.subscription_service.subscriptions
+    assert sub2.subscription_id not in server.iserver.subscription_service.subscriptions
 
 async def test_historize_events(server):
     srv_node = server.get_node(ua.ObjectIds.Server)


### PR DESCRIPTION
This PR fixes a bug where closing a client session will delete all subscriptions of all sessions on a server, rather than just the subscriptions for the particular client. 

It looks like `python-opcua` had this covered by keeping track of a list of subscriptions specific to the session and [only deleting those](https://github.com/FreeOpcUa/python-opcua/blob/master/opcua/server/internal_server.py#L333). In this PR I add similar functionality back in.

This was tested locally by running two clients connected to the same server. Previously, each time a client would disconnect, subscriptions would get removed, and after this change, this doesn't happen. I've also added a unit test to multiple clients with subscriptions. I validated that this test fails on master and passes on this branch.

