### PR TITLE
Close thread loop after stopping in sync wrapper

### DIFF
--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -41,6 +41,8 @@ class ThreadLoop(Thread):
 
     def stop(self):
         self.loop.call_soon_threadsafe(self.loop.stop)
+        self.join()
+        self.loop.close()
 
     def post(self, coro):
         if not self.loop or not self.loop.is_running():
@@ -54,7 +56,6 @@ class ThreadLoop(Thread):
 
     def __exit__(self, exc_t, exc_v, trace):
         self.stop()
-        self.join()
 
 
 def syncmethod(func):


### PR DESCRIPTION
I noticed an issue where if I ran a process that periodically created new `asyncua.sync.Client` objects, I would eventually run out of file descriptors on that process, manifesting itself as a `OSError: [Errno 24] Too many open files`. It appears that every time a new `asyncua.sync.Client` object is instantiated, we leak a few file descriptors, so over time I hit the max limit of my process. This can be recreated as follows (you will need two terminals):

- Launch a Python REPL from one terminal
- From a second terminal get the PID of the Python REPL (using `ps aux` on Linux). Then run `ls -l /proc/PID/fd | wc -l` where `PID` is the PID of the Python REPL. In my case, the output of this command is 12 active file descriptors.
- From the Python REPL, run the following lines:
```python
from asyncua.sync import Client
c=Client("opc.tcp://localhost:4848")
```
- Run the same command to get the number of active file descriptors. I now see 15. This is from the thread loop getting started in the constructor for `asyncua.sync.Client`.
- From the Python REPL, run the following line:
```python
c.connect()
```
- Run the same command to get the number of active file descriptors. I now see 16. This is from the connection of the client to the OPC-UA server.
- From the Python REPL, run the following line:
```python
c.disconnect()
```
- Run the same command to get the number of active file descriptors. I now see 15. I would expect to see the original number (12), but we appear to have leaked 3 file descriptors.

The leaked file descriptors appear to be from not explicitly stopping the underlying `asycnio` event loop that the `ThreadLoop` object makes use of. The change in this PR explicitly closes the event loop after waiting for it to stop. When I run through the same process as above after making this change, I now see 12 file descriptors left after disconnecting the client, meaning no descriptors have been leaked.