### PR TITLE
add service result code to log

### DIFF
--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -156,8 +156,8 @@ class UASocketProtocol(asyncio.Protocol):
         data = data.copy()
         typeid = nodeid_from_binary(data)
         if typeid == ua.FourByteNodeId(ua.ObjectIds.ServiceFault_Encoding_DefaultBinary):
-            self.logger.warning("ServiceFault from server received %s", context)
             hdr = struct_from_binary(ua.ResponseHeader, data)
+            self.logger.warning("ServiceFault (%s) from server received %s", hdr.ServiceResult.name, context)
             hdr.ServiceResult.check()
             return False
         return True

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -157,7 +157,7 @@ class UASocketProtocol(asyncio.Protocol):
         typeid = nodeid_from_binary(data)
         if typeid == ua.FourByteNodeId(ua.ObjectIds.ServiceFault_Encoding_DefaultBinary):
             hdr = struct_from_binary(ua.ResponseHeader, data)
-            self.logger.warning("ServiceFault (%s) from server received %s", hdr.ServiceResult.name, context)
+            self.logger.warning("ServiceFault (%s, diagnostics: %s) from server received %s", hdr.ServiceResult.name, hdr.ServiceDiagnostics, context)
             hdr.ServiceResult.check()
             return False
         return True


### PR DESCRIPTION
Having run into 
```
2021-04-08 14:55:44.939 WARNING  asyncua.client.ua_client.UASocketProtocol: ServiceFault from server received  in response to CreateMonitoredItemsRequest
```
and used Wireshark to check for details, I thought it might be useful to have the response code, too.
```
2021-04-08 14:55:44.939 WARNING  asyncua.client.ua_client.UASocketProtocol: ServiceFault (BadTooManyOperations) from server received  in response to CreateMonitoredItemsRequest
```