### PR TITLE
Fix immediate publishing

### DIFF
--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -61,7 +61,7 @@ class InternalSubscription:
         """
         Trigger immediate publication (if requested by the PublishingInterval).
         """
-        if self._task and self.data.RevisedPublishingInterval <= 0.0:
+        if not self._task and self.data.RevisedPublishingInterval <= 0.0:
             # Publish immediately (as fast as possible)
             self.publish_results()
 


### PR DESCRIPTION
As discussed in https://github.com/FreeOpcUa/opcua-asyncio/issues/93, the call to `publish_results` in `_trigger_publish` currently seems unreachable due to conflicting conditionals.

In this PR, I update the logic for publishing of a subscription to be the following:
* If the publishing interval of a subscription is non-zero, start a subscription loop task that publishes updates on the provided interval
* If the publishing interval of the subscription is zero, don't start a subscription loop task, and instead publish an update immediately when it is manually triggered.

In the future, do you think it would make sense to allow both immediate triggering and interval-based triggering? I think to allow that you'd need some locking to ensure that the immediate trigger doesn't clash with the subscription loop. Not sure if that goes against the OPC-UA spec or not.

I tested this by running a server, then creating a subscription through the client with a polling interval of 0ms. It appears to be publishing relatively quickly now.