### PR TITLE
Update instantiate_util.py

### DIFF
--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -95,7 +95,7 @@ async def _instantiate_node(server,
                     if not refs:
                         # spec says to ignore nodes without modelling rules
                         logger.info("Instantiate: Skip node without modelling rule %s as part of %s",
-                        c_rdesc.BrowseName, addnode.BrowseName)
+                                    c_rdesc.BrowseName, addnode.BrowseName)
                         continue
                         # exclude nodes with optional ModellingRule if requested
                     if refs[0].nodeid in (ua.NodeId(ua.ObjectIds.ModellingRule_Optional), ua.NodeId(ua.ObjectIds.ModellingRule_OptionalPlaceholder)):

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -123,7 +123,8 @@ async def _instantiate_node(server,
                             res.AddedNodeId,
                             c_rdesc,
                             nodeid=ua.NodeId(namespaceidx=res.AddedNodeId.NamespaceIndex),
-                            bname=c_rdesc.BrowseName,instantiate_optional=instantiate_optional
+                            bname=c_rdesc.BrowseName,
+                            instantiate_optional=instantiate_optional
                         )
                     added_nodes.extend(nodeids)
     return added_nodes

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -12,7 +12,7 @@ from .node_factory import make_node
 logger = logging.getLogger(__name__)
 
 
-async def instantiate(parent, node_type, nodeid=None, bname=None, dname=None, idx=0, instantiate_optional=False):
+async def instantiate(parent, node_type, nodeid=None, bname=None, dname=None, idx=0, instantiate_optional=True):
     """
     instantiate a node type under a parent node.
     nodeid and browse name of new node can be specified, or just namespace index

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -98,7 +98,7 @@ async def _instantiate_node(server,
                             c_rdesc.BrowseName, addnode.BrowseName)
                         continue
                         # exclude nodes with optional ModellingRule if requested
-                    if refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
+                    if refs[0].nodeid in (ua.NodeId(ua.ObjectIds.ModellingRule_Optional), ua.NodeId(ua.ObjectIds.ModellingRule_OptionalPlaceholder)):
                         # instatiate optionals
                         if not instantiate_optional:
                             logger.info("Instantiate: Skip optional node %s as part of %s", c_rdesc.BrowseName,

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -98,7 +98,8 @@ async def _instantiate_node(server,
                             c_rdesc.BrowseName, addnode.BrowseName)
                         continue
                         # exclude nodes with optional ModellingRule if requested
-                    if refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):#not instantiate_optional or refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
+                    if refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
+                        # instatiate optionals
                         if not instantiate_optional:
                             logger.info("Instantiate: Skip optional node %s as part of %s", c_rdesc.BrowseName,
                                 addnode.BrowseName)

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -49,7 +49,7 @@ async def _instantiate_node(server,
                             bname,
                             dname=None,
                             recursive=True,
-                            instantiate_optional=False):
+                            instantiate_optional=True):
     """
     instantiate a node type under parent
     """

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -95,7 +95,7 @@ async def _instantiate_node(server,
                     if not refs:
                         # spec says to ignore nodes without modelling rules
                         logger.info("Instantiate: Skip node without modelling rule %s as part of %s",
-                            c_rdesc.BrowseName, addnode.BrowseName)
+                        c_rdesc.BrowseName, addnode.BrowseName)
                         continue
                         # exclude nodes with optional ModellingRule if requested
                     if refs[0].nodeid in (ua.NodeId(ua.ObjectIds.ModellingRule_Optional), ua.NodeId(ua.ObjectIds.ModellingRule_OptionalPlaceholder)):

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -98,7 +98,7 @@ async def _instantiate_node(server,
                                     c_rdesc.BrowseName, addnode.BrowseName)
                         continue
                         # exclude nodes with optional ModellingRule if requested
-                    if not instantiate_optional and refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
+                    if not instantiate_optional or refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
                         logger.info("Instantiate: Skip optional node %s as part of %s", c_rdesc.BrowseName,
                                     addnode.BrowseName)
                         continue

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -99,9 +99,7 @@ async def _instantiate_node(server,
                         continue
                         # exclude nodes with optional ModellingRule if requested
                     if refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):#not instantiate_optional or refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
-                        if instantiate_optional:
-                            pass
-                        else:
+                        if not instantiate_optional:
                             logger.info("Instantiate: Skip optional node %s as part of %s", c_rdesc.BrowseName,
                                 addnode.BrowseName)
                             continue

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -113,7 +113,8 @@ async def _instantiate_node(server,
                             res.AddedNodeId,
                             c_rdesc,
                             nodeid=ua.NodeId(identifier=inst_nodeid, namespaceidx=res.AddedNodeId.NamespaceIndex),
-                            bname=c_rdesc.BrowseName
+                            bname=c_rdesc.BrowseName,
+                            instantiate_optional=instantiate_optional
                         )
                     else:
                         nodeids = await _instantiate_node(
@@ -122,7 +123,7 @@ async def _instantiate_node(server,
                             res.AddedNodeId,
                             c_rdesc,
                             nodeid=ua.NodeId(namespaceidx=res.AddedNodeId.NamespaceIndex),
-                            bname=c_rdesc.BrowseName
+                            bname=c_rdesc.BrowseName,instantiate_optional=instantiate_optional
                         )
                     added_nodes.extend(nodeids)
     return added_nodes

--- a/asyncua/common/instantiate_util.py
+++ b/asyncua/common/instantiate_util.py
@@ -12,7 +12,7 @@ from .node_factory import make_node
 logger = logging.getLogger(__name__)
 
 
-async def instantiate(parent, node_type, nodeid=None, bname=None, dname=None, idx=0, instantiate_optional=True):
+async def instantiate(parent, node_type, nodeid=None, bname=None, dname=None, idx=0, instantiate_optional=False):
     """
     instantiate a node type under a parent node.
     nodeid and browse name of new node can be specified, or just namespace index
