### PR TITLE
[Fix ZeroDivisionError] RequestedMaxKeepAliveCount

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -565,6 +565,7 @@ class Client:
         Part4 5.13.2: If the requested value is 0, the Server
         shall revise with the smallest supported keep-alive count.
         """
+        period = period or 1000
         return int((self.session_timeout / period) * 0.75)
 
     async def get_namespace_array(self):

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -376,6 +376,10 @@ async def test_subscription_keepalive_count(mocker):
     publish_interval = 75000
     sub = await c.create_subscription(publish_interval, handler)
     assert sub.parameters.RequestedMaxKeepAliveCount == 0
+    # RequestedPublishingInterval == 0
+    publish_interval = 0
+    sub = await c.create_subscription(publish_interval, handler)
+    assert sub.parameters.RequestedMaxKeepAliveCount == 22
 
 
 async def test_subscribe_server_time(opc):


### PR DESCRIPTION
When RequestedPublishingInterval isn't provided, calculating the RequestedMaxKeepAliveCount raises a ZeroDivisionError.

Therefore, let's calculate RequestedMaxKeepAliveCount with a conservative PublishInterval value of 1000ms when this occurs.

Worth noting our server doesn't revise the PublishInterval value, hence will not start the publication with a value of 0.
https://github.com/FreeOpcUa/opcua-asyncio/blob/master/asyncua/server/internal_subscription.py#L50-L51

Fixes #490