### PR TITLE
fix bug when sending event with no message

### DIFF
--- a/asyncua/server/event_generator.py
+++ b/asyncua/server/event_generator.py
@@ -98,6 +98,6 @@ class EventGenerator:
         if message:
             self.event.Message = ua.LocalizedText(message)
         elif not self.event.Message:
-            self.event.Message = ua.LocalizedText(Node(self.isession, self.event.SourceNode).read_browse_name().Text)
+            self.event.Message = ua.LocalizedText((await Node(self.isession, self.event.SourceNode).read_browse_name()).Name).Text
 
         await self.isession.subscription_service.trigger_event(self.event)


### PR DESCRIPTION
if im trying to send an event like 

```
evgen = await self._server.get_event_generator()
...
evgen.event.Message = None
await evgen.trigger()
```

I got an error like 
```ValueError: A LocalizedText object takes a string as argument "text", not a <class 'coroutine'>, <coroutine object Node.read_browse_name at 0x7f1dae170340>```

It seems to come from this code which likely hasnt been hit since the port from sync to async :)
