### PR TITLE
[ Cli tools ] Fix uaserver and tests

### DIFF
--- a/asyncua/tools.py
+++ b/asyncua/tools.py
@@ -29,7 +29,7 @@ if sys.version_info.minor >= 7:
         return asyncio.run(coro)
 else:
     def run(coro):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
         return loop.run_until_complete(coro)
 
 

--- a/asyncua/tools.py
+++ b/asyncua/tools.py
@@ -146,8 +146,12 @@ async def _uaread():
             print(attr.Value)
         else:
             print(attr)
+    except Exception as e:
+        print(e)
+        sys.exit(1)
     finally:
         await client.disconnect()
+    sys.exit(0)
 
 
 def _args_to_array(val, array):
@@ -284,9 +288,12 @@ async def _uawrite():
         node = await get_node(client, args)
         val = _val_to_variant(args.value, args)
         await node.write_attribute(args.attribute, ua.DataValue(val))
+    except Exception as e:
+        print(e)
+        sys.exit(1)
     finally:
         await client.disconnect()
-
+    sys.exit(0)
 
 def uals():
     run(_uals())
@@ -326,6 +333,7 @@ async def _uals():
     except (OSError, concurrent.futures._base.TimeoutError) as e:
         print(e)
         sys.exit(1)
+    sys.exit(0)
 
 
 async def _lsprint_0(node, depth, indent=""):
@@ -577,18 +585,19 @@ async def _uaserver():
     try:
         await server.init()
         async with server:
+
             if args.shell:
                 embed()
             elif args.populate:
                 count = 0
                 while True:
-                    time.sleep(1)
+                    await asyncio.sleep(1)
                     myvar.write_value(math.sin(count / 10))
                     myarrayvar.write_value([math.sin(count / 10), math.sin(count / 100)])
                     count += 1
             else:
                 while True:
-                    time.sleep(1)
+                    await asyncio.sleep(1)
     except OSError as e:
         print(e)
         sys.exit(1)
@@ -709,6 +718,9 @@ async def _uahistoryread():
                 print(ev)
         else:
             print_history(await node.read_raw_history(starttime, endtime, numvalues=args.limit))
+    except Exception as e:
+        print(e)
+        sys.exit(1)
     finally:
         await client.disconnect()
     sys.exit(0)
@@ -770,8 +782,12 @@ async def _uacall():
                 method_id = methods[0]
         result = await node.call_method(method_id, *val)
         print(f"resulting result_variants={result}")
+    except Exception as e:
+        print(e)
+        sys.exit(1)
     finally:
         await client.disconnect()
