### PR TITLE
Lazy load lxml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - pip install pytest-mock
   - pip install cryptography
   - pip install dataclasses
+  - pip install lazy_import
   - pip install --editable .
 # command to run tests
 script: pytest -v -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ install:
   - pip install pytest-mock
   - pip install cryptography
   - pip install dataclasses
-  - pip install lazy_import
   - pip install --editable .
 # command to run tests
 script: pytest -v -s

--- a/asyncua/common/structures.py
+++ b/asyncua/common/structures.py
@@ -15,19 +15,21 @@ from asyncua import ua
 from .structures104 import get_default_value, clean_name
 
 # Use lazy loading of lxml.objectify to speed up server startup and to 
-# slim down frozen code that doesn't require XML processing
+# slim down frozen code that doesn't require XML processing. See post on
+# StackExchange https://stackoverflow.com/questions/42703908/how-do-i-use-importlib-lazyloader
+import sys
 import importlib.util
 
 def lazy(fullname):
-  try:
-    return sys.modules[fullname]
-  except KeyError:
-    spec = importlib.util.find_spec(fullname)
-    module = importlib.util.module_from_spec(spec)
-    loader = importlib.util.LazyLoader(spec.loader)
-    # Make module with proper locking and get it inserted into sys.modules.
-    loader.exec_module(module)
-    return module
+    try:
+        return sys.modules[fullname]
+    except KeyError:
+        spec = importlib.util.find_spec(fullname)
+        module = importlib.util.module_from_spec(spec)
+        loader = importlib.util.LazyLoader.factory(spec.loader)
+        # Make module with proper locking and get it inserted into sys.modules.
+        loader.exec_module(module)
+        return module
 
 objectify = lazy("lxml.objectify")
 

--- a/asyncua/common/structures.py
+++ b/asyncua/common/structures.py
@@ -31,7 +31,7 @@ def lazy(fullname):
         loader.exec_module(module)
         return module
 
-lxml = lazy("lxml")
+tempmod = lazy("lxml")
 objectify = lxml.objectify
 
 _logger = logging.getLogger(__name__)

--- a/asyncua/common/structures.py
+++ b/asyncua/common/structures.py
@@ -31,7 +31,8 @@ def lazy(fullname):
         loader.exec_module(module)
         return module
 
-objectify = lazy("lxml.objectify")
+lxml = lazy("lxml")
+objectify = lxml.objectify
 
 _logger = logging.getLogger(__name__)
 

--- a/asyncua/common/structures.py
+++ b/asyncua/common/structures.py
@@ -16,8 +16,20 @@ from .structures104 import get_default_value, clean_name
 
 # Use lazy loading of lxml.objectify to speed up server startup and to 
 # slim down frozen code that doesn't require XML processing
-import lazy_import
-objectify = lazy_import.lazy_module("lxml.objectify")
+import importlib.util
+
+def lazy(fullname):
+  try:
+    return sys.modules[fullname]
+  except KeyError:
+    spec = importlib.util.find_spec(fullname)
+    module = importlib.util.module_from_spec(spec)
+    loader = importlib.util.LazyLoader(spec.loader)
+    # Make module with proper locking and get it inserted into sys.modules.
+    loader.exec_module(module)
+    return module
+
+objectify = lazy("lxml.objectify")
 
 _logger = logging.getLogger(__name__)
 

--- a/asyncua/common/structures.py
+++ b/asyncua/common/structures.py
@@ -9,11 +9,15 @@ import logging
 # The next two imports are for generated code
 from datetime import datetime
 from enum import Enum, IntEnum, EnumMeta
-from lxml import objectify
 
 from asyncua import ua
 
 from .structures104 import get_default_value, clean_name
+
+# Use lazy loading of lxml.objectify to speed up server startup and to 
+# slim down frozen code that doesn't require XML processing
+import lazy_import
+objectify = lazy_import.lazy_module("lxml.objectify")
 
 _logger = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     provides=["asyncua"],
     license="GNU Lesser General Public License v3 or later",
-    install_requires=["aiofiles", "aiosqlite", "python-dateutil", "pytz", "lxml", "cryptography", "lazy_import"],
+    install_requires=["aiofiles", "aiosqlite", "python-dateutil", "pytz", "lxml", "cryptography"],
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     provides=["asyncua"],
     license="GNU Lesser General Public License v3 or later",
-    install_requires=["aiofiles", "aiosqlite", "python-dateutil", "pytz", "lxml", 'cryptography'],
+    install_requires=["aiofiles", "aiosqlite", "python-dateutil", "pytz", "lxml", "cryptography", "lazy_import"],
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Lazy load lxml to reduce frozen app size (>2MB) and save time at startup and for applications that don't require lxml processing. Should also speed up unit testing. Caveat - I have not run unit tests on this.