### PR TITLE
Fix bad Python identifiers ending in generated code

### DIFF
--- a/asyncua/common/structures.py
+++ b/asyncua/common/structures.py
@@ -76,7 +76,7 @@ class EnumeratedValue(object):
 
 class Struct(object):
     def __init__(self, name):
-        self.name = name
+        self.name = _clean_name(name)
         self.fields = []
         self.typeid = None
 


### PR DESCRIPTION
This fixes the second problem described in https://github.com/FreeOpcUa/opcua-asyncio/issues/160#issuecomment-622985985