### PR TITLE
Don't cancel missing subscription task

### DIFF
--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -51,10 +51,13 @@ class InternalSubscription:
             self._task = self.loop.create_task(self._subscription_loop())
 
     async def stop(self):
-        self.logger.info("stopping internal subscription %s", self.data.SubscriptionId)
-        self._task.cancel()
-        await self._task
-        self._task = None
+        if self._task:
+            self.logger.info("stopping internal subscription %s", self.data.SubscriptionId)
+            self._task.cancel()
+            await self._task
+            self._task = None
+        else:
+            self.logger.debug(f"internal subscription has no task to stop")
         self.monitored_item_srv.delete_all_monitored_items()
 
     def _trigger_publish(self):

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -56,8 +56,6 @@ class InternalSubscription:
             self._task.cancel()
             await self._task
             self._task = None
-        else:
-            self.logger.debug(f"internal subscription has no task to stop")
         self.monitored_item_srv.delete_all_monitored_items()
 
     def _trigger_publish(self):


### PR DESCRIPTION
In https://github.com/FreeOpcUa/opcua-asyncio/pull/94, I made it so that you could have a 0ms publishing interval on your subscription. When you do this, the [`InternalSubscription` doesn't create a subscription task](https://github.com/FreeOpcUa/opcua-asyncio/blob/08861799d3413345dcc5b4ae387427739b864bad/asyncua/server/internal_subscription.py#L50-L51). Then, when the `InternalSubscription` is stopped, the `stop` function attempts to cancel the `InternalSubscription`s task, which doesn't exist, leading to an `AttributeError`.

This PR introduces a simple check to see if the task exists before cancelling it, and do nothing if the task doesn't exist.

This was tested with both a server and a client from this package. I subscribed to the server (with a 0ms subscription interval) with the client, then confirmed that the `AttributeError` was not raised when the subscription was stopped.