### PR TITLE
[fix] Always call ua_client.close_session on disconnect

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -514,7 +514,10 @@ class Client:
         Close session
         """
         self._renew_channel_task.cancel()
-        await self._renew_channel_task
+        try:
+            await self._renew_channel_task
+        except Exception:
+            _logger.exception("Error while closing secure channel loop")
         return await self.uaclient.close_session(True)
 
     def get_root_node(self):


### PR DESCRIPTION
When disconnecting a client, we cancel the uaclient [publish_task](https://github.com/FreeOpcUa/opcua-asyncio/blob/master/asyncua/client/ua_client.py#L463) (done via [close_session](https://github.com/FreeOpcUa/opcua-asyncio/blob/master/asyncua/client/ua_client.py#L315-L319)). Failing at doing this can prevent a proper client reconnection since a ```publish_task``` will still be running, and could be hanging on a previous request that has never completed (i.e network issue) because Yes, there's no timeout for requests coming from the [publish_loop](https://github.com/FreeOpcUa/opcua-asyncio/blob/master/asyncua/client/ua_client.py#L505) (details about ```asyncio.wait_for(.., timeout=0)``` in #163).

When disconnecting an unhealthy client, there'a time window during which waiting on the cancelled [renew_channel_task](https://github.com/FreeOpcUa/opcua-asyncio/blob/ba006abd2e8443aab872d6d88c67cc45726e9c67/asyncua/client/client.py#L520) can raise. It will then prevent the lower level ```close_session``` call from happening. Any subscription based on this client will then be unable to send/receive publish notification. This is related to #314. 

Sample of a repro using iptables with the patch:

```
2020-10-22 15:11:01,353 - ERROR - Error while closing secure channel loop
Traceback (most recent call last):
  File "asyncua/client/client.py", line 96, in close_session
    await self._renew_channel_task
  File "asyncua/client/client.py", line 387, in _renew_channel_loop
    await self.open_secure_channel(renew=True)
  File "asyncua/client/client.py", line 279, in open_secure_channel
    result = await self.uaclient.open_secure_channel(params)
  File "asyncua/client/ua_client.py", line 281, in open_secure_channel
    return await self.protocol.open_secure_channel(params)
  File "asyncua/client/ua_client.py", line 212, in open_secure_channel
    self.timeout
  File "lib/python3.7/asyncio/tasks.py", line 449, in wait_for
    raise futures.TimeoutError()
```