### PR TITLE
Fix exception raised by `lxml.objectify.fromstring`

### DIFF
--- a/asyncua/common/structures.py
+++ b/asyncua/common/structures.py
@@ -233,7 +233,6 @@ async def load_type_definitions(server, nodes=None):
     generators = []
     for node in nodes:
         xml = await node.read_value()
-        xml = xml.decode("utf-8")
         generator = StructGenerator()
         generators.append(generator)
         generator.make_model_from_string(xml)


### PR DESCRIPTION
This fixes the first problem described in https://github.com/FreeOpcUa/opcua-asyncio/issues/160#issuecomment-622985985

As stated on https://lxml.de/FAQ.html:
> First of all, XML is explicitly defined as a stream of bytes. It's not Unicode text. Take a look at the XML specification, it's all about byte sequences and how to map them to text and structure. That leads to rule number one: do not decode your XML data yourself. That's a part of the work of an XML parser, and it does it very well. Just pass it your data as a plain byte stream, it will always do the right thing, by specification.