### PR TITLE
enable the ServerTimestamp

### DIFF
--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -2,6 +2,7 @@
 High level node object, to access node attribute
 and browse address space
 """
+from datetime import datetime
 
 import logging
 
@@ -171,7 +172,9 @@ class Node:
         An exception will be generated for other node types.
         DataValue contain a variable value as a variant as well as server and source timestamps
         """
-        return await self.get_attribute(ua.AttributeIds.Value)
+        datavalue = await self.get_attribute(ua.AttributeIds.Value)
+        datavalue.ServerTimestamp = datetime.utcnow()
+        return datavalue
 
     async def set_array_dimensions(self, value):
         """

--- a/asyncua/common/ua_utils.py
+++ b/asyncua/common/ua_utils.py
@@ -23,9 +23,11 @@ def value_to_datavalue(val, varianttype=None):
     elif isinstance(val, ua.Variant):
         datavalue = ua.DataValue(val)
         datavalue.SourceTimestamp = datetime.utcnow()
+        datavalue.ServerTimestamp = datetime.utcnow()
     else:
         datavalue = ua.DataValue(ua.Variant(val, varianttype))
         datavalue.SourceTimestamp = datetime.utcnow()
+        datavalue.ServerTimestamp = datetime.utcnow()
     return datavalue
 
 

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -418,7 +418,7 @@ class NodeManagementService:
         if item.SpecifiedAttributes & getattr(ua.NodeAttributesMask, name):
             dv = ua.DataValue(ua.Variant(getattr(item, name), vtype))
             if add_timestamps:
-                # dv.ServerTimestamp = datetime.utcnow()  # Disabled until someone explains us it should be there
+                dv.ServerTimestamp = datetime.utcnow()
                 dv.SourceTimestamp = datetime.utcnow()
             nodedata.attributes[getattr(ua.AttributeIds, name)] = AttributeValue(dv)
 
@@ -655,6 +655,9 @@ class AddressSpace:
             dv.StatusCode = ua.StatusCode(ua.StatusCodes.BadAttributeIdInvalid)
             return dv
         attval = node.attributes[attr]
+        if attr == 13:
+            datavalue = attval.value
+            datavalue.ServerTimestamp = datetime.utcnow()
         if attval.value_callback:
             return attval.value_callback()
         return attval.value


### PR DESCRIPTION
Hey,

here I enabled the ServerTimestamp again.
I think it is useful because you know the server time of the request and then you know at least the timedelta between the writing and the request.

Or why shouldn`t it be useful?