### PR TITLE
Add a few methods to sync Node API

### DIFF
--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -248,12 +248,19 @@ class Node:
         self.aio_obj = aio_node
         self.tloop = tloop
 
-    def __hash__(self):
-        return self.aio_obj.__hash__()
+    def __eq__(self, other):
+        return self.aio_obj == other.aio_obj
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __str__(self):
         return "Sync" + self.aio_obj.__str__()
+    
     __repr__ = __str__
+
+    def __hash__(self):
+        return self.aio_obj.__hash__()
 
     @property
     def nodeid(self):
@@ -261,6 +268,10 @@ class Node:
 
     @syncmethod
     def get_browse_name(self):
+        pass
+
+    @syncmethod
+    def get_display_name(self):
         pass
 
     @syncmethod
@@ -317,7 +328,7 @@ class Node:
     set_value = write_value  # legacy
 
     @syncmethod
-    def read_value(self, val):
+    def read_value(self):
         pass
 
     get_value = read_value  # legacy
@@ -326,8 +337,17 @@ class Node:
     def call_method(self, methodid, *args):
         pass
 
-    def __eq__(self, other):
-        return self.aio_obj == other.aio_obj
+    @syncmethod
+    def get_references(self, refs=ua.ObjectIds.References, direction=ua.BrowseDirection.Both, nodeclassmask=ua.NodeClass.Unspecified, includesubtypes=True):
+        pass
+
+    @syncmethod
+    def get_description(self):
+        pass
+
+    @syncmethod
+    def get_variables(self):
+        pass
 
 
 class Subscription:

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -256,7 +256,7 @@ class Node:
 
     def __str__(self):
         return "Sync" + self.aio_obj.__str__()
-    
+
     __repr__ = __str__
 
     def __hash__(self):
@@ -275,14 +275,18 @@ class Node:
         pass
 
     @syncmethod
-    def get_children(self, refs=ua.ObjectIds.HierarchicalReferences, nodeclassmask=ua.NodeClass.Unspecified):
+    def get_children(
+        self, refs=ua.ObjectIds.HierarchicalReferences, nodeclassmask=ua.NodeClass.Unspecified
+    ):
         pass
 
     @syncmethod
-    def get_children_descriptions(self,
-                                  refs=ua.ObjectIds.HierarchicalReferences,
-                                  nodeclassmask=ua.NodeClass.Unspecified,
-                                  includesubtypes=True):
+    def get_children_descriptions(
+        self,
+        refs=ua.ObjectIds.HierarchicalReferences,
+        nodeclassmask=ua.NodeClass.Unspecified,
+        includesubtypes=True,
+    ):
         pass
 
     @syncmethod
@@ -338,7 +342,13 @@ class Node:
         pass
 
     @syncmethod
-    def get_references(self, refs=ua.ObjectIds.References, direction=ua.BrowseDirection.Both, nodeclassmask=ua.NodeClass.Unspecified, includesubtypes=True):
+    def get_references(
+        self,
+        refs=ua.ObjectIds.References,
+        direction=ua.BrowseDirection.Both,
+        nodeclassmask=ua.NodeClass.Unspecified,
+        includesubtypes=True,
+    ):
         pass
 
     @syncmethod
@@ -360,11 +370,13 @@ class Subscription:
         pass
 
     @syncmethod
-    def subscribe_events(self,
-                         sourcenode=ua.ObjectIds.Server,
-                         evtypes=ua.ObjectIds.BaseEventType,
-                         evfilter=None,
-                         queuesize=0):
+    def subscribe_events(
+        self,
+        sourcenode=ua.ObjectIds.Server,
+        evtypes=ua.ObjectIds.BaseEventType,
+        evfilter=None,
+        queuesize=0,
+    ):
         pass
 
     @syncmethod


### PR DESCRIPTION
I was starting to use the sync API to replace `python-opcua` in an application, but came across a few incompatibilities due to some missing methods in the sync API that did exist in `ua.Node`. I added these methods back to the API and my application is working equivalently to when it was using `python-opcua`. 

While adding these methods to the API, I also noticed that `read_value` had the wrong arguments (it took an extra positional argument that it shouldn't have), so I fixed that as well.

Is the goal to eventually expose the entire API for each object in this sync file?