### PR TITLE
[HaClient] subscription and client prerequisites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ install:
   - pip install pytest --upgrade
   - pip install pytest-asyncio
   - pip install pytest-mock
+  - pip install asynctest
   - pip install cryptography
   - pip install dataclasses
   - pip install --editable .

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -539,7 +539,7 @@ class Client:
         """
         return Node(self.uaclient, nodeid)
 
-    async def create_subscription(self, period, handler):
+    async def create_subscription(self, period, handler, publishing=True):
         """
         Create a subscription.
         Returns a Subscription object which allows to subscribe to events or data changes on server.
@@ -558,7 +558,7 @@ class Client:
             params.RequestedLifetimeCount = 10000
             params.RequestedMaxKeepAliveCount = 3000
             params.MaxNotificationsPerPublish = 10000
-            params.PublishingEnabled = True
+            params.PublishingEnabled = publishing
             params.Priority = 0
         subscription = Subscription(self.uaclient, params, handler)
         await subscription.init()

--- a/asyncua/common/shortcuts.py
+++ b/asyncua/common/shortcuts.py
@@ -27,6 +27,7 @@ class Shortcuts(object):
         self.opc_binary = Node(server, ObjectIds.OPCBinarySchema_TypeSystem)
         self.base_structure_type = Node(server, ObjectIds.Structure)
         self.server_state = Node(server, ObjectIds.Server_ServerStatus_State)
+        self.service_level = Node(server, ObjectIds.Server_ServiceLevel)
         self.HasComponent = Node(server, ObjectIds.HasComponent)
         self.HasProperty = Node(server, ObjectIds.HasProperty)
         self.Organizes = Node(server, ObjectIds.Organizes)

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -159,7 +159,9 @@ class Subscription:
     async def subscribe_data_change(self,
                                     nodes: Union[Node, Iterable[Node]],
                                     attr=ua.AttributeIds.Value,
-                                    queuesize=0) -> Union[int, List[Union[int, ua.StatusCode]]]:
+                                    queuesize=0,
+                                    monitoring=ua.MonitoringMode.Reporting,
+                                   ) -> Union[int, List[Union[int, ua.StatusCode]]]:
         """
         Subscribe to data change events of one or multiple nodes.
         The default attribute used for the subscription is `Value`.
@@ -176,7 +178,9 @@ class Subscription:
         :param queuesize: 0 or 1 for default queue size (shall be 1 - no queuing), n for FIFO queue
         :return: Handle for changing/cancelling of the subscription
         """
-        return await self._subscribe(nodes, attr, queuesize=queuesize)
+        return await self._subscribe(
+            nodes, attr, queuesize=queuesize, monitoring=monitoring
+        )
 
     async def subscribe_events(self,
                                sourcenode: Node = ua.ObjectIds.Server,
@@ -205,14 +209,20 @@ class Subscription:
             evfilter = await get_filter_from_event_type(evtypes)
         return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)
 
-    async def _subscribe(self, nodes: Union[Node, Iterable[Node]],
-                         attr, mfilter=None, queuesize=0) -> Union[int, List[Union[int, ua.StatusCode]]]:
+    async def _subscribe(self,
+                         nodes: Union[Node, Iterable[Node]],
+                         attr=ua.AttributeIds.Value,
+                         mfilter=None,
+                         queuesize=0,
+                         monitoring=ua.MonitoringMode.Reporting,
+                        ) -> Union[int, List[Union[int, ua.StatusCode]]]:
         """
         Private low level method for subscribing.
         :param nodes: One Node or an Iterable og Nodes.
         :param attr: ua.AttributeId
         :param mfilter: MonitoringFilter
         :param queuesize: queue size
+        :param monitoring: ua.MonitoringMode
         :return: Integer handle or if multiple Nodes were given a List of Integer handles/ua.StatusCode
         """
         is_list = True
@@ -224,7 +234,9 @@ class Subscription:
         # Create List of MonitoredItemCreateRequest
         mirs = []
         for node in nodes:
-            mir = self._make_monitored_item_request(node, attr, mfilter, queuesize)
+            mir = self._make_monitored_item_request(
+                node, attr, mfilter, queuesize, monitoring
+            )
             mirs.append(mir)
         # Await MonitoredItemCreateResult
         mids = await self.create_monitored_items(mirs)
