### PR TITLE
[Session keepalive] Use sub keepalive instead of secure_channel 

### DIFF
--- a/asyncua/client/ha/ha_client.py
+++ b/asyncua/client/ha/ha_client.py
@@ -85,6 +85,7 @@ class HaConfig:
     reconciliator_timer: int = 15
     session_timeout: int = 60
     request_timeout: int = 30
+    secure_channel_timeout: int = 3600
     session_name: str = "HaClient"
     urls: List[str] = field(default_factory=list)
 
@@ -142,7 +143,7 @@ class HaClient:
             c = Client(url, timeout=self._config.request_timeout, loop=self.loop)
             # timeouts for the session and secure channel are in ms
             c.session_timeout = self._config.session_timeout * 1000
-            c.secure_channel_timeout = self._config.request_timeout * 1000
+            c.secure_channel_timeout = self._config.secure_channel_timeout * 1000
             c.description = self._config.session_name
             server_info = ServerInfo(url)
             self.clients[c] = server_info

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -41,7 +41,7 @@ class TestHaClient:
             urls.remove(url)
             assert client.session_timeout == ha_config.session_timeout * 1000
             assert client.session_timeout == ha_client.session_timeout * 1000
-            assert client.secure_channel_timeout == ha_config.request_timeout * 1000
+            assert client.secure_channel_timeout == ha_config.secure_channel_timeout * 1000
             assert client.uaclient._timeout == ha_config.request_timeout
             assert client.description == ha_config.session_name
             # ideal map is empty at startup


### PR DESCRIPTION
When a session has a short session timeout, the secure_channel is renewed at 75% of its lifetime. While this is convenient to keep the session alive, the encryption operations involved behind the scenes can be expensive, especially on hardware with limited resources (i.e: OPC-UA server embedded on PLC module).

The suggestion here is to give back more control to the secure channel timeout parameter, and to instead rely on the subscription keepalive mechanism to avoid timing out when subscriptions are inactive.

There's still the rare use-case when there's no subscription at all (client is connected but idling without subscriptions). In this situation, the user has to specifically set a secure_channel_timeout < session_timeout, or alternatively, use an external keepalive mechanism like the HaClient uses to determine the server health.

Finally, I noticed that the ua-server doesn't respect the session_timeout sent by the client during the session_creation (i.e the session never times out). Probably worth to follow-up on this.

