### PR TITLE
Auto set ServerTimestamp if value is written

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -68,6 +68,8 @@ class AttributeService:
                         ua.ua_binary.test_bit(ual.Value.Value, ua.AccessLevel.CurrentWrite):
                     res.append(ua.StatusCode(ua.StatusCodes.BadUserAccessDenied))
                     continue
+            if not writevalue.Value.ServerTimestamp:
+                writevalue.Value.ServerTimestamp = datetime.utcnow()
             res.append(
                 await self._aspace.write_attribute_value(writevalue.NodeId, writevalue.AttributeId, writevalue.Value))
         return res


### PR DESCRIPTION
Added the feature discussed here:
- https://github.com/FreeOpcUa/python-opcua/issues/685
- https://github.com/FreeOpcUa/python-opcua/issues/850
- https://github.com/FreeOpcUa/python-opcua/issues/1192

I read, many wonder why the ServerTimestamp is necessary. Yes, it is necessary and equally important as the SourceTimestamp.

Why?
On simple systems the ServerTimestamp is more or less the same than the SourceTimestamp. But on more complex systems with several signal sources on different PCs or Controls it is a different topic. In the past often nobody cared about setting the correct timezone on different controls. As long as the clock showed the right time, everyone was fine. Another issue is time synchronization between the different PCs or controls. Sometimes that is not implemented at all.

Suppose you have 3 different signal sources on 3 different machines for your OPC UA Server. The signals are aggregated from different servers or sent via other protocols. They all provide a Source Timestamp, but their clocks are not synchronized and sometimes timezones are not set accordingly.  On your client side, where you do your analytics, correct order really matters. In such a scenario the SourceTimestamps are worthless. And the ServerTimestamps come to the rescue. They are a great fallback for that kind of scenarios. Everything is synchronized to a common clock.
=> That is the main reason some people only rely on the ServerTimestamps at the moment.

Another interesting scenario for the ServerTimestamp is to compare ServerTimestamp and SourceTimestamp if you signal source is on a different system further away. Then you get the delay time.

 