+    sys.exit(0)
 
 
 def uageneratestructs():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def event_loop(request):
     loop.close()
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 async def running_server(request):
     """
     Spawn a server in a separate thread
@@ -51,6 +51,7 @@ async def running_server(request):
             async with srv:
                 while t.do_run:
                     await asyncio.sleep(1)
+            await srv.stop()
         loop = asyncio.new_event_loop()
         loop.run_until_complete(server(url))
 
@@ -63,6 +64,7 @@ async def running_server(request):
 
     def fin():
         t.do_run = False
+        t.join()
     request.addfinalizer(fin)
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,26 +1,53 @@
 import pytest
-from threading import Thread
-import time
 from unittest.mock import patch
 import sys
 import subprocess
+import concurrent.futures
 
-from asyncua.tools import uaread, uals, uawrite, uasubscribe, uahistoryread, uaserver, uaclient, uadiscover, uacall, uageneratestructs
+from asyncua.tools import uaread, uals, uawrite, uahistoryread, uaclient, uadiscover, uacall
 
-
-@pytest.mark.parametrize("tool", [uaread, uals, uawrite, uasubscribe, uahistoryread, uaclient, uadiscover, uacall, uageneratestructs])
-def test_that_tool_can_be_invoked_without_internal_error(tool):
-    # It's necessary to mock argv, else the tool is invoked with *pytest's* argv
-    with patch.object(sys, 'argv', [""]):
-        try:
-            tool()
-        except SystemExit:
-            pass
+pytestmark = pytest.mark.asyncio
 
 
-def test_that_server_can_be_invoked_without_internal_error():
-    proc = subprocess.Popen(['uaserver'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    time.sleep(2)
-    proc.send_signal(subprocess.signal.SIGINT)
-    proc.wait(timeout=2)
-    assert proc.returncode == 0
+async def test_cli_tools(running_server):
+    # admin privileges are only needed for uawrite
+    url = running_server.replace("//", "//admin@")
+    default_opts = ["mock_func", "-u", f"{url}"]
+    rw_node = ["-n", "i=3078"]
+    call_node = ["-n", "i=85"]
+    write_val = ["val_to_write"]
+    rw_opts = default_opts + rw_node
+    write_opts = rw_opts + write_val
+    call_opts = default_opts + call_node + write_val
+
+    tool_opts = {}
+    tool_opts[uaread] = rw_opts
+    tool_opts[uals] = rw_opts
+    tool_opts[uawrite] = write_opts
+    tool_opts[uahistoryread] = rw_opts
+    tool_opts[uaclient] = default_opts
+    tool_opts[uadiscover] = default_opts
+    tool_opts[uacall] = call_opts
+
+    for tool in (uaread, uals, uawrite, uahistoryread, uaclient, uadiscover, uacall):
+        # It's necessary to mock argv, else the tool is invoked with *pytest's* argv
+        with patch.object(sys, 'argv', tool_opts[tool]):
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                result = executor.submit(tool)
+                for future in concurrent.futures.as_completed([result]):
+                    exception = future.exception()
+                    assert (repr(exception) == "SystemExit(0)")
+
+
+async def test_cli_tools_which_require_sigint(running_server):
+    url = running_server
+    tools = (
+        ["tools/uaserver"], 
+        ["tools/uasubscribe", "-u", url, "-n", "i=3078"]
+    )
+    for tool in tools:
+        proc = subprocess.Popen(tool, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        with pytest.raises(subprocess.TimeoutExpired):
+            # we consider there's no error if the process is still alive
+            proc.communicate(timeout=2)
+        proc.send_signal(subprocess.signal.SIGINT)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,13 +8,15 @@ from asyncua.tools import uaread, uals, uawrite, uahistoryread, uaclient, uadisc
 
 pytestmark = pytest.mark.asyncio
 
+ROOT_NODE = "i=85"
+RW_NODE = "i=3078"
 
 async def test_cli_tools(running_server):
     # admin privileges are only needed for uawrite
     url = running_server.replace("//", "//admin@")
     default_opts = ["mock_func", "-u", f"{url}"]
-    rw_node = ["-n", "i=3078"]
-    call_node = ["-n", "i=85"]
+    rw_node = ["-n", RW_NODE]
+    call_node = ["-n", ROOT_NODE]
     write_val = ["val_to_write"]
     rw_opts = default_opts + rw_node
     write_opts = rw_opts + write_val
@@ -36,14 +38,16 @@ async def test_cli_tools(running_server):
                 result = executor.submit(tool)
                 for future in concurrent.futures.as_completed([result]):
                     exception = future.exception()
-                    assert (repr(exception) == "SystemExit(0)")
+                    # py3.6 returns SystemExit(0,)
+                    str_exp = repr(exception).replace(",", "")
+                    assert str_exp == "SystemExit(0)"
 
 
 async def test_cli_tools_which_require_sigint(running_server):
     url = running_server
     tools = (
-        ["tools/uaserver"], 
-        ["tools/uasubscribe", "-u", url, "-n", "i=3078"]
+        ["tools/uaserver"],
+        ["tools/uasubscribe", "-u", url, "-n", RW_NODE]
     )
     for tool in tools:
         proc = subprocess.Popen(tool, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
This commit adds the following:

* A server fixture which runs in a dedicated thread to handle OPC-UA requests properly (existing server fixture just accept TCP connections but can't handle hello since they are not running).

* We then use it to enhance the CLI tests and set more consistent exit codes across the cli (following the comment on #283).

* Fix the ```uaserver``` cli tool, its event_loop was stuck in non-async sleep preventing it from accepting requests.