### PR TITLE
Fix #71 (missing publish call in internal server subscriptions)

### DIFF
--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -526,7 +526,7 @@ class UaClient:
             else:
                 try:
                     callback(response.Parameters)
-                except Exception:  # we call client code, catch everything!
+                except Exception:  # we call user code, catch everything!
                     self.logger.exception("Exception while calling user callback: %s")
             # Repeat with acknowledgement
             ack = ua.SubscriptionAcknowledgement()

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -118,8 +118,8 @@ class InternalSession:
         """COROUTINE"""
         return self.iserver.method_service.call(params)
 
-    async def create_subscription(self, params, callback=None):
-        result = await self.subscription_service.create_subscription(params, callback)
+    async def create_subscription(self, params, callback=None, is_for_client=False):
+        result = await self.subscription_service.create_subscription(params, callback, is_for_client)
         self.subscriptions.append(result.SubscriptionId)
         return result
 

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -118,8 +118,8 @@ class InternalSession:
         """COROUTINE"""
         return self.iserver.method_service.call(params)
 
-    async def create_subscription(self, params, callback=None, is_for_client=False):
-        result = await self.subscription_service.create_subscription(params, callback, is_for_client)
+    async def create_subscription(self, params, callback=None):
+        result = await self.subscription_service.create_subscription(params, callback, external=self.external)
         self.subscriptions.append(result.SubscriptionId)
         return result
 

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -13,11 +13,19 @@ from .address_space import AddressSpace
 
 class InternalSubscription:
     """
-
+    Server internal subscription.
+    Runs the publication loop and stores the Publication Results until they are acknowledged.
     """
 
     def __init__(self, loop: asyncio.AbstractEventLoop, data: ua.CreateSubscriptionResult, aspace: AddressSpace,
                  callback=None, no_acks=False):
+        """
+        :param loop: Event loop instance
+        :param data: Create Subscription Result
+        :param aspace: Server Address Space
+        :param callback: Callback for publishing
+        :param no_acks: If true no acknowledging will be expected (for server internal subscriptions)
+        """
         self.logger = logging.getLogger(__name__)
         self.loop: asyncio.AbstractEventLoop = loop
         self.data: ua.CreateSubscriptionResult = data

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -17,7 +17,7 @@ class InternalSubscription:
     """
 
     def __init__(self, loop: asyncio.AbstractEventLoop, data: ua.CreateSubscriptionResult, aspace: AddressSpace,
-                 callback=None, is_for_client=False):
+                 callback=None, no_acks=False):
         self.logger = logging.getLogger(__name__)
         self.loop: asyncio.AbstractEventLoop = loop
         self.data: ua.CreateSubscriptionResult = data
@@ -32,7 +32,7 @@ class InternalSubscription:
         self._keep_alive_count = 0
         self._publish_cycles_count = 0
         self._task = None
-        self._is_for_client = is_for_client
+        self.no_acks = no_acks
 
     def __str__(self):
         return f"Subscription(id:{self.data.SubscriptionId})"
@@ -93,7 +93,7 @@ class InternalSubscription:
             self.monitored_item_srv.trigger_statuschange(ua.StatusCode(ua.StatusCodes.BadTimeout))
         result = None
         if self.has_published_results():
-            if self._is_for_client:
+            if not self.no_acks:
                 self._publish_cycles_count += 1
             result = self._pop_publish_result()
         if result is not None:
@@ -116,7 +116,7 @@ class InternalSubscription:
         self._keep_alive_count = 0
         self._startup = False
         result.NotificationMessage.SequenceNumber = self._notification_seq
-        if result.NotificationMessage.NotificationData and self._is_for_client:
+        if result.NotificationMessage.NotificationData and not self.no_acks:
             # Acknowledgement is only expected when the Subscription is for a client.
             self._notification_seq += 1
             self._not_acknowledged_results[result.NotificationMessage.SequenceNumber] = result

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -97,6 +97,7 @@ class InternalSubscription:
         if result is not None:
             self.logger.info('publish_results for %s', self.data.SubscriptionId)
             self.pub_result_callback(result)
+            self.publish([result.NotificationMessage.SequenceNumber])
 
     def _pop_publish_result(self) -> ua.PublishResult:
         """

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -28,7 +28,7 @@ class SubscriptionService:
     def active_subscription_ids(self):
         return self.subscriptions.keys()
 
