### PR TITLE
Add indexrange kwarg to Node.set_attribute

### DIFF
--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -252,16 +252,18 @@ class Node:
         """
         return self.set_writable(False)
 
-    async def write_attribute(self, attributeid, datavalue):
+    async def write_attribute(self, attributeid, datavalue, indexrange=None):
         """
         Set an attribute of a node
         attributeid is a member of ua.AttributeIds
         datavalue is a ua.DataValue object
+        indexrange is a NumericRange (a string)
         """
         attr = ua.WriteValue()
         attr.NodeId = self.nodeid
         attr.AttributeId = attributeid
         attr.Value = datavalue
+        attr.IndexRange = indexrange
         params = ua.WriteParameters()
         params.NodesToWrite = [attr]
         result = await self.server.write(params)

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -257,7 +257,8 @@ class Node:
         Set an attribute of a node
         attributeid is a member of ua.AttributeIds
         datavalue is a ua.DataValue object
-        indexrange is a NumericRange (a string)
+        indexrange is a NumericRange (a string; e.g. "1" or "1:3".  
+            See https://reference.opcfoundation.org/v104/Core/docs/Part4/7.22/)
         """
         attr = ua.WriteValue()
         attr.NodeId = self.nodeid


### PR DESCRIPTION
This allows for a workaround  for writing (relates to #711) to allow clients to write partial arrays.

I think this seems like a reasonable incremental addition but I am not sure if there is something I am missing here... in any case it does with with the OPC servers I have tested with.