### PR TITLE
Add async and await statement for HistoryManager.stop

### DIFF
--- a/asyncua/server/history.py
+++ b/asyncua/server/history.py
@@ -375,8 +375,8 @@ class HistoryManager:
             results.append(results)
         return results
 
-    def stop(self) -> Coroutine:
+    async def stop(self) -> Coroutine:
         """
         call stop methods of active storage interface whenever the server is stopped
         """
-        return self.storage.stop()
+        return await self.storage.stop()


### PR DESCRIPTION
Because a Coroutine was expected, I added an async and await statement, even if this feature seems not to be supported at the moment.