-    async def create_subscription(self, params, callback=None):
+    async def create_subscription(self, params, callback=None, is_for_client=False):
         self.logger.info("create subscription")
         result = ua.CreateSubscriptionResult()
         result.RevisedPublishingInterval = params.RequestedPublishingInterval
@@ -36,7 +36,7 @@ class SubscriptionService:
         result.RevisedMaxKeepAliveCount = params.RequestedMaxKeepAliveCount
         self._sub_id_counter += 1
         result.SubscriptionId = self._sub_id_counter
-        internal_sub = InternalSubscription(self.loop, result, self.aspace, callback)
+        internal_sub = InternalSubscription(self.loop, result, self.aspace, callback, is_for_client)
         await internal_sub.start()
         self.subscriptions[result.SubscriptionId] = internal_sub
         return result

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -28,7 +28,7 @@ class SubscriptionService:
     def active_subscription_ids(self):
         return self.subscriptions.keys()
 
-    async def create_subscription(self, params, callback=None, is_for_client=False):
+    async def create_subscription(self, params, callback=None, external=False):
         self.logger.info("create subscription")
         result = ua.CreateSubscriptionResult()
         result.RevisedPublishingInterval = params.RequestedPublishingInterval
@@ -36,7 +36,7 @@ class SubscriptionService:
         result.RevisedMaxKeepAliveCount = params.RequestedMaxKeepAliveCount
         self._sub_id_counter += 1
         result.SubscriptionId = self._sub_id_counter
-        internal_sub = InternalSubscription(self.loop, result, self.aspace, callback, is_for_client)
+        internal_sub = InternalSubscription(self.loop, result, self.aspace, callback=callback, no_acks=not external)
         await internal_sub.start()
         self.subscriptions[result.SubscriptionId] = internal_sub
         return result

--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -294,7 +294,8 @@ class UaProcessor:
         elif typeid == ua.NodeId(ua.ObjectIds.CreateSubscriptionRequest_Encoding_DefaultBinary):
             _logger.info("create subscription request")
             params = struct_from_binary(ua.CreateSubscriptionParameters, body)
-            result = await self.session.create_subscription(params, callback=self.forward_publish_response)
+            result = await self.session.create_subscription(params, callback=self.forward_publish_response,
+                                                            is_for_client=True)
             response = ua.CreateSubscriptionResponse()
             response.Parameters = result
             _logger.info("sending create subscription response")

--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -294,8 +294,7 @@ class UaProcessor:
         elif typeid == ua.NodeId(ua.ObjectIds.CreateSubscriptionRequest_Encoding_DefaultBinary):
             _logger.info("create subscription request")
             params = struct_from_binary(ua.CreateSubscriptionParameters, body)
-            result = await self.session.create_subscription(params, callback=self.forward_publish_response,
-                                                            is_for_client=True)
+            result = await self.session.create_subscription(params, callback=self.forward_publish_response)
             response = ua.CreateSubscriptionResponse()
             response.Parameters = result
             _logger.info("sending create subscription response")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,7 +105,6 @@ async def opc(request):
         await srv.stop()
     elif request.param == 'server':
         # start our own server
-        # start our own server
         srv = Server()
         await srv.init()
         srv.set_endpoint(f'opc.tcp://127.0.0.1:{port_num1}')


### PR DESCRIPTION
On internal server subscriptions `InternalSubscription._not_acknowledged_results` kept growing onexternal data changes. This was a bug that was introduced in the #45 Subscription refactoring.