### PR TITLE
stream

### DIFF
--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -517,10 +517,10 @@ class Node:
             details.EndTime = ua.get_win_epoch()
         details.NumValuesPerNode = numvalues
         details.ReturnBounds = True
-        result = await self.history_read(details)
+        result = await self.history_read(details, None)
         return result.HistoryData.DataValues
 
-    async def history_read(self, details):
+    async def history_read(self, details, session):
         """
         Read raw history of a node, low-level function
         result code from server is checked and an exception is raised in case of error
@@ -533,9 +533,9 @@ class Node:
         params.TimestampsToReturn = ua.TimestampsToReturn.Both
         params.ReleaseContinuationPoints = False
         params.NodesToRead.append(valueid)
-        return (await self.server.history_read(params))[0]
+        return (await self.server.history_read(params, session))[0]
 
-    async def read_event_history(self, starttime=None, endtime=None, numvalues=0, evtypes=ua.ObjectIds.BaseEventType):
+    async def read_event_history(self, starttime=None, endtime=None, numvalues=0, evtypes=ua.ObjectIds.BaseEventType, session=None):
         """
         Read event history of a source node
         result code from server is checked and an exception is raised in case of error
@@ -557,7 +557,7 @@ class Node:
         evtypes = [Node(self.server, evtype) for evtype in evtypes]
         evfilter = await get_filter_from_event_type(evtypes)
         details.Filter = evfilter
-        result = await self.history_read_events(details)
+        result = await self.history_read_events(details, session)
         event_res = []
         for res in result.HistoryData.Events:
             event_res.append(
@@ -565,7 +565,7 @@ class Node:
             )
         return event_res
 
-    async def history_read_events(self, details):
+    async def history_read_events(self, details, session):
         """
         Read event history of a node, low-level function
         result code from server is checked and an exception is raised in case of error
@@ -578,7 +578,7 @@ class Node:
         params.TimestampsToReturn = ua.TimestampsToReturn.Both
         params.ReleaseContinuationPoints = False
         params.NodesToRead.append(valueid)
-        return (await self.server.history_read(params))[0]
+        return (await self.server.history_read(params, session))[0]
 
     async def delete(self, delete_references=True, recursive=False):
         """

--- a/asyncua/server/history.py
+++ b/asyncua/server/history.py
@@ -39,7 +39,7 @@ class HistoryStorageInterface:
         """
         raise NotImplementedError
 
-    async def read_node_history(self, node_id, start, end, nb_values):
+    async def read_node_history(self, node_id, start, end, nb_values, session):
         """
         Called when a client make a history read request for a node
         if start or end is missing then nb_values is used to limit query
@@ -64,7 +64,7 @@ class HistoryStorageInterface:
         """
         raise NotImplementedError
 
-    async def read_event_history(self, source_id, start, end, nb_values, evfilter):
+    async def read_event_history(self, source_id, start, end, nb_values, evfilter, session):
         """
         Called when a client make a history read request for events
         Start time and end time are inclusive
@@ -113,7 +113,7 @@ class HistoryDict(HistoryStorageInterface):
         if count and len(data) > count:
             data.pop(0)
 
-    async def read_node_history(self, node_id, start, end, nb_values):
+    async def read_node_history(self, node_id, start, end, nb_values, session):
         cont = None
         if node_id not in self._datachanges:
             self.logger.warning("Error attempt to read history for a node which is not historized")
@@ -154,7 +154,7 @@ class HistoryDict(HistoryStorageInterface):
         if count and len(evts) > count:
             evts.pop(0)
 
-    async def read_event_history(self, source_id, start, end, nb_values, evfilter):
+    async def read_event_history(self, source_id, start, end, nb_values, evfilter, session):
         cont = None
         if source_id not in self._events:
             print("Error attempt to read event history for a node which does not historize events")
@@ -278,20 +278,19 @@ class HistoryManager:
         else:
             self.logger.error("History Manager isn't subscribed to %s", node)
 
-    async def read_history(self, params):
+    async def read_history(self, params, session):
         """
         Read history for a node
         This is the part AttributeService, but implemented as its own service
         since it requires more logic than other attribute service methods
         """
         results = []
-
         for rv in params.NodesToRead:
-            res = await self._read_history(params.HistoryReadDetails, rv)
+            res = await self._read_history(params.HistoryReadDetails, rv, session)
             results.append(res)
         return results
 
