### PR TITLE
[ Fix ] test_tool quick fix

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -19,7 +19,7 @@ def test_that_tool_can_be_invoked_without_internal_error(tool):
 
 
 def test_that_server_can_be_invoked_without_internal_error():
-    proc = subprocess.Popen(['uaserver'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(['tools/uaserver'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     time.sleep(2)
     proc.send_signal(subprocess.signal.SIGINT)
     proc.wait(timeout=2)


### PR DESCRIPTION
Fix the test ```test_that_server_can_be_invoked_without_internal_error``` failing on TravisCI since tests are executed from the repository root directory, see #212. 

## Before
```
> pytest tests/test_tools.py
================================================ test session starts =================================================
platform linux -- Python 3.7.5+, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/prigentj/github/opcua-asyncio, inifile: pytest.ini
plugins: asyncio-0.10.0, cov-2.8.1, mock-2.0.0
collected 10 items

tests/test_tools.py .........F                                                                                 [100%]

====================================================== FAILURES ======================================================
_______________________________ test_that_server_can_be_invoked_without_internal_error _______________________________

    def test_that_server_can_be_invoked_without_internal_error():
>       proc = subprocess.Popen(['uaserver'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)

tests/test_tools.py:22:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/local/fbcode/platform007/lib/python3.7/subprocess.py:800: in __init__
    restore_signals, start_new_session)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <subprocess.Popen object at 0x7f018f8f5c90>, args = ['uaserver'], executable = b'uaserver', preexec_fn = None
close_fds = True, pass_fds = (), cwd = None, env = None, startupinfo = None, creationflags = 0, shell = False
p2cread = -1, p2cwrite = -1, c2pread = 12, c2pwrite = 13, errread = 14, errwrite = 15, restore_signals = True
start_new_session = False

[...]
>               raise child_exception_type(errno_num, err_msg, err_filename)
E               FileNotFoundError: [Errno 2] No such file or directory: 'uaserver': 'uaserver'

/usr/local/fbcode/platform007/lib/python3.7/subprocess.py:1551: FileNotFoundError
============================================ 1 failed, 9 passed in 0.43s =============================================
```

## After
```
> pytest tets/test_tools.py
================================================ test session starts =================================================
platform linux -- Python 3.7.5+, pytest-5.3.2, py-1.8.1, pluggy-0.13.1
rootdir: /home/prigentj/github/opcua-asyncio, inifile: pytest.ini
plugins: asyncio-0.10.0, cov-2.8.1, mock-2.0.0
collected 10 items

tests/test_tools.py ..........                                                                                 [100%]

================================================= 10 passed in 2.58s =================================================
```