### PR TITLE
Fix issues with disconnect

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Union, Coroutine
+from typing import Union, Coroutine, Optional
 from urllib.parse import urlparse
 
 from asyncua import ua
@@ -479,12 +479,15 @@ class Client:
         data, uri = security_policies.encrypt_asymmetric(pubkey, etoken, policy_uri)
         return data, uri
 
-    async def close_session(self) -> Coroutine:
+    async def close_session(self) -> Optional[Coroutine]:
         """
         Close session
         """
         self._renew_channel_task.cancel()
         await self._renew_channel_task
+        if not self.uaclient.protocol or self.uaclient.protocol.closed:
+            _logger.info("close_session was called, but session is closed already")
+            return None
         return await self.uaclient.close_session(True)
 
     def get_root_node(self):

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -265,6 +265,9 @@ class UaClient:
         if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
             self.logger.warning("disconnect_socket was called but connection is closed")
             return None
+        if not self.protocol:
+            self.logger.warning("disconnect was called while connect is in progress")
+            return None
         return self.protocol.disconnect_socket()
 
     async def send_hello(self, url, max_messagesize=0, max_chunkcount=0):


### PR DESCRIPTION
This PR addresses two issues:
1. If close_session is called on a Client, that is already disconnected we'll just return to prevent an exception. This is a use case when the Client loses the connection and therefore disconnects the socket. One would need to call disconnect on the Client to ensure, that i.e. the renew_channel_loop is stopped correctly.
2. Fix an exception that occurs, when the UaClient tries to disconnect its socket, but has not protocol. 