-    async def _read_history(self, details, rv):
+    async def _read_history(self, details, rv, session):
         """
         determine if the history read is for a data changes or events; then read the history for that node
         """
@@ -302,7 +301,7 @@ class HistoryManager:
                 # we do not support modified history by design so we return what we have
             else:
                 result.HistoryData = ua.HistoryData()
-            dv, cont = await self._read_datavalue_history(rv, details)
+            dv, cont = await self._read_datavalue_history(rv, details, session)
             result.HistoryData.DataValues = dv
             result.ContinuationPoint = cont
 
@@ -310,7 +309,7 @@ class HistoryManager:
             result.HistoryData = ua.HistoryEvent()
             # FIXME: filter is a cumbersome type, maybe transform it something easier
             # to handle for storage
-            ev, cont = await self._read_event_history(rv, details)
+            ev, cont = await self._read_event_history(rv, details, session)
             result.HistoryData.Events = ev
             result.ContinuationPoint = cont
 
@@ -319,7 +318,7 @@ class HistoryManager:
             result.StatusCode = ua.StatusCode(ua.StatusCodes.BadNotImplemented)
         return result
 
-    async def _read_datavalue_history(self, rv, details):
+    async def _read_datavalue_history(self, rv, details, session):
         starttime = details.StartTime
         if rv.ContinuationPoint:
             # Spec says we should ignore details if cont point is present
@@ -331,14 +330,15 @@ class HistoryManager:
         dv, cont = await self.storage.read_node_history(rv.NodeId,
                                                         starttime,
                                                         details.EndTime,
-                                                        details.NumValuesPerNode)
+                                                        details.NumValuesPerNode,
+                                                        session)
         if cont:
             cont = ua.ua_binary.Primitives.DateTime.pack(cont)
         # rv.IndexRange
         # rv.DataEncoding # xml or binary, seems spec say we can ignore that one
         return dv, cont
 
-    async def _read_event_history(self, rv, details):
+    async def _read_event_history(self, rv, details, session):
         starttime = details.StartTime
         if rv.ContinuationPoint:
             # Spec says we should ignore details if cont point is present
@@ -351,7 +351,8 @@ class HistoryManager:
                                                            starttime,
                                                            details.EndTime,
                                                            details.NumValuesPerNode,
-                                                           details.Filter)
+                                                           details.Filter,
+                                                           session)
         results = []
         for ev in evts:
             field_list = ua.HistoryEventFieldList()

--- a/asyncua/server/history_mongo.py
+++ b/asyncua/server/history_mongo.py
@@ -4,6 +4,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from asyncua.ua.uatypes import LocalizedText
 from asyncua.ua.uatypes import VariantType
 import json
+from asyncua.server.internal_session import InternalSession
 
 
 class HistoryMongoDb(HistoryStorageInterface):
@@ -53,14 +54,44 @@ class HistoryMongoDb(HistoryStorageInterface):
         event.add_property("Message", content, VariantType(21))
         return event
 
-    async def read_event_history(self, source_id, start, end, nb_values, evfilter, session):
+    async def read_event_history(self, source_id, start, end, nb_values, evfilter, session: InternalSession):
+        # create the variables
+        _session_id = str(session.session_id)
         events_query = list()
+        query = {'$and': [{"time_stamp": {"$gte": start}}, {"time_stamp": {"$lte": end}}]}
+
+        # limits the number of requests per query
         if (not nb_values) or nb_values > self.limits_for_request:
-            _max_value = 5001
+            _max_value = self.limits_for_request + 1
         else:
             _max_value = nb_values + 1
 
