### PR TITLE
Fix no client callback on StatusCode change

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -698,7 +698,8 @@ class AddressSpace:
         old = attval.value
         attval.value = value
         cbs = []
-        if old.Value != value.Value:  # only send call callback when a value change has happend
+        # only send call callback when a value or status code change has happened
+        if (old.Value != value.Value) or (old.StatusCode != value.StatusCode):  
             cbs = list(attval.datachange_callbacks.items())
 
         for k, v in cbs:


### PR DESCRIPTION
If on the server side only the StatusCode is changed, the clients are not informed. It only works if at the same time there is a change to the value as well. This is incorrect behavior. You should be able to set for example status code BadWaitingForInitialData without changing the value.

I think I ran into the same issue as mentioned here:
https://github.com/FreeOpcUa/python-opcua/issues/375

I extended the check for also checking the StatusCode. In fact I think even more has to be changed, but this is most important.

A client needs to be informed when:
- The value changes OR
- The status code changes OR
- One of the timestamps changes

When subscribing, the client can decide whether he wants to be informed on value, statuscode or timestamp change via the DataChangeFilter. See:
- https://reference.opcfoundation.org/v104/Core/docs/Part4/7.17.2/
- https://reference.opcfoundation.org/v104/Core/docs/Part4/5.12.1/

Good default behavior is to callback on value and status code change.
https://forum.prosysopc.com/forum/opc-ua-java-sdk/datachange-notification-when-value-doesnt-change/

