### PR TITLE
User manager and permission ruleset fix

### DIFF
--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -300,9 +300,17 @@ class InternalServer:
         user_name = token.UserName
         password = token.Password
 
+        # TODO Support all Token Types
+        # AnonimousIdentityToken
+        # UserIdentityToken
+        # UserNameIdentityToken
+        # X509IdentityToken
+        # IssuedIdentityToken
+
         # decrypt password if we can
         if str(token.EncryptionAlgorithm) != "None":
             if not uacrypto:
+                # raise  # Should I raise a significant exception?
                 return False
             try:
                 if token.EncryptionAlgorithm == "http://www.w3.org/2001/04/xmlenc#rsa-1_5":
@@ -311,12 +319,15 @@ class InternalServer:
                     raw_pw = uacrypto.decrypt_rsa_oaep(self.private_key, password)
                 else:
                     self.logger.warning("Unknown password encoding %s", token.EncryptionAlgorithm)
-                    return False
+                    # raise  # Should I raise a significant exception?
+                    return user_name, password
                 length = unpack_from('<I', raw_pw)[0] - len(isession.nonce)
                 password = raw_pw[4:4 + length]
                 password = password.decode('utf-8')
             except Exception:
                 self.logger.exception("Unable to decrypt password")
                 return False
-        # call user_manager
-        return self.user_manager(self, isession, user_name, password)
+        else:
+            password = password.decode('utf-8')
+
+        return user_name, password

--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -327,7 +327,7 @@ class InternalServer:
             except Exception:
                 self.logger.exception("Unable to decrypt password")
                 return False
-        else:
+        elif type(password) == bytes:  # TODO check
             password = password.decode('utf-8')
 
         return user_name, password

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -89,8 +89,7 @@ class InternalSession:
         id_token = params.UserIdentityToken
         if self.iserver.user_manager is not None:
             if isinstance(id_token, ua.UserNameIdentityToken):
-                username = id_token.UserName
-                password = id_token.Password
+                username, password = self.iserver.check_user_token(self, id_token)
             else:
                 username, password = None, None
 

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -295,7 +295,7 @@ class Server:
         # to be called just before starting server since it needs all parameters to be setup
         if ua.SecurityPolicyType.NoSecurity in self._security_policy:
             self._set_endpoints()
-            self._policies = [ua.SecurityPolicyFactory()]
+            self._policies = [ua.SecurityPolicyFactory(permission_ruleset=self._permission_ruleset)]
 
         if self._security_policy != [ua.SecurityPolicyType.NoSecurity]:
             if not (self.certificate and self.iserver.private_key):

--- a/asyncua/ua/uaprotocol_hand.py
+++ b/asyncua/ua/uaprotocol_hand.py
@@ -234,14 +234,14 @@ class SecurityPolicy:
     signature_key_size = 0
     symmetric_key_size = 0
 
-    def __init__(self):
+    def __init__(self, permissions=None):
         self.asymmetric_cryptography = CryptographyNone()
         self.symmetric_cryptography = CryptographyNone()
         self.Mode = auto.MessageSecurityMode.None_
         self.peer_certificate = None
         self.host_certificate = None
         self.user = None
-        self.permissions = None
+        self.permissions = permissions
 
     def make_local_symmetric_key(self, secret, seed):
         pass
@@ -268,7 +268,7 @@ class SecurityPolicyFactory:
 
     def create(self, peer_certificate):
         if self.cls is SecurityPolicy:
-            return self.cls()
+            return self.cls(permissions=self.permission_ruleset)
         else:
             return self.cls(peer_certificate, self.certificate, self.private_key, self.mode, permission_ruleset=self.permission_ruleset)
 


### PR DESCRIPTION
Hello,
I noticed two bugs in UserManager and PermissionRuleSet handling:

1. the user-defined PermissionRuleset is now propagated and used also into the server endpoint with NoSecurity; without this fix a valid user has full acess to the server if uses an unencrypted connection;
2. a clear password is now passed to the user-defined UserManager.get_user when using a Basic256Sha256SignAndEncrypt endpoint.

