### PR TITLE
[test_tools] Implement client retry to fix race

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -10,6 +10,7 @@ import asyncio
 from datetime import datetime
 from datetime import timedelta
 import math
+import time
 
 import pytest
 
@@ -1375,3 +1376,21 @@ async def test_custom_method_with_struct(opc):
     result = await opc.opc.nodes.objects.call_method(methodid, mystruct)
 
     assert result.MyUInt32 == [78, 79, 100]
+
+
+def retry(times, sleep, exceptions):
+    def wrapper(func):
+        def fn(*args, **kwargs):
+            attempt = 0
+            while attempt < times:
+                try:
+                    return func(*args, **kwargs)
+                except Exception as e:
+                    if type(e) not in exceptions:
+                        raise e
+                    print(f"Failed with {e}, retry attempt {attempt}")
+                    attempt += 1
+                    time.sleep(sleep)
+            return func(*args, **kwargs)
+        return fn
+    return wrapper


### PR DESCRIPTION
Fix for #522

Implement a client retry decorator for test_tools to workaround the race condition between the server start and first client connect. That's certainly the best approach since the server is running in a separate thread for this specific test and it's consequently difficult to get its status.

I was able to repro by inserting a sleep in [add_server_methods](https://github.com/FreeOpcUa/opcua-asyncio/blob/2dcba36ee25999411521feaf5355702beb790d7d/tests/test_common.py#L26) 

I've performed various tests around the retry function to make sure it only triggers with the provided exception. Let's see if 5s is enough for our validation pipeline.
