### PR TITLE
Auto generate client event filter for Alarms and Conditions

### DIFF
--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -211,13 +211,13 @@ class Subscription:
             evfilter = await self._create_eventfilter(evtypes)
         return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)
 
-    async def subscribe_conditions(self,
-                                   sourcenode: Node = ua.ObjectIds.Server,
-                                   evtypes=ua.ObjectIds.ConditionType,
-                                   evfilter=None,
-                                   queuesize=0) -> int:
+    async def subscribe_alarms_and_conditions(self,
+                                              sourcenode: Node = ua.ObjectIds.Server,
+                                              evtypes=ua.ObjectIds.ConditionType,
+                                              evfilter=None,
+                                              queuesize=0) -> int:
         """
-        Subscribe to condition events from a node. Default node is Server node.
+        Subscribe to alarm and condition events from a node. Default node is Server node.
         In many servers the server node is the only one you can subscribe to.
         If evtypes is not provided, evtype defaults to ConditionType.
         If evtypes is a list or tuple of custom event types, the events will be filtered to the supplied types.

--- a/examples/client_to_uanet_alarm_conditions.py
+++ b/examples/client_to_uanet_alarm_conditions.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from asyncua import Client, ua
-from asyncua.common.events import Event, get_filter_from_event_type
 
 logging.basicConfig(level=logging.INFO)
 _logger = logging.getLogger(__name__)
@@ -35,33 +34,22 @@ async def main():
     # OPCFoundation/UA-.NETStandard-Samples Quickstart AlarmConditionServer
     url = "opc.tcp://localhost:62544/Quickstarts/AlarmConditionServer"
     async with Client(url=url) as client:
-        alarmConditionType = await client.nodes.root.get_child(["0:Types", "0:EventTypes", "0:BaseEventType", "0:ConditionType", 
-                                                                "0:AcknowledgeableConditionType", "0:AlarmConditionType"])  
-
-        conditionType = await client.nodes.root.get_child(["0:Types", "0:EventTypes", "0:BaseEventType", "0:ConditionType"])
-         
-        # Create Operand for necessary field ConditionId
-        # Hint: The ConditionId is not a property of the event, but it's NodeId.
-        #       ConditionId is named "NodeId" in event field list.
-        conditionIdOperand = ua.SimpleAttributeOperand()
-        conditionIdOperand.TypeDefinitionId = ua.NodeId(ua.ObjectIds.ConditionType)    
-        conditionIdOperand.AttributeId = ua.AttributeIds.NodeId 
-
-        # Add ConditionId to select filter
-        evfilter = await get_filter_from_event_type([alarmConditionType])        
-        evfilter.SelectClauses.append(conditionIdOperand)
+        # Standard types in namespace 0 have fixed NodeIds
+        conditionType = client.get_node("ns=0;i=2782")
+        alarmConditionType = client.get_node("ns=0;i=2915")
                
         # Create subscription for AlarmConditionType
         msclt = SubHandler()
-        sub = await client.create_subscription(0, msclt)      
-        handle = await sub.subscribe_events(client.nodes.server, alarmConditionType, evfilter)          
+        sub = await client.create_subscription(0, msclt)
+        handle = await sub.subscribe_conditions(client.nodes.server, alarmConditionType)     
 
         # Call ConditionRefresh to get the current conditions with retain = true
         # Should also be called after reconnects
-        await conditionType.call_method("0:ConditionRefresh", ua.Variant(sub.subscription_id, ua.VariantType.UInt32))     
+        await conditionType.call_method("0:ConditionRefresh", ua.Variant(sub.subscription_id, ua.VariantType.UInt32))    
 
-        await asyncio.sleep(30)  
+        await asyncio.sleep(30)
         await sub.unsubscribe(handle)
+
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/client_to_uanet_alarm_conditions.py
+++ b/examples/client_to_uanet_alarm_conditions.py
@@ -41,7 +41,7 @@ async def main():
         # Create subscription for AlarmConditionType
         msclt = SubHandler()
         sub = await client.create_subscription(0, msclt)
-        handle = await sub.subscribe_conditions(client.nodes.server, alarmConditionType)     
+        handle = await sub.subscribe_alarms_and_conditions(client.nodes.server, alarmConditionType)     
 
         # Call ConditionRefresh to get the current conditions with retain = true
         # Should also be called after reconnects


### PR DESCRIPTION
**Current solution for normal events:**
The current solution for subscribing to events is great. Setting the event-filter is optional. If not set, an event-filter containing all properties and variables, is auto-generated. The client coder does not need to have knowledge about the complex filter system. If he has, he can go fancy as well.

**Issue with the condition events:**
In a similar way that should be the case for an alarms/conditions client as well. But for subscribing to condition-events an extra operand in the select clause of the event filter is necessary (like in example _client_to_uanet_alarm_conditions_). Each client does need to add the same code, does need to cope with the filters, and just needs to realize that this has to be done. 

So it should be autogenerated as well. There are 2 possible approaches.

- **The implicit approach:**  
Stick to `subscribe_events` and when autogenerating the event-filter, check for the existence of a ConditionType. If a ConditionType is involved, auto-add the extra operand in the select clause.
- **The explicit approach**: 
Add `subscribe_conditions` to the subscriptions interface. `subscribe_conditions` does the same as `subscribe_events`, but adds the extra operand in the select clause.

@oroulet, which approach shall we follow? I tend a little bit more to the explicit approach, since I don't like too much implicit magic happening. But in that case I really think both approaches would be fine. So what do you prefer?

Code in the PR shows the explicit approach and how it simplifies everything for the client in _client_to_uanet_alarm_conditions_.

Related to #365 