### PR TITLE
Add async and await for _add_node method in XMLImporter class

### DIFF
--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -88,11 +88,11 @@ class XmlImporter:
             raise ValueError(f"Not implemented node type: {nodedata.nodetype} ")
         return node
 
-    def _add_node(self, node: "Node") -> Coroutine:
+    async def _add_node(self, node: "Node") -> Coroutine:
         if hasattr(self.server, "iserver"):
-            return self.server.iserver.isession.add_nodes([node])
+            return await self.server.iserver.isession.add_nodes([node])
         else:
-            return self.server.uaclient.add_nodes([node])
+            return await self.server.uaclient.add_nodes([node])
 
     async def _add_references(self, refs):
         if hasattr(self.server, "iserver"):


### PR DESCRIPTION
I am not sure why: https://github.com/FreeOpcUa/opcua-asyncio/blob/79072d761e3e1e4fcb00ec324bb6c3f4d13f7dbd/asyncua/server/internal_session.py#L111
is async, because it just contains a sync method.

Should have been there something more async?

Anyway, the commited method now it is clearly async.