-        query = {'$and': [{"time_stamp": {"$gte": start}}, {"time_stamp": {"$lte": end}}]}
+        # check if the session exists, otherwise create a data key for it
+        if _session_id not in self.clients_session_packages:
+            self.clients_session_packages[_session_id] = dict()
+            self.clients_session_packages[_session_id]["isFirstRequest"] = True
+            self.clients_session_packages[_session_id]["length"] = 0
+            self.clients_session_packages[_session_id]["count_pages"] = 0
+            self.clients_session_packages[_session_id]["pages"] = 0
+
+        # if the session already exists it means it's a next appointment
+        else:
+            self.clients_session_packages[_session_id]["count_pages"] += 1
+
+        # create initial query data, return number of documents, calculate number of required pages.
+        if self.clients_session_packages[_session_id]["isFirstRequest"]:
+            length_request = await self.collection.count_documents(query)
+            pages = round(length_request / (_max_value - 1))
+            missing = length_request % (_max_value - 1)
+
+            if missing > 0:
+                pages += 1
+
+            self.clients_session_packages[_session_id]["length"] = length_request
+            self.clients_session_packages[_session_id]["pages"] = pages
+            self.clients_session_packages[_session_id]["isFirstRequest"] = False
+
+        # execute the query by sorting by date and limiting the cursor to only the number requested by the client
         cursor = self.collection.find(query, {"_id": 0}).sort([('sample_datetime', 1)]).limit(_max_value)
         async for document in cursor:
             events_query.append(document)
@@ -68,18 +99,31 @@ class HistoryMongoDb(HistoryStorageInterface):
         events = list(map(self.format_event, events_query))
         length = len(events)
 
+        # if the query returns one more format document and event to display pagination data
         if length > (_max_value - 1):
             last_event = events_query[length - 1]
             last_time_stamp = last_event["time_stamp"]
 
-            event = Event()
             last_sample = dict()
-            last_sample["last_sample"] = last_time_stamp.iso_format()
+            last_sample["pages"] = self.clients_session_packages[_session_id]["pages"]
+            last_sample["count"] = self.clients_session_packages[_session_id]["count_pages"]
+            last_sample["length"] = self.clients_session_packages[_session_id]["length"]
+            last_sample["last_sample"] = last_time_stamp.isoformat()
+
+            event = Event()
             content = LocalizedText(text=json.dumps(last_sample))
             event.add_property("Message", content, VariantType(21))
 
             events.pop(length - 1)
             events.append(event)
+
+        pages = self.clients_session_packages[_session_id]["pages"]
+        count_pages = self.clients_session_packages[_session_id]["count_pages"]
+
+        # check if the query number is equal to the number of pages, if yes delete the session
+        if count_pages >= (pages - 1):
+            if _session_id in self.clients_session_packages:
+                del self.clients_session_packages[_session_id]
 
         return events, None
 
@@ -91,3 +135,4 @@ class HistoryMongoDb(HistoryStorageInterface):
         self.database = self.server_database["MyHistoryEvents"]
         self.collection = self.database["myevents"]
         self.limits_for_request = 5000
+        self.clients_session_packages = dict()

--- a/asyncua/server/history_mongo.py
+++ b/asyncua/server/history_mongo.py
@@ -1,0 +1,93 @@
+from ..common.events import Event
+from .history import HistoryStorageInterface
+from motor.motor_asyncio import AsyncIOMotorClient
+from asyncua.ua.uatypes import LocalizedText
+from asyncua.ua.uatypes import VariantType
+import json
+
+
+class HistoryMongoDb(HistoryStorageInterface):
+    """
+    Create an interface for storing and tracking event and variable history with the
+    mongodb database server.
+
+    In this example I am using a maximum of 5000 results limit and storing the last result
+    as an ack of the date of the last event to be fetched.
+    The biggest reason was the need that I am having to deploy opcua servers that store
+    data every 1 second and can request the track record of at least one year which will add
+    up to a total of 31.104.000 samples.
+
+    Limiting this value to stream an http server with an internal opcua client that will
+    fetch the samples from the opcua server and feed a graph to an html page.
+
+    """
+    async def init(self):
+        pass
+
+    async def new_historized_node(self, node_id, period, count=0):
+        pass
+
+    async def save_node_value(self, node_id, datavalue):
+        pass
+
+    async def read_node_history(self, node_id, start, end, nb_values, session):
+        pass
+
+    async def new_historized_event(self, source_id, evtypes, period, count=0):
+        pass
+
+    async def save_event(self, event):
+        message_event = event.get_event_props_as_fields_dict()
+        message = message_event["Message"].Value.Text
+        time_stamp = message_event["Time"].Value
+
+        _event = dict()
+        _event["message"] = message
+        _event["time_stamp"] = time_stamp
+
+        self.collection.insert_one(_event)
+
+    def format_event(self, document):
+        event = Event()
+        content = LocalizedText(text=json.dumps(document["message"]))
+        event.add_property("Message", content, VariantType(21))
+        return event
+
+    async def read_event_history(self, source_id, start, end, nb_values, evfilter, session):
+        events_query = list()
+        if (not nb_values) or nb_values > self.limits_for_request:
+            _max_value = 5001
+        else:
+            _max_value = nb_values + 1
+
+        query = {'$and': [{"time_stamp": {"$gte": start}}, {"time_stamp": {"$lte": end}}]}
+        cursor = self.collection.find(query, {"_id": 0}).sort([('sample_datetime', 1)]).limit(_max_value)
+        async for document in cursor:
+            events_query.append(document)
+
+        events = list(map(self.format_event, events_query))
+        length = len(events)
+
+        if length > (_max_value - 1):
+            last_event = events_query[length - 1]
+            last_time_stamp = last_event["time_stamp"]
+
+            event = Event()
+            last_sample = dict()
+            last_sample["last_sample"] = last_time_stamp.iso_format()
+            content = LocalizedText(text=json.dumps(last_sample))
+            event.add_property("Message", content, VariantType(21))
+
+            events.pop(length - 1)
+            events.append(event)
+
+        return events, None
+
+    async def stop(self):
+        pass
+
+    def __init__(self):
+        self.server_database: AsyncIOMotorClient = AsyncIOMotorClient("10.10.20.100:27017")
+        self.database = self.server_database["MyHistoryEvents"]
+        self.collection = self.database["myevents"]
+        self.limits_for_request = 5000