Test with MaxKeepAliveCount == 22
(session_timeout = 30; publish_interval = 1000)
```
2021-02-07 16:23:00,147 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: CreateSubscriptionRequest(TypeId:i=787, RequestHeader:RequestHeader(AuthenticationToken:b=b'2\xd2\x82w\xad\x0f\x99\x9a %\xfaj\xb6\xb9\xaf\xa8\xe7\x13\xe6\xec\x15G\xf7G\x15\xbb\x82\x1d\xda\x17\xafh', Timestamp:2021-02-08 00:23:00.147523, RequestHandle:4, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:4000, AdditionalHeader:ExtensionObject(TypeId:i=0, Encoding:0, None bytes)), Parameters:CreateSubscriptionParameters(RequestedPublishingInterval:1000, RequestedLifetimeCount:10000, RequestedMaxKeepAliveCount:22, MaxNotificationsPerPublish:10000, PublishingEnabled:True, Priority:0))
2021-02-07 16:23:00,170 - asyncua.client.ua_client.UaClient - DEBUG - publish []
2021-02-07 16:23:00,170 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: PublishRequest(TypeId:i=826, RequestHeader:RequestHeader(AuthenticationToken:b=b'2\xd2\x82w\xad\x0f\x99\x9a %\xfaj\xb6\xb9\xaf\xa8\xe7\x13\xe6\xec\x15G\xf7G\x15\xbb\x82\x1d\xda\x17\xafh', Timestamp:2021-02-08 00:23:00.170972, RequestHandle:6, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:0, AdditionalHeader:ExtensionObject(TypeId:i=0, Encoding:0, None bytes)), Parameters:PublishParameters(SubscriptionAcknowledgements:[]))
21-02-08 00:23:00.939388))], DiagnosticInfos:[])]), Results:[], DiagnosticInfos:[])
DataChangeNotification(<asyncua.common.subscription.SubscriptionItemData object at 0x7fdbf1444c10>, MonitoredItemNotification(ClientHandle:201, Value:DataValue(Value:Variant(val:300000,type:VariantType.Int32), StatusCode:StatusCode(Good), SourceTimestamp:2021-02-08 00:23:00.900000, ServerTimestamp:2021-02-08 00:23:00.939388)))

# Sub Ack
2021-02-07 16:23:01,189 - asyncua.client.ua_client.UaClient - DEBUG - publish [SubscriptionAcknowledgement(SubscriptionId:75, SequenceNumber:1)]
2021-02-07 16:23:01,189 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: PublishRequest(TypeId:i=826, RequestHeader:RequestHeader(AuthenticationToken:b=b'2\xd2\x82w\xad\x0f\x99\x9a %\xfaj\xb6\xb9\xaf\xa8\xe7\x13\xe6\xec\x15G\xf7G\x15\xbb\x82\x1d\xda\x17\xafh', Timestamp:2021-02-08 00:23:01.189588, RequestHandle:7, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:0, AdditionalHeader:ExtensionObject(TypeId:i=0, Encoding:0, None bytes)), Parameters:PublishParameters(SubscriptionAcknowledgements:[SubscriptionAcknowledgement(SubscriptionId:75, SequenceNumber:1)]))
2021-02-07 16:23:23,198 - asyncua.common.subscription - INFO - Publish callback called with result: PublishResult(SubscriptionId:75, AvailableSequenceNumbers:[], MoreNotifications:False, NotificationMessage:NotificationMessage(SequenceNumber:2, PublishTime:2021-02-08 00:23:23.195861, NotificationData:[]), Results:[StatusCode(Good)], DiagnosticInfos:[])

# Keepalive triggers after 22*1000ms = 22s
2021-02-07 16:23:45,175 - asyncua.common.subscription - INFO - Publish callback called with result: PublishResult(SubscriptionId:75, AvailableSequenceNumbers:[], MoreNotifications:False, NotificationMessage:NotificationMessage(SequenceNumber:2, PublishTime:2021-02-08 00:23:45.172315, NotificationData:[]), Results:[], DiagnosticInfos:[])
2021-02-07 16:23:45,175 - asyncua.client.ua_client.UaClient - DEBUG - publish []
2021-02-07 16:23:45,175 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: PublishRequest(TypeId:i=826, RequestHeader:RequestHeader(AuthenticationToken:b=b'2\xd2\x82w\xad\x0f\x99\x9a %\xfaj\xb6\xb9\xaf\xa8\xe7\x13\xe6\xec\x15G\xf7G\x15\xbb\x82\x1d\xda\x17\xafh', Timestamp:2021-02-08 00:23:45.175790, RequestHandle:9, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:0, AdditionalHeader:ExtensionObject(TypeId:i=0, Encoding:0, None bytes)), Parameters:PublishParameters(SubscriptionAcknowledgements:[]))
2021-02-07 16:24:07,185 - asyncua.common.subscription - INFO - Publish callback called with result: PublishResult(SubscriptionId:75, AvailableSequenceNumbers:[], MoreNotifications:False, NotificationMessage:NotificationMessage(SequenceNumber:2, PublishTime:2021-02-08 00:24:07.182767, NotificationData:[]), Results:[], DiagnosticInfos:[])
```

