### PR TITLE
Set the correct client signature algorithm

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -394,8 +394,9 @@ class Client:
             challenge += self.security_policy.server_certificate
         if self._server_nonce is not None:
             challenge += self._server_nonce
-        params.ClientSignature.Algorithm = self.security_policy.AsymmetricSignatureURI
-        if not params.ClientSignature.Algorithm:
+        if self.security_policy.AsymmetricSignatureURI:
+            params.ClientSignature.Algorithm = self.security_policy.AsymmetricSignatureURI
+        else:
             params.ClientSignature.Algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
         params.ClientSignature.Signature = self.security_policy.asymmetric_cryptography.signature(challenge)
         params.LocaleIds.append("en")

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -394,7 +394,9 @@ class Client:
             challenge += self.security_policy.server_certificate
         if self._server_nonce is not None:
             challenge += self._server_nonce
-        params.ClientSignature.Algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
+        params.ClientSignature.Algorithm = self.security_policy.AsymmetricSignatureURI
+        if not params.ClientSignature.Algorithm:
+            params.ClientSignature.Algorithm = "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
         params.ClientSignature.Signature = self.security_policy.asymmetric_cryptography.signature(challenge)
         params.LocaleIds.append("en")
         if not username and not certificate:


### PR DESCRIPTION
Servers, for example servers created with the UA .NETStandard SDK, check the signature algorithm when activating a session. 

Until now the algorithm was always set to the sha1 uri in the client class. 
Basic256Sha256 needs the sha256 uri as signature algorithm. Connections will fail if the incorrect algorithm is set.

As the security_policies classes contain the property AsymmetricSignatureURI we can use that information in the activate_session method.

See example C# validation code here: [https://github.com/OPCFoundation/UA-.NETStandard/blob/master/Stack/Opc.Ua.Core/Security/Constants/SecurityPolicies.cs#L325](https://github.com/OPCFoundation/UA-.NETStandard/blob/master/Stack/Opc.Ua.Core/Security/Constants/SecurityPolicies.cs#L325)