### PR TITLE
Resolve collections.Iterable DeprecationWarning for Python 3.8

### DIFF
--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -3,7 +3,7 @@ high level interface to subscriptions
 """
 import asyncio
 import logging
-from collections import Iterable as CollectionsIterable
+import collections.abc
 from typing import Union, List, Iterable
 
 from asyncua import ua
@@ -207,7 +207,7 @@ class Subscription:
         :return: Integer handle or if multiple Nodes were given a List of Integer handles/ua.StatusCode
         """
         is_list = True
-        if isinstance(nodes, CollectionsIterable):
+        if isinstance(nodes, collections.abc.Iterable):
             nodes = list(nodes)
         else:
             nodes = [nodes]

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -3,7 +3,7 @@ high level interface to subscriptions
 """
 import asyncio
 import logging
-import collections
+from collections import Iterable as CollectionsIterable
 from typing import Union, List, Iterable
 
 from asyncua import ua
@@ -207,7 +207,7 @@ class Subscription:
         :return: Integer handle or if multiple Nodes were given a List of Integer handles/ua.StatusCode
         """
         is_list = True
-        if isinstance(nodes, collections.Iterable):
+        if isinstance(nodes, CollectionsIterable):
             nodes = list(nodes)
         else:
             nodes = [nodes]


### PR DESCRIPTION
While running tests, I saw this `DeprecationWarning` come up:

```
...\opcua-asyncio\asyncua\common\subscription.py:210: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    if isinstance(nodes, collections.Iterable):
```

This change [was made in Python 3.3](https://docs.python.org/3.7/library/collections.abc.html#module-collections.abc), and since `opcua-asyncio` only support Python 3.6+, this should be a safe change.