### PR TITLE
if you lose the connection the endless loop has to be closed

### DIFF
--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -526,6 +526,8 @@ class UaClient:
             except UaStructParsingError:
                 ack = None
                 continue
+            except ConnectionError:
+                break
             subscription_id = response.Parameters.SubscriptionId
             if not subscription_id:
                 # The value 0 is used to indicate that there were no Subscriptions defined for which a


### PR DESCRIPTION
Hi,

I lost the connecton to the server and then had this error and tryed to fix it. 

2020-10-23 15:12:02,399 - asyncio:1604 - ERROR - Task exception was never retrieved
future: <Task finished coro=<UaClient._publish_loop() done, defined at asyncua\client\ua_client.py:497> exception=ConnectionError('Connection is closed')>

Any problems with it?