### PR TITLE
[uatools] Missing await to load certificates

### DIFF
--- a/asyncua/tools.py
+++ b/asyncua/tools.py
@@ -558,9 +558,9 @@ async def _uaserver():
     server = Server()
     server.set_endpoint(args.url)
     if args.certificate:
-        server.load_certificate(args.certificate)
+        await server.load_certificate(args.certificate)
     if args.private_key:
-        server.load_private_key(args.private_key)
+        await server.load_private_key(args.private_key)
     server.disable_clock(args.disable_clock)
     server.set_server_name("FreeOpcUa Example Server")
     if args.xml:


### PR DESCRIPTION
Those missing await prevent the server from loading the certificates via CLI.

```
 $ ./uaserver --certificate ../examples/certificate-example.der --private_key ../examples/private-key-example.pem -v DEBUG
/home/prigentj/github/opcua-asyncio/tools/../asyncua/tools.py:561: RuntimeWarning: coroutine 'Server.load_certificate' was never awaited
  server.load_certificate(args.certificate)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
/home/prigentj/github/opcua-asyncio/tools/../asyncua/tools.py:563: RuntimeWarning: coroutine 'Server.load_private_key' was never awaited
  server.load_private_key(args.private_key)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```