### PR TITLE
Allow Asynchronous Method Calls

### DIFF
--- a/asyncua/common/methods.py
+++ b/asyncua/common/methods.py
@@ -86,7 +86,7 @@ def uamethod(func):
 
 def _format_call_inputs(parent, *args):
         if isinstance(parent, ua.NodeId):
-        return (parent, *[arg.Value for arg in args])
+            return (parent, *[arg.Value for arg in args])
         else:
             self = parent
             parent = args[0]

--- a/examples/server-methods.py
+++ b/examples/server-methods.py
@@ -1,24 +1,12 @@
-import sys
-sys.path.insert(0, "..")
+import asyncio
 import logging
-
-try:
-    from IPython import embed
-except ImportError:
-    import code
-
-    def embed():
-        vars = globals()
-        vars.update(locals())
-        shell = code.InteractiveConsole(vars)
-        shell.interact()
-
 
 from asyncua import ua, uamethod, Server
 
 
 # method to be exposed through server
 def func(parent, variant):
+    print("func method call with parameters: ", variant.Value)
     ret = False
     if variant.Value % 2 == 0:
         ret = True
@@ -26,7 +14,17 @@ def func(parent, variant):
 
 
 # method to be exposed through server
+async def func_async(parent, variant):
+    if variant.Value % 2 == 0:
+        print("Sleeping asynchronously for 1 second")
+        await asyncio.sleep(1)
+    else:
+        print("Not sleeping!")
+
+
+# method to be exposed through server
 # uses a decorator to automatically convert to and from variants
+
 
 @uamethod
 def multiply(parent, x, y):
@@ -34,42 +32,52 @@ def multiply(parent, x, y):
     return x * y
 
 
-if __name__ == "__main__":
+@uamethod
+async def multiply_async(parent, x, y):
+    sleep_time = x * y
+    print(f"Sleeping asynchronously for {x * y} seconds")
+    await asyncio.sleep(sleep_time)
+
+
+async def main():
     # optional: setup logging
     logging.basicConfig(level=logging.WARN)
-    #logger = logging.getLogger("asyncua.address_space")
+    # logger = logging.getLogger("asyncua.address_space")
     # logger.setLevel(logging.DEBUG)
-    #logger = logging.getLogger("asyncua.internal_server")
+    # logger = logging.getLogger("asyncua.internal_server")
     # logger.setLevel(logging.DEBUG)
-    #logger = logging.getLogger("asyncua.binary_server_asyncio")
+    # logger = logging.getLogger("asyncua.binary_server_asyncio")
     # logger.setLevel(logging.DEBUG)
-    #logger = logging.getLogger("asyncua.uaprocessor")
+    # logger = logging.getLogger("asyncua.uaprocessor")
     # logger.setLevel(logging.DEBUG)
-    #logger = logging.getLogger("asyncua.subscription_service")
+    # logger = logging.getLogger("asyncua.subscription_service")
     # logger.setLevel(logging.DEBUG)
 
     # now setup our server
     server = Server()
-    #server.set_endpoint("opc.tcp://localhost:4840/freeopcua/server/")
+    await server.init()
+    # server.set_endpoint("opc.tcp://localhost:4840/freeopcua/server/")
     server.set_endpoint("opc.tcp://0.0.0.0:4840/freeopcua/server/")
     server.set_server_name("FreeOpcUa Example Server")
 
     # setup our own namespace
     uri = "http://examples.freeopcua.github.io"
-    idx = server.register_namespace(uri)
+    idx = await server.register_namespace(uri)
 
     # get Objects node, this is where we should put our custom stuff
     objects = server.get_objects_node()
 
     # populating our address space
-    myfolder = objects.add_folder(idx, "myEmptyFolder")
-    myobj = objects.add_object(idx, "MyObject")
-    myvar = myobj.add_variable(idx, "MyVariable", 6.7)
-    myvar.set_writable()    # Set MyVariable to be writable by clients
-    myarrayvar = myobj.add_variable(idx, "myarrayvar", [6.7, 7.9])
-    myarrayvar = myobj.add_variable(idx, "myStronglytTypedVariable", ua.Variant([], ua.VariantType.UInt32))
-    myprop = myobj.add_property(idx, "myproperty", "I am a property")
-    mymethod = myobj.add_method(idx, "mymethod", func, [ua.VariantType.Int64], [ua.VariantType.Boolean])
+    await objects.add_folder(idx, "myEmptyFolder")
+    myobj = await objects.add_object(idx, "MyObject")
+    myvar = await myobj.add_variable(idx, "MyVariable", 6.7)
+    await myvar.set_writable()  # Set MyVariable to be writable by clients
+    myarrayvar = await myobj.add_variable(idx, "myarrayvar", [6.7, 7.9])
+    await myobj.add_variable(
+        idx, "myStronglytTypedVariable", ua.Variant([], ua.VariantType.UInt32)
+    )
+    await myobj.add_property(idx, "myproperty", "I am a property")
+    await myobj.add_method(idx, "mymethod", func, [ua.VariantType.Int64], [ua.VariantType.Boolean])
 
     inargx = ua.Argument()
     inargx.Name = "x"
