### PR TITLE
Async multiple methods

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -547,15 +547,15 @@ class Client:
         _logger.info("get_namespace_index %s %r", type(uries), uries)
         return uries.index(uri)
 
-    def delete_nodes(self, nodes, recursive=False) -> Coroutine:
-        return delete_nodes(self.uaclient, nodes, recursive)
+    async def delete_nodes(self, nodes, recursive=False) -> Coroutine:
+        return await delete_nodes(self.uaclient, nodes, recursive)
 
-    def import_xml(self, path=None, xmlstring=None) -> Coroutine:
+    async def import_xml(self, path=None, xmlstring=None) -> Coroutine:
         """
         Import nodes defined in xml
         """
         importer = XmlImporter(self)
-        return importer.import_xml(path, xmlstring)
+        return await importer.import_xml(path, xmlstring)
 
     async def export_xml(self, nodes, path):
         """
@@ -578,20 +578,20 @@ class Client:
         await ns_node.write_value(uries)
         return len(uries) - 1
 
-    def load_type_definitions(self, nodes=None) -> Coroutine:
+    async def load_type_definitions(self, nodes=None) -> Coroutine:
         """
         Load custom types (custom structures/extension objects) definition from server
         Generate Python classes for custom structures/extension objects defined in server
         These classes will available in ua module
         """
-        return load_type_definitions(self, nodes)
+        return await load_type_definitions(self, nodes)
 
-    def load_enums(self) -> Coroutine:
+    async def load_enums(self) -> Coroutine:
         """
         generate Python enums for custom enums on server.
         This enums will be available in ua module
         """
-        return load_enums(self)
+        return await load_enums(self)
 
     async def register_nodes(self, nodes):
         """

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -88,11 +88,11 @@ class XmlImporter:
             raise ValueError(f"Not implemented node type: {nodedata.nodetype} ")
         return node
 
-    def _add_node(self, node: "Node") -> Coroutine:
+    async def _add_node(self, node: "Node") -> Coroutine:
         if hasattr(self.server, "iserver"):
-            return self.server.iserver.isession.add_nodes([node])
+            return await self.server.iserver.isession.add_nodes([node])
         else:
-            return self.server.uaclient.add_nodes([node])
+            return await self.server.uaclient.add_nodes([node])
 
     async def _add_references(self, refs):
         if hasattr(self.server, "iserver"):

--- a/asyncua/server/history.py
+++ b/asyncua/server/history.py
@@ -375,8 +375,8 @@ class HistoryManager:
             results.append(results)
         return results
 
-    def stop(self) -> Coroutine:
+    async def stop(self) -> Coroutine:
         """
         call stop methods of active storage interface whenever the server is stopped
         """
-        return self.storage.stop()
+        return await self.storage.stop()

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -96,8 +96,8 @@ class InternalSession:
         results = self.iserver.attribute_service.read(params)
         return results
 
-    def history_read(self, params) -> Coroutine:
-        return self.iserver.history_manager.read_history(params)
+    async def history_read(self, params) -> Coroutine:
+        return await self.iserver.history_manager.read_history(params)
 
     async def write(self, params):
         return await self.iserver.attribute_service.write(params, self.user)
@@ -123,9 +123,9 @@ class InternalSession:
     def add_method_callback(self, methodid, callback):
         return self.aspace.add_method_callback(methodid, callback)
 
-    def call(self, params):
+    async def call(self, params):
         """COROUTINE"""
-        return self.iserver.method_service.call(params)
+        return await self.iserver.method_service.call(params)
 
     async def create_subscription(self, params, callback=None):
         result = await self.subscription_service.create_subscription(params, callback, external=self.external)

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -242,8 +242,8 @@ class Server:
     def set_endpoint(self, url):
         self.endpoint = urlparse(url)
 
-    def get_endpoints(self) -> Coroutine:
-        return self.iserver.get_endpoints()
+    async def get_endpoints(self) -> Coroutine:
+        return await self.iserver.get_endpoints()
 
     def set_security_policy(self, security_policy, certificate_handler=None):
         """
@@ -520,12 +520,12 @@ class Server:
             await custom_t.add_method(idx, method[0], method[1], method[2], method[3])
         return custom_t
 
-    def import_xml(self, path=None, xmlstring=None) -> Coroutine:
+    async def import_xml(self, path=None, xmlstring=None) -> Coroutine:
         """
         Import nodes defined in xml
         """
         importer = XmlImporter(self)
-        return importer.import_xml(path, xmlstring)
+        return await importer.import_xml(path, xmlstring)
 
     async def export_xml(self, nodes, path):
         """
@@ -547,8 +547,8 @@ class Server:
         nodes = await get_nodes_of_namespace(self, namespaces)
         await self.export_xml(nodes, path)
 
-    def delete_nodes(self, nodes, recursive=False) -> Coroutine:
-        return delete_nodes(self.iserver.isession, nodes, recursive)
+    async def delete_nodes(self, nodes, recursive=False) -> Coroutine:
+        return await delete_nodes(self.iserver.isession, nodes, recursive)
 
     async def historize_node_data_change(self, node, period=timedelta(days=7), count=0):
         """
@@ -605,19 +605,19 @@ class Server:
         """
         self.iserver.isession.add_method_callback(node.nodeid, callback)
 
-    def load_type_definitions(self, nodes=None) -> Coroutine:
+    async def load_type_definitions(self, nodes=None) -> Coroutine:
         """
         load custom structures from our server.
         Server side this can be used to create python objects from custom structures
         imported through xml into server
         """
-        return load_type_definitions(self, nodes)
+        return await load_type_definitions(self, nodes)
 
-    def load_enums(self) -> Coroutine:
+    async def load_enums(self) -> Coroutine:
         """
         load UA structures and generate python Enums in ua module for custom enums in server
         """
-        return load_enums(self)
+        return await load_enums(self)
 
     async def write_attribute_value(self, nodeid, datavalue, attr=ua.AttributeIds.Value):
         """


### PR DESCRIPTION
Async call method in internal_session
Async history_read method in internal_session
Async get_endpoints method in server
Async delete_nodes method in server and client
Async load_enums in server and client
Async load_type_definitions method in server and Client
Async import_xml in server and Client

Async stop method in HistoryManager class
- Because a Coroutine was expected in this class, I added an async and await statement, even if this feature seems not to be supported at the moment.

I am not sure why:
https://github.com/FreeOpcUa/opcua-asyncio/blob/79072d761e3e1e4fcb00ec324bb6c3f4d13f7dbd/asyncua/server/internal_session.py#L111

is async, because it just contains a sync method.
Should have been there something more async?

Anyway, the commited methods are now clearly async as expected.