### PR TITLE
Fix create events with special EventFilter and add tests

### DIFF
--- a/asyncua/common/events.py
+++ b/asyncua/common/events.py
@@ -91,8 +91,11 @@ class Event:
         return a field list using a select clause and the object properties
         """
         fields = []
-        for sattr in select_clauses:
-            name = self.simple_attribute_to_attribute_name(sattr)
+        for sattr in select_clauses:           
+            if len(sattr.BrowsePath) == 0:                  
+                name = ua.AttributeIds(sattr.AttributeId).name
+            else:
+                name = self.browse_path_to_attribute_name(sattr.BrowsePath)               
             try:
                 val = getattr(self, name)
             except AttributeError:
@@ -113,22 +116,22 @@ class Event:
         ev = Event()
         ev.select_clauses = select_clauses
         ev.event_fields = fields
-        for idx, sattr in enumerate(select_clauses):
-            name = Event.simple_attribute_to_attribute_name(sattr)
+        for idx, sattr in enumerate(select_clauses):           
+            if len(sattr.BrowsePath) == 0:
+                name = sattr.AttributeId.name               
+            else:
+                name = Event.browse_path_to_attribute_name(sattr.BrowsePath)
             ev.add_property(name, fields[idx].Value, fields[idx].VariantType)
         return ev
 
     @staticmethod
-    def simple_attribute_to_attribute_name(simpleAttribute):
-        if len(simpleAttribute.BrowsePath) == 0:
-            name = simpleAttribute.AttributeId.name
-        else:
-            name = simpleAttribute.BrowsePath[0].Name
-            # Append the sub-property of a VariableType with '/'
-            iter_paths = iter(simpleAttribute.BrowsePath)
-            next(iter_paths)                
-            for path in iter_paths:
-                name += '/' + path.Name
+    def browse_path_to_attribute_name(browsePath):  
+        name = browsePath[0].Name
+        # Append the sub-property of a VariableType with '/'
+        iter_paths = iter(browsePath)
+        next(iter_paths)                
+        for path in iter_paths:
+            name += '/' + path.Name
         return name
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -431,6 +431,23 @@ async def test_eventgenerator_custom_event(server):
     await server.delete_nodes([etype])
 
 
+async def test_eventgenerator_custom_event_with_variables(server):
+    # Here use generic create_custom_object_type
+    # Variables are still missing in create_custom_event_type
+    properties = [('PropertyNum', ua.VariantType.Int32),
+                  ('PropertyString', ua.VariantType.String)]
+    variables = [('VariableString', ua.VariantType.String),
+                 ('MyEnumVar', ua.VariantType.Int32, ua.NodeId(ua.ObjectIds.ApplicationType))]
+    etype = await server.create_custom_object_type(2, 'MyEvent33', ua.ObjectIds.BaseEventType, 
+                                                       properties, variables)
+    evgen = await server.get_event_generator(etype, ua.ObjectIds.Server)
+    check_eventgenerator_custom_event(evgen, etype, server)
+    await check_eventgenerator_source_server(evgen, server)
+    assert 0 == evgen.event.PropertyNum
+    assert evgen.event.PropertyString is None
+    await server.delete_nodes([etype])
+
+
 async def test_eventgenerator_double_custom_event(server):
     event1 = await server.create_custom_event_type(3, 'MyEvent4', ua.ObjectIds.BaseEventType,
                                                    [('PropertyNum', ua.VariantType.Int32),


### PR DESCRIPTION
Fixes an oversight in refactoring. Creating Events for a special EventFilter with SimpleAttributeOperand including AttributeId.NodeId does fail.

The PR also adds test cases for that case and PR #455.