Test with MaxKeepAliveCount == 0
```
2021-02-07 16:25:40,994 - asyncua.client.ua_client.UaClient - DEBUG - create_subscription
2021-02-07 16:25:40,994 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: CreateSubscriptionRequest(TypeId:i=787, RequestHeader:RequestHeader(AuthenticationToken:b=b'\x18*m\xa6E\xf3?\x9d\x86\xe2\xe9rgI\xa7\x073\xe90\xdb\x82\x82~F\x81\xe8\xb2T\xdb\xb0\xf8\xea', Timestamp:2021-02-08 00:25:40.994336, RequestHandle:4, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:4000, AdditionalHeader:ExtensionObject(TypeId:i=0, Encoding:0, None bytes)), Parameters:CreateSubscriptionParameters(RequestedPublishingInterval:1000, RequestedLifetimeCount:10000, RequestedMaxKeepAliveCount:0, MaxNotificationsPerPublish:10000, PublishingEnabled:True, Priority:0))
2021-02-07 16:25:45,006 - asyncua.common.subscription - INFO - Publish callback called with result: PublishResult(SubscriptionId:76, AvailableSequenceNumbers:[], MoreNotifications:False, NotificationMessage:NotificationMessage(SequenceNumber:2, PublishTime:2021-02-08 00:25:45.003386, NotificationData:[]), Results:[StatusCode(Good)], DiagnosticInfos:[])
2021-02-07 16:25:45,007 - asyncua.client.ua_client.UaClient - DEBUG - publish []
2021-02-07 16:25:45,007 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: PublishRequest(TypeId:i=826, RequestHeader:RequestHeader(AuthenticationToken:b=b'\x18*m\xa6E\xf3?\x9d\x86\xe2\xe9rgI\xa7\x073\xe90\xdb\x82\x82~F\x81\xe8\xb2T\xdb\xb0\xf8\xea', Timestamp:2021-02-08 00:25:45.007090, RequestHandle:8, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:0, AdditionalHeader:ExtensionObject(TypeId:i=0, Encoding:0, None bytes)), Parameters:PublishParameters(SubscriptionAcknowledgements:[]))

# Sub Ack
2021-02-07 16:25:42,023 - asyncua.client.ua_client.UaClient - DEBUG - publish [SubscriptionAcknowledgement(SubscriptionId:76, SequenceNumber:1)]
2021-02-07 16:25:42,023 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: PublishRequest(TypeId:i=826, RequestHeader:RequestHeader(AuthenticationToken:b=b'\x18*m\xa6E\xf3?\x9d\x86\xe2\xe9rgI\xa7\x073\xe90\xdb\x82\x82~F\x81\xe8\xb2T\xdb\xb0\xf8\xea', Timestamp:2021-02-08 00:25:42.023578, RequestHandle:7, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:0, AdditionalHeader:ExtensionObject(TypeId:i=0, Encoding:0, None bytes)), Parameters:PublishParameters(SubscriptionAcknowledgements:[SubscriptionAcknowledgement(SubscriptionId:76, SequenceNumber:1)]))

# Keepalive kicks in after 3s
2021-02-07 16:25:45,006 - asyncua.common.subscription - INFO - Publish callback called with result: PublishResult(SubscriptionId:76, AvailableSequenceNumbers:[], MoreNotifications:False, NotificationMessage:NotificationMessage(SequenceNumber:2, PublishTime:2021-02-08 00:25:45.003386, NotificationData:[]), Results:[StatusCode(Good)], DiagnosticInfos:[])
2021-02-07 16:25:45,007 - asyncua.client.ua_client.UaClient - DEBUG - publish []
2021-02-07 16:25:45,007 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: PublishRequest(TypeId:i=826, RequestHeader:RequestHeader(AuthenticationToken:b=b'\x18*m\xa6E\xf3?\x9d\x86\xe2\xe9rgI\xa7\x073\xe90\xdb\x82\x82~F\x81\xe8\xb2T\xdb\xb0\xf8\xea', Timestamp:2021-02-08 00:25:45.007090, RequestHandle:8, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:0, AdditionalHeader:ExtensionObject(TypeId:i=0, Encoding:0, None bytes)), Parameters:PublishParameters(SubscriptionAcknowledgements:[]))

# Again
2021-02-07 16:25:48,016 - asyncua.common.subscription - INFO - Publish callback called with result: PublishResult(SubscriptionId:76, AvailableSequenceNumbers:[], MoreNotifications:False, NotificationMessage:NotificationMessage(SequenceNumber:2, PublishTime:2021-02-08 00:25:48.013598, NotificationData:[]), Results:[], DiagnosticInfos:[])
2021-02-07 16:25:48,016 - asyncua.client.ua_client.UaClient - DEBUG - publish []
2021-02-07 16:25:48,017 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: PublishRequest(TypeId:i=826, RequestHeader:RequestHeader(AuthenticationToken:b=b'\x18*m\xa6E\xf3?\x9d\x86\xe2\xe9rgI\xa7\x073\xe90\xdb\x82\x82~F\x81\xe8\xb2T\xdb\xb0\xf8\xea', Timestamp:2021-02-08 00:25:48.017009, RequestHandle:9, ReturnDiagnostics:0, AuditEntryId:None, TimeoutHint:0, AdditionalHeader:ExtensionObject(TypeId:i=0, Encoding:0, None bytes)), Parameters:PublishParameters(SubscriptionAcknowledgements:[]))
2021-02-07 16:25:51,016 - asyncua.common.subscription - INFO - Publish callback called with result: PublishResult(SubscriptionId:76, AvailableSequenceNumbers:[], MoreNotifications:False, NotificationMessage:NotificationMessage(SequenceNumber:2, PublishTime:2021-02-08 00:25:51.012809, NotificationData:[]), Results:[], DiagnosticInfos:[])
```