### PR TITLE
Remove pytest.mark.skip from test_xml_method

### DIFF
--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -64,7 +64,6 @@ async def test_xml_import_additional_ns(opc):
     assert ns == r3.NodeId.NamespaceIndex
 
 
-@pytest.mark.skip("FIXME")
 async def test_xml_method(opc, tmpdir):
     await opc.opc.register_namespace("foo")
     await opc.opc.register_namespace("bar")


### PR DESCRIPTION
Tests run, perhaps of #130 
Mentioned in #334