### PR TITLE
Also clean names for generated Enums

### DIFF
--- a/asyncua/common/structures.py
+++ b/asyncua/common/structures.py
@@ -23,7 +23,7 @@ _logger = logging.getLogger(__name__)
 
 class EnumType(object):
     def __init__(self, name):
-        self.name = name
+        self.name = clean_name(name)
         self.fields = []
         self.typeid = None
 
@@ -44,7 +44,7 @@ class {0}(IntEnum):
 """.format(self.name)
 
         for EnumeratedValue in self.fields:
-            name = EnumeratedValue.Name
+            name = clean_name(EnumeratedValue.Name)
             value = EnumeratedValue.Value
             code += f"    {name} = {value}\n"
 

--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -108,12 +108,13 @@ def clean_name(name):
     Remove characters that might be present in  OPC UA structures
     but cannot be part of of Python class names
     """
-    newname = re.sub(r'\W+', '_', name)
-    newname = re.sub(r'^[0-9]+', r'_\g<0>', newname)
-
-    if name != newname:
+    if name.isidentifier():
+        return name
+    else:
+        newname = re.sub(r'\W+', '_', name)
+        newname = re.sub(r'^[0-9]+', r'_\g<0>', newname)
         logger.warning("renamed %s to %s due to Python syntax", name, newname)
-    return newname
+        return newname
 
 
 def get_default_value(uatype, enums=None):


### PR DESCRIPTION
Clean up invalid variable names in auto generation of Enums.
I encountered servers which have white spaces in enum types and invalid characters in enum values.

The optimization in "clean_name" doubles the performance, since 99% of names are valid. I tested the performance.