### PR TITLE
[ Certificate ] More flexibility with certificate extensions

### DIFF
--- a/asyncua/crypto/uacrypto.py
+++ b/asyncua/crypto/uacrypto.py
@@ -10,12 +10,18 @@ from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers import algorithms
 from cryptography.hazmat.primitives.ciphers import modes
+from dataclasses import dataclass
 
+@dataclass
+class CertProperties:
+    path: str = None
+    extension: str = None
+    password: str = None
 
-async def load_certificate(path, format=None):
+async def load_certificate(path, extension=None):
     _, ext = os.path.splitext(path)
     async with aiofiles.open(path, mode='rb') as f:
-        if ext == ".pem" or format == 'pem' or format == 'PEM':
+        if ext == ".pem" or extension == 'pem' or extension == 'PEM':
             return x509.load_pem_x509_certificate(await f.read(), default_backend())
         else:
             return x509.load_der_x509_certificate(await f.read(), default_backend())
@@ -27,12 +33,12 @@ def x509_from_der(data):
     return x509.load_der_x509_certificate(data, default_backend())
 
 
-async def load_private_key(path, password=None, format=None):
+async def load_private_key(path, password=None, extension=None):
     _, ext = os.path.splitext(path)
     if isinstance(password, str):
         password.encode('utf-8')
     async with aiofiles.open(path, mode='rb') as f:
-        if ext == ".pem" or format == 'pem' or format == 'PEM':
+        if ext == ".pem" or extension == 'pem' or extension == 'PEM':
             return serialization.load_pem_private_key(await f.read(), password=password, backend=default_backend())
         else:
             return serialization.load_der_private_key(await f.read(), password=password, backend=default_backend())

--- a/examples/client-with-encryption.py
+++ b/examples/client-with-encryption.py
@@ -18,9 +18,9 @@ async def task(loop):
     client = Client(url=url)
     await client.set_security(
         SecurityPolicyBasic256Sha256,
-        certificate_path=cert,
-        private_key_path=private_key,
-        server_certificate_path="certificate-example.der"
+        certificate=cert,
+        private_key=private_key,
+        server_certificate="certificate-example.der"
     )
     async with client:
         objects = client.nodes.objects

--- a/tests/test_crypto_connect.py
+++ b/tests/test_crypto_connect.py
@@ -212,6 +212,27 @@ async def test_encrypted_private_key_handling_success(srv_crypto_encrypted_key_o
         assert await clt.get_objects_node().get_children()
 
 
+async def test_encrypted_private_key_handling_success_with_cert_props(srv_crypto_encrypted_key_one_cert):
+    _, cert = srv_crypto_encrypted_key_one_cert
+    clt = Client(uri_crypto_cert)
+    user_cert = uacrypto.CertProperties(encrypted_private_key_peer_creds['certificate'], "DER")
+    user_key = uacrypto.CertProperties(
+        path=encrypted_private_key_peer_creds['private_key'],
+        password=encrypted_private_key_peer_creds['password'],
+        extension="PEM",
+    )
+    server_cert = uacrypto.CertProperties(cert)
+    await clt.set_security(
+        security_policies.SecurityPolicyBasic256Sha256,
+        user_cert,
+        user_key,
+        server_certificate=server_cert,
+        mode=ua.MessageSecurityMode.SignAndEncrypt
+    )
+    async with clt:
+        assert await clt.get_objects_node().get_children()
+
+
 async def test_certificate_handling_failure(srv_crypto_one_cert):
     _, cert = srv_crypto_one_cert
     clt = Client(uri_crypto_cert)

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -83,7 +83,7 @@ async def test_permissions_admin(srv_crypto_one_cert):
         admin_peer_creds['certificate'],
         admin_peer_creds['private_key'],
         None,
-        server_certificate_path=srv_crypto_params[0][1],
+        server_certificate=srv_crypto_params[0][1],
         mode=ua.MessageSecurityMode.SignAndEncrypt
     )
 
@@ -102,7 +102,7 @@ async def test_permissions_user(srv_crypto_one_cert):
         user_peer_creds['certificate'],
         user_peer_creds['private_key'],
         None,
-        server_certificate_path=srv_crypto_params[0][1],
+        server_certificate=srv_crypto_params[0][1],
         mode=ua.MessageSecurityMode.SignAndEncrypt
     )
     async with clt:
@@ -121,7 +121,7 @@ async def test_permissions_anonymous(srv_crypto_one_cert):
         anonymous_peer_creds['certificate'],
         anonymous_peer_creds['private_key'],
         None,
-        server_certificate_path=srv_crypto_params[0][1],
+        server_certificate=srv_crypto_params[0][1],
         mode=ua.MessageSecurityMode.SignAndEncrypt
     )
     await clt.connect()


### PR DESCRIPTION
This commit contains the following changes:

* Allow a client to specify the extension of its certificate, while keeping retro compatibility with the ```set_security_string``` API, ex:

```
# Before
In [3]: import sys; sys.path.insert(0, "/home/zuzud/github/opcua-asyncio")
   ...: import asyncua
   ...: from asyncua.crypto.uacrypto import CertProperties
   ...: from asyncua.crypto import security_policies
   ...: from asyncua.ua import MessageSecurityMode
   ...: URL="opc.tcp://127.0.0.1:4901/OPCUA"
   ...: client = asyncua.Client(url=URL)
   ...: user_cert = "/tmp/client-cert/testA.cert"
   ...: user_key = "/tmp/client-cert/testA.key"
   ...: security_policy = getattr(security_policies, "SecurityPolicyBasic256Sha256")
   ...: security_mode = getattr(MessageSecurityMode, "SignAndEncrypt")
   ...: await client.set_security(security_policy, user_cert, user_key, mode=security_mode)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
[..]
ValueError: Unable to load certificate
```

```
# After
In [1]: import sys; sys.path.insert(0, "/home/zuzud/github/opcua-asyncio")
   ...: import asyncua
   ...: from asyncua.crypto.uacrypto import CertProperties
   ...: from asyncua.crypto import security_policies
   ...: from asyncua.ua import MessageSecurityMode
   ...: URL="opc.tcp://127.0.0.1:4901/OPCUA"
   ...: client = asyncua.Client(url=URL)
   ...: user_cert = CertProperties("/tmp/client-cert/testA.cert", "PEM")
   ...: user_key = CertProperties("/tmp/client-cert/testA.key", "PEM")
   ...: security_policy = getattr(security_policies, "SecurityPolicyBasic256Sha256")
   ...: security_mode = getattr(MessageSecurityMode, "SignAndEncrypt")
   ...: await client.set_security(security_policy, user_cert, user_key, mode=security_mode)

```
* Change the uacrypto ```format``` variable name (built-in function in python)
* Possibility to specify a certificate extension for user authentication as well. 
* More test