### PR TITLE
add ability to find endpoints for unauthenticated user

### DIFF
--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -146,7 +146,8 @@ class UaProcessor:
 
     async def _process_message(self, typeid, requesthdr, seqhdr, body):
         if typeid in [ua.NodeId(ua.ObjectIds.CreateSessionRequest_Encoding_DefaultBinary),
-                      ua.NodeId(ua.ObjectIds.ActivateSessionRequest_Encoding_DefaultBinary)]:
+                      ua.NodeId(ua.ObjectIds.ActivateSessionRequest_Encoding_DefaultBinary),
+                      ua.NodeId(ua.ObjectIds.GetEndpointsRequest_Encoding_DefaultBinary)]:
             # The connection is first created without a user being attached, and then during activation the
             user = None
         elif self.session is None:

--- a/examples/server-minimal.py
+++ b/examples/server-minimal.py
@@ -35,12 +35,11 @@ async def main():
     await server.nodes.objects.add_method(ua.NodeId('ServerMethod', 2), ua.QualifiedName('ServerMethod', 2), func, [ua.VariantType.Int64], [ua.VariantType.Int64])
     _logger.info('Starting server!')
     async with server:
-        count = 0
         while True:
             await asyncio.sleep(1)
-            count += 0.1
-            _logger.info('Set value of %s to %.1f', myvar, count)
-            await myvar.write_value(count)
+            new_val = await myvar.get_value() + 0.1
+            _logger.info('Set value of %s to %.1f', myvar, new_val)
+            await myvar.write_value(new_val)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I made the mistake earlier thinking that GetEndpoints should be only available to authenticated users. However clients such as UAExpert do a GetEndpoints before authenticating. I think therefore GetEndpoint is necessary to be allowed to unauthenticated users.