### PR TITLE
Don't remove previous security token when revolving tokens

### DIFF
--- a/asyncua/common/connection.py
+++ b/asyncua/common/connection.py
@@ -233,6 +233,7 @@ class SecureConnection:
         self.security_token = self.next_security_token
         self.next_security_token = ua.ChannelSecurityToken()
         self.security_policy.make_local_symmetric_key(self.remote_nonce, self.local_nonce)
+        self.security_policy.make_remote_symmetric_key(self.local_nonce, self.remote_nonce)
 
     def message_to_binary(self, message, message_type=ua.MessageType.SecureMessage, request_id=0):
         """
@@ -268,7 +269,6 @@ class SecureConnection:
 
         if securityHeader.TokenId == self.next_security_token.TokenId:
             self.revolve_tokens()
-            self.security_policy.make_remote_symmetric_key(self.local_nonce, self.remote_nonce)
             return
 
         if self._allow_prev_token and securityHeader.TokenId == self.prev_security_token.TokenId:

--- a/asyncua/common/connection.py
+++ b/asyncua/common/connection.py
@@ -260,9 +260,9 @@ class SecureConnection:
         Validates the symmetric header of the message chunk and revolves the
         security token if needed.
         """
-        assert isinstance(
-            securityHeader, ua.SymmetricAlgorithmHeader
-        ), "Expected SymAlgHeader, got: {0}".format(securityHeader)
+        assert isinstance(securityHeader, ua.SymmetricAlgorithmHeader), "Expected SymAlgHeader, got: {0}".format(
+            securityHeader
+        )
 
         if securityHeader.TokenId == self.security_token.TokenId:
             return
@@ -292,9 +292,7 @@ class SecureConnection:
         if self._allow_prev_token:
             expected_tokens.insert(0, self.prev_security_token.TokenId)
         raise ua.UaError(
-            "Invalid security token id {}, expected one of: {}".format(
-                securityHeader.TokenId, expected_tokens
-            )
+            "Invalid security token id {}, expected one of: {}".format(securityHeader.TokenId, expected_tokens)
         )
 
     def _check_incoming_chunk(self, chunk):


### PR DESCRIPTION
In https://github.com/FreeOpcUa/python-opcua/pull/915, @jonasgreen88 introduced logic to revolve security tokens whenever a channel is renewed.

In my application, I had a client that used `opcua==0.98.5` and I recently switched to `asyncua==0.8.0`. In that switch, I started seeing an influx of errors that all said `Invalid security token id {n}, expected {n+1} or {0}`. In each case, the received token was always one less than the expected token.

After looking through the change where this was introduced, it seems like whenever the tokens were revolved, [the previous token was removed](https://github.com/FreeOpcUa/opcua-asyncio/compare/master...chrisjbremner:fix_revolve?expand=1#diff-b15c66d6385a64ef5957e8a8e40e354bL280), so that if you then received an "old" token after revolving, this error would be triggered, even if the "old" token was within the 25% expiration window. I didn't see anything in the spec (mainly looked in part 4, 5.5.2.1) that says that "old" tokens should be rejected after a new token is received, so I removed the logic that removes these old tokens prematurely.

In addition, this PR:
* Cleans up some of the conditional logic to un-nest things and make it slightly easier to read
* Applies [`black`](https://github.com/psf/black) to the modified logic with a line length of 99
* Moves `make_remote_symmetric_key` into `revolve_tokens` to simplify conditional logic

I'd love some feedback from @jonasgreen88 as to whether he thinks any of these changes could be detrimental. I have been able to test with a client and a server both using this code, and haven't encountered any issues.
