### PR TITLE
remove unnecessary production dependency into tests requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,5 @@ setup(
             'uageneratestructs = asyncua.tools:uageneratestructs',
         ]
     },
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
+    tests_require=['pytest', 'pytest-runner'],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
 from setuptools import setup, find_packages
+import sys
+
+# don't require pytest-runner unless we have been invoked as a test launch
+needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
+pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup(
     name="asyncua",
@@ -35,5 +40,6 @@ setup(
             'uageneratestructs = asyncua.tools:uageneratestructs',
         ]
     },
-    tests_require=['pytest', 'pytest-runner'],
+    setup_requires=[] + pytest_runner,
+    tests_require=['pytest'],
 )


### PR DESCRIPTION
As per title. Production systems shouldn't need to have `pytest-runner` installed.

(Note: possibly a duplicated effort as branch `asyncua` has a different setup.py file which does not contain this problem)