### PR TITLE
Use UASocketProtocol.timeout as default in send_request

### DIFF
--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -129,12 +129,13 @@ class UASocketProtocol(asyncio.Protocol):
         self.transport.write(msg)
         return future
 
-    async def send_request(self, request, timeout=10, message_type=ua.MessageType.SecureMessage):
+    async def send_request(self, request, timeout=None, message_type=ua.MessageType.SecureMessage):
         """
         Send a request to the server.
         Timeout is the timeout written in ua header.
         Returns response object if no callback is provided.
         """
+        timeout = self.timeout if timeout is None else timeout
         data = await asyncio.wait_for(
             self._send_request(request, timeout, message_type),
             timeout if timeout else None


### PR DESCRIPTION
I use asyncua as a client to connect with a pretty slow server (probably it's all because of hardware)

But UaClient raises TimeoutError after 10 seconds regardless a timeout it's initialized with.

So it's a simple fix of the hardcoded timeout.