### PR TITLE
check for tasks before cancelling them

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -508,11 +508,14 @@ class Client:
         """
         Close session
         """
-        self._renew_channel_task.cancel()
-        try:
-            await self._renew_channel_task
-        except Exception:
-            _logger.exception("Error while closing secure channel loop")
+        if self._renew_channel_task is not None:
+            self._renew_channel_task.cancel()
+            try:
+                await self._renew_channel_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                _logger.exception("Error while closing secure channel loop")
         return await self.uaclient.close_session(True)
 
     def get_root_node(self):

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -266,7 +266,7 @@ class UaClient:
         await asyncio.wait_for(asyncio.get_running_loop().create_connection(self._make_protocol, host, port), self._timeout)
 
     def disconnect_socket(self):
-        if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
+        if self.protocol and self.protocol.state == UASocketProtocol.CLOSED or self.protocol is None:
             self.logger.warning("disconnect_socket was called but connection is closed")
             return None
         return self.protocol.disconnect_socket()
@@ -282,7 +282,7 @@ class UaClient:
         close secure channel. It seems to trigger a shutdown of socket
         in most servers, so be prepare to reconnect
         """
-        if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
+        if self.protocol and self.protocol.state == UASocketProtocol.CLOSED or self.protocol is None:
             self.logger.warning("close_secure_channel was called but connection is closed")
             return
         return await self.protocol.close_secure_channel()
@@ -311,9 +311,15 @@ class UaClient:
 
     async def close_session(self, delete_subscriptions):
         self.logger.info("close_session")
-        self.protocol.closed = True
-        if self._publish_task and not self._publish_task.done():
+        if self._publish_task and not self._publish_task.done() or self._publish_task is not None:
             self._publish_task.cancel()
+            try:
+                await self._publish_task
+            except asyncio.CancelledError:
+                pass
+        if self.protocol is None:
+            return
+        self.protocol.closed = True
         if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
             self.logger.warning("close_session was called but connection is closed")
             return


### PR DESCRIPTION
Fixes #337.
Have a look at the changes and see if you want the `None` tasks to not trigger a log warning or not.