### PR TITLE
added exception handling to open_secure_channel and _renew_channel_loop

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -385,8 +385,12 @@ class Client:
                 _logger.debug("server state is: %s ", val)
         except asyncio.CancelledError:
             pass
-        except:
+        except Exception as err:
             _logger.exception("Error while renewing session")
+            self.loop.call_exception_handler({
+                'message':'Error while renewing session',
+                'exception': err
+            })
             raise
 
     def server_policy_id(self, token_type, default):


### PR DESCRIPTION
Maybe I have a solution for issue #208

A minimal example to handle errors could be something like this:
```
import asyncio

from asyncua import Client


class OpcSubscriptionHandler(object):

    def datachange_notification(self, node_value, node):
        print(f'{node.subscription_data.node.nodeid}: {node_value} ')

    def event_notification(self, event):
        print("Python: New event", event)


def execption_handler(loop, context):
    print('Do something when error occur!')
    print(context)
    loop.stop()


async def main():
    client = Client(url='opc.tcp://10.60.123.123:4841', timeout=1, loop=loop)
    client.session_timeout = 3000
    await client.connect()
    subscription = await client.create_subscription(500, OpcSubscriptionHandler)
    node = client.get_node("ns=6;s=::ResReader:Cooling_Water.WaterTemp_Out")
    await subscription.subscribe_data_change(node)



if __name__ == '__main__':
    loop = asyncio.get_event_loop()
    loop.set_exception_handler(execption_handler)
    loop.create_task(main())
    loop.run_forever()

```
A use case for this is to handle failure if a Ethernet cable get unplugged. 