### PR TITLE
[ Security ] Password encoding bug and typing adjustement

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -141,10 +141,10 @@ class Client:
                                        parts[4] if len(parts) >= 5 else None, mode)
 
     async def set_security(self,
-                           policy,
+                           policy: ua.SecurityPolicy,
                            certificate: Union[str, uacrypto.CertProperties],
                            private_key: Union[str, uacrypto.CertProperties],
-                           private_key_password: str = None,
+                           private_key_password: Optional[Union[str, bytes]] = None,
                            server_certificate: Optional[Union[str, uacrypto.CertProperties]] = None,
                            mode: ua.MessageSecurityMode = ua.MessageSecurityMode.SignAndEncrypt):
         """
@@ -165,7 +165,7 @@ class Client:
         return await self._set_security(policy, certificate, private_key, server_certificate, mode)
 
     async def _set_security(self,
-                            policy,
+                            policy: ua.SecurityPolicy,
                             certificate: uacrypto.CertProperties,
                             private_key: uacrypto.CertProperties,
                             server_cert: uacrypto.CertProperties,
@@ -178,13 +178,16 @@ class Client:
         self.security_policy = policy(server_cert, cert, pk, mode)
         self.uaclient.set_security(self.security_policy)
 
-    async def load_client_certificate(self, path: str, extension: str = None):
+    async def load_client_certificate(self, path: str, extension: Optional[str] = None):
         """
         load our certificate from file, either pem or der
         """
         self.user_certificate = await uacrypto.load_certificate(path, extension)
 
-    async def load_private_key(self, path: str, password: str = None, extension: str = None):
+    async def load_private_key(self,
+                               path: str,
+                               password: Optional[Union[str, bytes]] = None,
+                               extension: Optional[str] = None):
         """
         Load user private key. This is used for authenticating using certificate
         """

--- a/asyncua/crypto/uacrypto.py
+++ b/asyncua/crypto/uacrypto.py
@@ -1,6 +1,7 @@
 import os
 
 import aiofiles
+from typing import Optional, Union
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -13,13 +14,15 @@ from cryptography.hazmat.primitives.ciphers import modes
 from cryptography.exceptions import InvalidSignature
 from dataclasses import dataclass
 
+
 @dataclass
 class CertProperties:
-    path: str = None
-    extension: str = None
-    password: str = None
+    path: str
+    extension: Optional[str] = None
+    password: Optional[Union[str, bytes]] = None
 
-async def load_certificate(path, extension=None):
+
+async def load_certificate(path: str, extension: Optional[str] = None):
     _, ext = os.path.splitext(path)
     async with aiofiles.open(path, mode='rb') as f:
         if ext == ".pem" or extension == 'pem' or extension == 'PEM':
@@ -34,10 +37,12 @@ def x509_from_der(data):
     return x509.load_der_x509_certificate(data, default_backend())
 
 
-async def load_private_key(path, password=None, extension=None):
+async def load_private_key(path: str,
+                           password: Optional[Union[str, bytes]] = None,
+                           extension: Optional[str] = None):
     _, ext = os.path.splitext(path)
     if isinstance(password, str):
-        password.encode('utf-8')
+        password = password.encode('utf-8')
     async with aiofiles.open(path, mode='rb') as f:
         if ext == ".pem" or extension == 'pem' or extension == 'PEM':
             return serialization.load_pem_private_key(await f.read(), password=password, backend=default_backend())


### PR DESCRIPTION
String are immutable, therefore the password is never encoded when it's a string and throws this error:

```
...../cryptography/hazmat/backends/openssl/backend.py in _load_key(self, openssl_read_func, convert_func, data, password)
   1284         userdata = self._ffi.new("CRYPTOGRAPHY_PASSWORD_DATA *")
   1285         if password is not None:
-> 1286             utils._check_byteslike("password", password)
   1287             password_ptr = self._ffi.from_buffer(password)
   1288             userdata.password = password_ptr

...../cryptography/utils.py in _check_byteslike(name, value)
     36         memoryview(value)
     37     except TypeError:
---> 38         raise TypeError("{} must be bytes-like".format(name))
     39
     40

TypeError: password must be bytes-like
```

This patch fixes this as well as some typing inaccuracy introduced by #281