### PR TITLE
Explicitly cancel automatic discovery renewal

### DIFF
--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -236,7 +236,7 @@ class Server:
 
     def _schedule_renew_registration(self):
         self.loop.create_task(self._renew_registration())
-        self.loop.call_later(self._discovery_period, self._schedule_renew_registration)
+        self._discovery_handle = self.loop.call_later(self._discovery_period, self._schedule_renew_registration)
 
     async def _renew_registration(self):
         for client in self._discovery_clients.values():

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -222,7 +222,7 @@ class Server:
         await self._discovery_clients[url].register_server(self)
         self._discovery_period = period
         if period:
-            self._discovery_handle = self.loop.call_soon(self._schedule_renew_registration)
+            self.loop.call_soon(self._schedule_renew_registration)
 
     async def unregister_to_discovery(self, url: str = "opc.tcp://localhost:4840"):
         """

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -87,6 +87,7 @@ class Server:
         self.bserver: Optional[BinaryServer] = None
         self._discovery_clients = {}
         self._discovery_period = 60
+        self._discovery_handle = None
         self._policies = []
         self.nodes = Shortcuts(self.iserver.isession)
         # enable all endpoints by default
@@ -221,14 +222,17 @@ class Server:
         await self._discovery_clients[url].register_server(self)
         self._discovery_period = period
         if period:
-            self.loop.call_soon(self._schedule_renew_registration)
+            self._discovery_handle = self.loop.call_soon(self._schedule_renew_registration)
 
-    def unregister_to_discovery(self, url: str = "opc.tcp://localhost:4840"):
+    async def unregister_to_discovery(self, url: str = "opc.tcp://localhost:4840"):
         """
         stop registration thread
         """
         # FIXME: is there really no way to deregister?
-        self._discovery_clients[url].disconnect()
+        await self._discovery_clients[url].disconnect()
+        del self._discovery_clients[url]
+        if not self._discovery_clients and self._discovery_handle:
+            self._discovery_handle.cancel()
 
     def _schedule_renew_registration(self):
         self.loop.create_task(self._renew_registration())
@@ -380,6 +384,8 @@ class Server:
         """
         Stop server
         """
+        if self._discovery_handle:
+            self._discovery_handle.cancel()
         if self._discovery_clients:
             await asyncio.wait([client.disconnect() for client in self._discovery_clients.values()])
         await self.bserver.stop()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,6 +32,22 @@ async def test_discovery(server, discovery_server):
         assert new_app_uri in [s.ApplicationUri for s in new_servers]
 
 
+async def test_unregister_discovery(server, discovery_server):
+    client = Client(discovery_server.endpoint.geturl())
+    async with client:
+        new_app_uri = 'urn:freeopcua:python:server:test_discovery2'
+        await server.set_application_uri(new_app_uri)
+        # register without automatic renewal
+        await server.register_to_discovery(discovery_server.endpoint.geturl(), period=0)
+        await asyncio.sleep(0.1)
+        # unregister, no automatic renewal to stop
+        await server.unregister_to_discovery(discovery_server.endpoint.geturl())
+        # reregister with automatic renewal
+        await server.register_to_discovery(discovery_server.endpoint.geturl(), period=60)
+        # unregister, cancel scheduled renewal
+        await server.unregister_to_discovery(discovery_server.endpoint.geturl())
+
+
 async def test_find_servers2(server, discovery_server):
     client = Client(discovery_server.endpoint.geturl())
     async with client:


### PR DESCRIPTION
In cases where we either
- call `unregister_to_discovery()` while keeping the server running, or
- call `stop()` while keeping to drive the event loop,

we run into exceptions as the callback scheduled for automatic renewal (`_schedule_renew_registration`) keeps being executed.

This PR introduces explicit cancellation of callbacks created when scheduling the next renewal.
The callbacks are cancelled either when the server is stopped altogether or when the last entry in `_discovery_clients` is disconnected.

In addition, `unregister_to_discovery()` will now remove the entry from `_discovery_clients` so they're not used in `_renew_registration()` after having been disconnected.

Finally, I changed `unregister_to_discovery()` to a coroutine as otherwise the affected client's `disconnect()` could not be awaited.