### PR TITLE
Fix exception when disconnecting while not all Requests were processed.

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -211,7 +211,6 @@ class Client:
         Connect, create and activate session
         """
         _logger.info("connect")
-        self.uaclient.protocol.disconnecting = False
         await self.connect_socket()
         try:
             await self.send_hello()
@@ -229,7 +228,6 @@ class Client:
         Close session, secure channel and socket
         """
         _logger.info("disconnect")
-        self.uaclient.protocol.disconnecting = True
         try:
             await self.close_session()
             await self.close_secure_channel()

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -211,6 +211,7 @@ class Client:
         Connect, create and activate session
         """
         _logger.info("connect")
+        self.uaclient.protocol.disconnecting = False
         await self.connect_socket()
         try:
             await self.send_hello()
@@ -228,6 +229,7 @@ class Client:
         Close session, secure channel and socket
         """
         _logger.info("disconnect")
+        self.uaclient.protocol.disconnecting = True
         try:
             await self.close_session()
             await self.close_secure_channel()

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -285,6 +285,7 @@ class UaClient:
 
     async def create_session(self, parameters):
         self.logger.info("create_session")
+        self.protocol.disconnecting = False
         request = ua.CreateSessionRequest()
         request.Parameters = parameters
         data = await self.protocol.send_request(request)
@@ -306,6 +307,7 @@ class UaClient:
 
     async def close_session(self, delete_subscriptions):
         self.logger.info("close_session")
+        self.protocol.disconnecting = True
         if self._publish_task and not self._publish_task.done():
             self._publish_task.cancel()
         if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:


### PR DESCRIPTION
With the current implementation, the client crashes when disconnecting while requests are awaiting their response. From the logs:

Request is sent:
```
2020-03-11 12:55:56.629 Thread-1 - asyncua.client.ua_client.UASocketProtocol - _send_request :112 - DEBUG - Sending: PublishRequest(TypeId:FourByteNodeId(i=826), RequestHeader:RequestHeader(AuthenticationToken:NumericNodeId(i=30607522), Timestamp:2020-03-11 11:55:56.629308, RequestHandle:15, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:0, AdditionalHeader:ExtensionObject(TypeId:TwoByteNodeId(i=0), Encoding:0, None bytes)), Parameters:PublishParameters(SubscriptionAcknowledgements:[SubscriptionAcknowledgement(SubscriptionId:83, SequenceNumber:8)]))
```

A disconnect starts:
```
2020-03-11 12:55:56.655 Thread-1 - asyncua.client.client - disconnect :230 - INFO - disconnect
2020-03-11 12:55:56.656 Thread-1 - asyncua.client.ua_client.UaClient - close_session :305 - INFO - close_session
2020-03-11 12:55:56.656 Thread-1 - asyncua.client.ua_client.UASocketProtocol - _send_request :112 - DEBUG - Sending: CloseSessionRequest(TypeId:FourByteNodeId(i=473), RequestHeader:RequestHeader(AuthenticationToken:NumericNodeId(i=30607522), Timestamp:2020-03-11 11:55:56.656236, RequestHandle:16, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:4000, AdditionalHeader:ExtensionObject(TypeId:TwoByteNodeId(i=0), Encoding:0, None bytes)), DeleteSubscriptions:True)
```

And reponse is received for PublishRequest:
```
2020-03-11 12:55:56.659 Thread-1 - asyncua.client.ua_client.UASocketProtocol - _process_received_data :85 - ERROR - Exception raised while parsing message from server
Traceback (most recent call last):
File "C:\Users\krumm-ti\Documents\PycharmProjects\LabMonitor\venv\lib\site-packages\asyncua\client\ua_client.py", line 158, in _call_callback
self._callbackmap[request_id].set_result(body)
asyncio.exceptions.InvalidStateError: invalid state

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
File "C:\Users\krumm-ti\Documents\PycharmProjects\LabMonitor\venv\lib\site-packages\asyncua\client\ua_client.py", line 79, in _process_received_data
self._process_received_message(msg)
File "C:\Users\krumm-ti\Documents\PycharmProjects\LabMonitor\venv\lib\site-packages\asyncua\client\ua_client.py", line 93, in _process_received_message
self._call_callback(msg.request_id(), msg.body())
File "C:\Users\krumm-ti\Documents\PycharmProjects\LabMonitor\venv\lib\site-packages\asyncua\client\ua_client.py", line 164, in _call_callback
raise ua.UaError(f"Future for request id {request_id} is already done")
asyncua.ua.uaerrors._base.UaError: Future for request id 15 is already done
```

This leads to several timeouts afterwards for the requests that are made to disconnect the session.

With this fix, the exception is suppressed when the client is disconnecting.