@@ -236,7 +248,12 @@ class Subscription:
             mids[0].check()
         return mids[0]
 
-    def _make_monitored_item_request(self, node: Node, attr, mfilter, queuesize) -> ua.MonitoredItemCreateRequest:
+    def _make_monitored_item_request(self,
+                                     node: Node,
+                                     attr,
+                                     mfilter,
+                                     queuesize,
+                                     monitoring) -> ua.MonitoredItemCreateRequest:
         rv = ua.ReadValueId()
         rv.NodeId = node.nodeid
         rv.AttributeId = attr
@@ -251,7 +268,7 @@ class Subscription:
             mparams.Filter = mfilter
         mir = ua.MonitoredItemCreateRequest()
         mir.ItemToMonitor = rv
-        mir.MonitoringMode = ua.MonitoringMode.Reporting
+        mir.MonitoringMode = monitoring
         mir.RequestedParameters = mparams
         return mir
 
@@ -370,3 +387,40 @@ class Subscription:
         # absolute float value or from 0 to 100 for percentage deadband
         deadband_filter.DeadbandValue = deadband_val
         return self._subscribe(var, attr, deadband_filter, queuesize)
+
+    async def set_monitoring_mode(self, monitoring: ua.MonitoringMode) -> ua.uatypes.StatusCode:
+        """
+        The monitoring mode parameter is used
+        to enable/disable the sampling of MonitoredItems
+        (Samples don't queue on the server side)
+
+        :param monitoring: The monitoring mode to apply
+        :return: Return a Set Monitoring Mode Result
+        """
+        node_handles = []
+        for mi in self._monitored_items.values():
+            node_handles.append(mi.server_handle)
+
+        params = ua.SetMonitoringModeParameters()
+        params.SubscriptionId = self.subscription_id
+        params.MonitoredItemIds = node_handles
+        params.MonitoringMode = monitoring
+        return await self.server.set_monitoring_mode(params)
+
+    async def set_publishing_mode(self, publishing: bool) -> ua.uatypes.StatusCode:
+        """
+        Disable publishing of NotificationMessages for the subscription,
+        but doesn't discontinue the sending of keep-alive Messages,
+        nor change the monitoring mode.
+
+        :param publishing: The publishing mode to apply
+        :return: Return a Set Publishing Mode Result
+        """
+        self.logger.info("set_publishing_mode")
+        params = ua.SetPublishingModeParameters()
+        params.SubscriptionIds = [self.subscription_id]
+        params.PublishingEnabled = publishing
+        result = await self.server.set_publishing_mode(params)
+        if result[0].is_good():
+            self.parameters.PublishingEnabled = publishing
+        return result

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,3 +3,4 @@ pytest-asyncio
 coverage
 pytest-cov
 pytest-mock
+asynctest

--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,5 @@ setup(
         ]
     },
     setup_requires=[] + pytest_runner,
-    tests_require=['pytest', 'pytest-mock'],
+    tests_require=['pytest', 'pytest-mock', 'asynctest'],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,11 @@ Opc = namedtuple('opc', ['opc', 'server'])
 
 
 def pytest_generate_tests(metafunc):
-    if 'opc' in metafunc.fixturenames:
+    mark = metafunc.definition.get_closest_marker('parametrize')
+    # override the opc parameters when explicilty provided
+    if getattr(mark, "args", None) and "opc" in mark.args:
+        pass
+    elif "opc" in metafunc.fixturenames:
         metafunc.parametrize('opc', ['client', 'server'], indirect=True)
     elif 'history' in metafunc.fixturenames:
         metafunc.parametrize('history', ['dict', 'sqlite'], indirect=True)


### PR DESCRIPTION
Few updates to be able to change the mode (hot/stand-by) of the HaClient underlying connections :

- Ability to specify the publishing mode at subscription creation (enabled/disabled).
- Subscription methods to change the publishing and monitoring mode of an existing subscription.
- Add a timeout on client's connect for the connection to fail if the server can't handle it.
- Client shortcut for the service_level.

See #314 for context.