@@ -49,7 +49,7 @@ async def _instantiate_node(server,
                             bname,
                             dname=None,
                             recursive=True,
-                            instantiate_optional=True):
+                            instantiate_optional=False):
     """
     instantiate a node type under parent
     """
@@ -95,13 +95,16 @@ async def _instantiate_node(server,
                     if not refs:
                         # spec says to ignore nodes without modelling rules
                         logger.info("Instantiate: Skip node without modelling rule %s as part of %s",
-                                    c_rdesc.BrowseName, addnode.BrowseName)
+                            c_rdesc.BrowseName, addnode.BrowseName)
                         continue
                         # exclude nodes with optional ModellingRule if requested
-                    if not instantiate_optional or refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
-                        logger.info("Instantiate: Skip optional node %s as part of %s", c_rdesc.BrowseName,
-                                    addnode.BrowseName)
-                        continue
+                    if refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):#not instantiate_optional or refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
+                        if instantiate_optional:
+                            pass
+                        else:
+                            logger.info("Instantiate: Skip optional node %s as part of %s", c_rdesc.BrowseName,
+                                addnode.BrowseName)
+                            continue
                     # if root node being instantiated has a String NodeId, create the children with a String NodeId
                     if res.AddedNodeId.NodeIdType is ua.NodeIdType.String:
                         inst_nodeid = res.AddedNodeId.Identifier + "." + c_rdesc.BrowseName.Name


### PR DESCRIPTION
Result of PR #239

```python
import os, asyncio
from asyncua import Server, ua, uamethod
from asyncua.common.instantiate_util import instantiate

NAMESPACE = "http://test.de/UA"

async def main():
    # Serversetup
    server = Server()
    await server.init()
    server.set_endpoint("opc.tcp://127.0.0.1:4840")
    idx = await server.register_namespace(NAMESPACE)

    objects = server.get_objects_node()

    base_object_type = server.get_node(ua.ObjectIds.BaseObjectType)

    my_object_type = await base_object_type.add_object_type(idx, "myObjectType")
    mandatory = await my_object_type.add_variable(idx, "Mandatory", 0.0, ua.VariantType.Float)
    await mandatory.set_modelling_rule(True)
    optional = await my_object_type.add_variable(idx, "Optional", 0.0, ua.VariantType.Float)
    await optional.set_modelling_rule(False)

    await objects.add_object(idx, "TestObj", my_object_type)

    async with server:
        while 1:
            await asyncio.sleep(1)

# Start Server
if __name__ == "__main__":
    asyncio.run(main())
```

![Unbenannt](https://user-images.githubusercontent.com/56362817/87910991-2f2cd480-ca6b-11ea-819d-beda26bdc4e3.PNG)

found a bug in instantiate_util.py
OLD:
```python
                    if not instantiate_optional and refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
                        logger.info("Instantiate: Skip optional node %s as part of %s", c_rdesc.BrowseName,
                            addnode.BrowseName)
                        continue
```
NEW (replaces the and with an or):
```python
                    if not instantiate_optional or refs[0].nodeid == ua.NodeId(ua.ObjectIds.ModellingRule_Optional):
                        logger.info("Instantiate: Skip optional node %s as part of %s", c_rdesc.BrowseName,
                            addnode.BrowseName)
                        continue
```

![Unbenannt](https://user-images.githubusercontent.com/56362817/87913953-360a1600-ca70-11ea-9688-bfde29ec96c3.PNG)
