### PR TITLE
fix delete nodes

### DIFF
--- a/asyncua/common/manage_nodes.py
+++ b/asyncua/common/manage_nodes.py
@@ -413,7 +413,7 @@ async def delete_nodes(server, nodes, recursive=False, delete_target_references=
     """
     nodestodelete = []
     if recursive:
-        nodes += await _add_childs(nodes)
+        nodes = await _add_childs(nodes)
     for mynode in nodes:
         it = ua.DeleteNodesItem()
         it.NodeId = mynode.nodeid


### PR DESCRIPTION
The origin node is already added at the end of _add_childs.
The sequence is important because otherwise we get a BadNodeIdUnknown.