@@ -90,13 +98,17 @@ if __name__ == "__main__":
     outarg.ArrayDimensions = []
     outarg.Description = ua.LocalizedText("Multiplication result")
 
-    multiply_node = myobj.add_method(idx, "multiply", multiply, [inargx, inargy], [outarg])
+    await myobj.add_method(idx, "multiply", multiply, [inargx, inargy], [outarg])
+    await myobj.add_method(idx, "multiply_async", multiply_async, [inargx, inargy], [])
+    await myobj.add_method(idx, "func_async", func_async, [ua.VariantType.Int64], [])
 
-    # starting!
-    server.start()
-    print("Available loggers are: ", logging.Logger.manager.loggerDict.keys())
-    try:
+    async with server:
+        while True:
+            await asyncio.sleep(1)
 
-        embed()
-    finally:
-        server.stop()
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    # loop.set_debug(True)
+    loop.run_until_complete(main())
+    loop.close()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -6,10 +6,12 @@ client side since we have been carefull to have the exact
 same api on server and client side
 """
 
-import pytest
+import asyncio
 from datetime import datetime
 from datetime import timedelta
 import math
+
+import pytest
 
 from asyncua import ua, uamethod, Node
 from asyncua.common import ua_utils
@@ -78,6 +80,15 @@ async def add_server_methods(srv):
     await o.add_method(
         ua.NodeId("ServerMethodTuple", 2), ua.QualifiedName('ServerMethodTuple', 2), func5, [],
         [ua.VariantType.Int64, ua.VariantType.Int64, ua.VariantType.Int64]
+    )
+
+    @uamethod
+    async def func6(parent):
+        await asyncio.sleep(0)
+
+    o = srv.get_objects_node()
+    await o.add_method(
+        ua.NodeId("ServerMethodAsync", 2), ua.QualifiedName('ServerMethodAsync', 2), func6, [], []
     )
 
 
@@ -616,6 +627,13 @@ async def test_method_none(opc):
     assert result is None
     result = await call_method_full(o, m)
     assert [] == result.OutputArguments
+
+
+async def test_method_async(opc):
+    o = opc.opc.get_objects_node()
+    m = await o.get_child("2:ServerMethodAsync")
+    await o.call_method(m)
+    await call_method_full(o, m)
 
 
 async def test_add_nodes(opc):


### PR DESCRIPTION
I occasionally run methods from my server that involve some I/O or other logic that doesn't execute relatively quickly, and therefore the server will block on these methods for a while if they are called synchronously. I have got around this in the past by running these methods in a thread and then emitting an event when it completes, but I thought it would make sense to implement the ability to run `async` methods directly. My goal is best demonstrated by example:

```python
@uamethod
async def func1(parent, value):
    _logger.info(f"Starting async sleep for {value} seconds")
    await asyncio.sleep(value)
    _logger.info("Ending async sleep")

@uamethod
def func2(parent, value):
    _logger.info(f"Starting sync sleep for {value} seconds")
    time.sleep(value)
    _logger.info("Ending sync sleep")
```

Before, only `func1` was possible, as you couldn't call coroutines from `MethodService.call`. In this PR, I added some logic into the `MethodService.call` method that determines if the method is a coroutine or not, and if it is, it will `await` it.

I created a small script with these functions as well as a variable that increments in the background every 1 sec. From this script's output you can see that the `async` method does not block, whereas the synchronous method does (thus preventing the variable from incrementing):

```
2019-10-11 15:48:43.648 INFO     call request
2019-10-11 15:48:43.649 INFO     Calling: CallMethodRequest(ObjectId:TwoByteNodeId(i=85), MethodId:StringNodeId(ns=2;s=ServerMethod), InputArguments:[Variant(val:3,type:VariantType.Int64)])
2019-10-11 15:48:43.650 INFO     Starting async sleep for 3 seconds
2019-10-11 15:48:43.698 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 0.7
2019-10-11 15:48:44.699 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 0.8
2019-10-11 15:48:45.702 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 0.9
2019-10-11 15:48:46.657 INFO     Ending async sleep
2019-10-11 15:48:46.705 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 1.0
2019-10-11 15:48:47.700 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 1.1
2019-10-11 15:48:48.701 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 1.2
2019-10-11 15:48:49.702 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 1.3
2019-10-11 15:48:50.695 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 1.4
2019-10-11 15:48:51.497 INFO     call request
2019-10-11 15:48:51.498 INFO     Calling: CallMethodRequest(ObjectId:TwoByteNodeId(i=85), MethodId:StringNodeId(ns=2;s=ServerMethod2), InputArguments:[Variant(val:3,type:VariantType.Int64)])
2019-10-11 15:48:51.499 INFO     Starting sync sleep for 3 seconds
2019-10-11 15:48:54.500 INFO     Ending sync sleep
2019-10-11 15:48:54.509 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 1.5
2019-10-11 15:48:55.510 INFO     Set value of Node(NumericNodeId(ns=2;i=2)) to 1.6
```

I have modified this logic such that it works regardless of whether you choose to use the `uamethod` decorator or not.

While testing this, I also found that `server-methods.py` did not get ported over to this from `python-opcua`, so I updated it and added examples of `async` methods