--- a/asyncua/server/history_sql.py
+++ b/asyncua/server/history_sql.py
@@ -87,7 +87,7 @@ class HistorySQLite(HistoryStorageInterface):
                 'SourceTimestamp = (SELECT CASE WHEN COUNT(*) > ? '
                 f'THEN MIN(SourceTimestamp) ELSE NULL END FROM "{table}")', (count,), table, node_id)
 
-    async def read_node_history(self, node_id, start, end, nb_values):
+    async def read_node_history(self, node_id, start, end, nb_values, session):
         table = self._get_table_name(node_id)
         start_time, end_time, order, limit = self._get_bounds(start, end, nb_values)
         cont = None
@@ -157,7 +157,7 @@ class HistorySQLite(HistoryStorageInterface):
             except aiosqlite.Error as e:
                 self.logger.error("Historizing SQL Delete Old Data Error for events from %s: %s", event.emitting_node, e)
 
-    async def read_event_history(self, source_id, start, end, nb_values, evfilter):
+    async def read_event_history(self, source_id, start, end, nb_values, evfilter, session):
         table = self._get_table_name(source_id)
         start_time, end_time, order, limit = self._get_bounds(start, end, nb_values)
         clauses, clauses_str = self._get_select_clauses(source_id, evfilter)

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -96,8 +96,8 @@ class InternalSession:
         results = self.iserver.attribute_service.read(params)
         return results
 
-    def history_read(self, params) -> Coroutine:
-        return self.iserver.history_manager.read_history(params)
+    def history_read(self, params, session) -> Coroutine:
+        return self.iserver.history_manager.read_history(params, session)
 
     async def write(self, params):
         return self.iserver.attribute_service.write(params, self.user)

--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -336,7 +336,7 @@ class UaProcessor:
         elif typeid == ua.NodeId(ua.ObjectIds.HistoryReadRequest_Encoding_DefaultBinary):
             _logger.info("history read request")
             params = struct_from_binary(ua.HistoryReadParameters, body)
-            results = await self.session.history_read(params)
+            results = await self.session.history_read(params, self.session)
             response = ua.HistoryReadResponse()
             response.Results = results
             #_logger.info("sending history read response")

--- a/tests/test_history_limits.py
+++ b/tests/test_history_limits.py
@@ -7,7 +7,7 @@ NODE_ID = ua.NodeId(123)
 
 
 async def result_count(history):
-    results, cont = await history.read_node_history(NODE_ID, None, None, None)
+    results, cont = await history.read_node_history(NODE_ID, None, None, None, None)
     return len(results)
 
 


### PR DESCRIPTION
Adding the client session history function arguments to better control data packets in a streamed data transmission to one or more optional clients.
The biggest reason was the need that I am having to deploy opcua servers that store data every 1 second and can request the track record of at least one year which will add up to a total of 31.104.000 samples.