### PR TITLE
[Fix] Revert to UTC for request header

### DIFF
--- a/asyncua/ua/uaprotocol_auto.py
+++ b/asyncua/ua/uaprotocol_auto.py
@@ -1,6 +1,6 @@
 """
 Autogenerate code from xml spec
-Date:2021-03-25 13:57:54.246658
+Date:2021-06-03 15:58:52.995576
 """
 
 from datetime import datetime
@@ -2666,7 +2666,7 @@ class RequestHeader:
     data_type = NodeId(ObjectIds.RequestHeader)
 
     AuthenticationToken: SessionAuthenticationToken = field(default_factory=NodeId)
-    Timestamp: UtcTime = field(default_factory=datetime.now)
+    Timestamp: UtcTime = field(default_factory=datetime.utcnow)
     RequestHandle: IntegerId = 0
     ReturnDiagnostics: UInt32 = 0
     AuditEntryId: String = None
@@ -2695,7 +2695,7 @@ class ResponseHeader:
 
     data_type = NodeId(ObjectIds.ResponseHeader)
 
-    Timestamp: UtcTime = field(default_factory=datetime.now)
+    Timestamp: UtcTime = field(default_factory=datetime.utcnow)
     RequestHandle: IntegerId = 0
     ServiceResult: StatusCode = field(default_factory=StatusCode)
     ServiceDiagnostics: DiagnosticInfo = field(default_factory=DiagnosticInfo)
@@ -2918,7 +2918,7 @@ class FindServersOnNetworkResult:
     :vartype Servers: ServerOnNetwork
     """
 
-    LastCounterResetTime: UtcTime = field(default_factory=datetime.now)
+    LastCounterResetTime: UtcTime = field(default_factory=datetime.utcnow)
     Servers: List[ServerOnNetwork] = field(default_factory=list)
 
 
@@ -3547,7 +3547,7 @@ class ChannelSecurityToken:
 
     ChannelId: UInt32 = 0
     TokenId: UInt32 = 0
-    CreatedAt: UtcTime = field(default_factory=datetime.now)
+    CreatedAt: UtcTime = field(default_factory=datetime.utcnow)
     RevisedLifetime: UInt32 = 0
 
 
@@ -4947,7 +4947,7 @@ class ViewDescription:
     data_type = NodeId(ObjectIds.ViewDescription)
 
     ViewId: NodeId = field(default_factory=NodeId)
-    Timestamp: UtcTime = field(default_factory=datetime.now)
+    Timestamp: UtcTime = field(default_factory=datetime.utcnow)
     ViewVersion: UInt32 = 0
 
 
@@ -6292,8 +6292,8 @@ class ReadRawModifiedDetails:
     data_type = NodeId(ObjectIds.ReadRawModifiedDetails)
 
     IsReadModified: Boolean = True
-    StartTime: UtcTime = field(default_factory=datetime.now)
-    EndTime: UtcTime = field(default_factory=datetime.now)
+    StartTime: UtcTime = field(default_factory=datetime.utcnow)
+    EndTime: UtcTime = field(default_factory=datetime.utcnow)
     NumValuesPerNode: Counter = 0
     ReturnBounds: Boolean = True
 
@@ -6358,7 +6358,7 @@ class ModificationInfo:
 
     data_type = NodeId(ObjectIds.ModificationInfo)
 
-    ModificationTime: UtcTime = field(default_factory=datetime.now)
+    ModificationTime: UtcTime = field(default_factory=datetime.utcnow)
     UpdateType: HistoryUpdateType = HistoryUpdateType.Insert
     UserName: String = None
 
@@ -6663,8 +6663,8 @@ class DeleteRawModifiedDetails:
 
     NodeId_: NodeId = field(default_factory=NodeId)
     IsDeleteModified: Boolean = True
-    StartTime: UtcTime = field(default_factory=datetime.now)
-    EndTime: UtcTime = field(default_factory=datetime.now)
+    StartTime: UtcTime = field(default_factory=datetime.utcnow)
+    EndTime: UtcTime = field(default_factory=datetime.utcnow)
 
     @property
     def NodeId(self):
@@ -7003,8 +7003,8 @@ class ReadEventDetails:
     data_type = NodeId(ObjectIds.ReadEventDetails)
 
     NumValuesPerNode: Counter = 0
-    StartTime: UtcTime = field(default_factory=datetime.now)
-    EndTime: UtcTime = field(default_factory=datetime.now)
+    StartTime: UtcTime = field(default_factory=datetime.utcnow)
+    EndTime: UtcTime = field(default_factory=datetime.utcnow)
     Filter: EventFilter = field(default_factory=EventFilter)
 
 
@@ -7053,8 +7053,8 @@ class ReadProcessedDetails:
 
     data_type = NodeId(ObjectIds.ReadProcessedDetails)
 
-    StartTime: UtcTime = field(default_factory=datetime.now)
-    EndTime: UtcTime = field(default_factory=datetime.now)
+    StartTime: UtcTime = field(default_factory=datetime.utcnow)
+    EndTime: UtcTime = field(default_factory=datetime.utcnow)
     ProcessingInterval: Duration = 0
     AggregateType: List[NodeId] = field(default_factory=list)
     AggregateConfiguration_: AggregateConfiguration = field(default_factory=AggregateConfiguration)
@@ -7085,7 +7085,7 @@ class AggregateFilter:
 
     data_type = NodeId(ObjectIds.AggregateFilter)
 
-    StartTime: UtcTime = field(default_factory=datetime.now)
+    StartTime: UtcTime = field(default_factory=datetime.utcnow)
     AggregateType: NodeId = field(default_factory=NodeId)
     ProcessingInterval: Duration = 0
     AggregateConfiguration_: AggregateConfiguration = field(default_factory=AggregateConfiguration)
@@ -7136,7 +7136,7 @@ class AggregateFilterResult:
     :vartype RevisedAggregateConfiguration: AggregateConfiguration
     """
 
-    RevisedStartTime: UtcTime = field(default_factory=datetime.now)
+    RevisedStartTime: UtcTime = field(default_factory=datetime.utcnow)
     RevisedProcessingInterval: Duration = 0
     RevisedAggregateConfiguration: AggregateConfiguration = field(default_factory=AggregateConfiguration)
 
@@ -7991,7 +7991,7 @@ class NotificationMessage:
     data_type = NodeId(ObjectIds.NotificationMessage)
 
     SequenceNumber: Counter = 0
-    PublishTime: UtcTime = field(default_factory=datetime.now)
+    PublishTime: UtcTime = field(default_factory=datetime.utcnow)
     NotificationData: List[ExtensionObject] = field(default_factory=list)
 
 
@@ -8544,7 +8544,7 @@ class BuildInfo:
     ProductName: String = None
     SoftwareVersion: String = None
     BuildNumber: String = None
-    BuildDate: UtcTime = field(default_factory=datetime.now)
+    BuildDate: UtcTime = field(default_factory=datetime.utcnow)
 
 
 @dataclass(frozen=FROZEN)
@@ -8697,8 +8697,8 @@ class ServerStatusDataType:
 
     data_type = NodeId(ObjectIds.ServerStatusDataType)
 
-    StartTime: UtcTime = field(default_factory=datetime.now)
-    CurrentTime: UtcTime = field(default_factory=datetime.now)
+    StartTime: UtcTime = field(default_factory=datetime.utcnow)
+    CurrentTime: UtcTime = field(default_factory=datetime.utcnow)
     State: ServerState = ServerState.Running
     BuildInfo_: BuildInfo = field(default_factory=BuildInfo)
     SecondsTillShutdown: UInt32 = 0
@@ -8871,8 +8871,8 @@ class SessionDiagnosticsDataType:
     LocaleIds: List[LocaleId] = field(default_factory=list)
     ActualSessionTimeout: Duration = 0
     MaxResponseMessageSize: UInt32 = 0
-    ClientConnectionTime: UtcTime = field(default_factory=datetime.now)
-    ClientLastContactTime: UtcTime = field(default_factory=datetime.now)
+    ClientConnectionTime: UtcTime = field(default_factory=datetime.utcnow)
+    ClientLastContactTime: UtcTime = field(default_factory=datetime.utcnow)
     CurrentSubscriptionsCount: UInt32 = 0
     CurrentMonitoredItemsCount: UInt32 = 0
     CurrentPublishRequestsInQueue: UInt32 = 0
@@ -9225,13 +9225,13 @@ class ProgramDiagnosticDataType:
 
     CreateSessionId: NodeId = field(default_factory=NodeId)
     CreateClientName: String = None
-    InvocationCreationTime: UtcTime = field(default_factory=datetime.now)
-    LastTransitionTime: UtcTime = field(default_factory=datetime.now)
+    InvocationCreationTime: UtcTime = field(default_factory=datetime.utcnow)
+    LastTransitionTime: UtcTime = field(default_factory=datetime.utcnow)
     LastMethodCall: String = None
     LastMethodSessionId: NodeId = field(default_factory=NodeId)
     LastMethodInputArguments: List[Argument] = field(default_factory=list)
     LastMethodOutputArguments: List[Argument] = field(default_factory=list)
-    LastMethodCallTime: UtcTime = field(default_factory=datetime.now)
+    LastMethodCallTime: UtcTime = field(default_factory=datetime.utcnow)
     LastMethodReturnStatus: StatusResult = field(default_factory=StatusResult)
 
 
@@ -9268,15 +9268,15 @@ class ProgramDiagnostic2DataType:
 
     CreateSessionId: NodeId = field(default_factory=NodeId)
     CreateClientName: String = None
-    InvocationCreationTime: UtcTime = field(default_factory=datetime.now)
-    LastTransitionTime: UtcTime = field(default_factory=datetime.now)
+    InvocationCreationTime: UtcTime = field(default_factory=datetime.utcnow)
+    LastTransitionTime: UtcTime = field(default_factory=datetime.utcnow)
     LastMethodCall: String = None
     LastMethodSessionId: NodeId = field(default_factory=NodeId)
     LastMethodInputArguments: List[Argument] = field(default_factory=list)
     LastMethodOutputArguments: List[Argument] = field(default_factory=list)
     LastMethodInputValues: List[Variant] = field(default_factory=list)
     LastMethodOutputValues: List[Variant] = field(default_factory=list)
-    LastMethodCallTime: UtcTime = field(default_factory=datetime.now)
+    LastMethodCallTime: UtcTime = field(default_factory=datetime.utcnow)
     LastMethodReturnStatus: StatusResult = field(default_factory=StatusResult)
 
 
@@ -9297,7 +9297,7 @@ class Annotation:
 
     Message: String = None
     UserName: String = None
-    AnnotationTime: UtcTime = field(default_factory=datetime.now)
+    AnnotationTime: UtcTime = field(default_factory=datetime.utcnow)
 
 
 nid = FourByteNodeId(ObjectIds.KeyValuePair_Encoding_DefaultBinary)

--- a/schemas/generate_protocol_python.py
+++ b/schemas/generate_protocol_python.py
@@ -178,7 +178,7 @@ class CodeGenerator:
         if dtype == 'Boolean':
             return 'True'
         if dtype == 'DateTime':
-            return 'field(default_factory=datetime.now)'
+            return 'field(default_factory=datetime.utcnow)'
         if dtype in ('Int16', 'Int32', 'Int64', 'UInt16', 'UInt32', 'UInt64', 'Double', 'Float', 'Byte'):
             return 0
         if dtype in 'ExtensionObject':


### PR DESCRIPTION
## Issue

We broke UTC timestamp with #496 which means clients in a different TZ than the server aren't able to connect anymore. See the stack trace:

```
BadInvalidTimestamp                       Traceback (most recent call last)
<ipython-input-1-7c6bfb3082fd> in <module>
     33         # We create a Client Subscription.
---> 34         subscription = await c.create_subscription(1000, handler)
     35         #nodes = [

~/github/opcua-asyncio/asyncua/client/client.py in create_subscription(self, period, handler, publishing)
    554         subscription = Subscription(self.uaclient, params, handler)
--> 555         await subscription.init()
    556         return subscription

~/github/opcua-asyncio/asyncua/common/subscription.py in init(self)
     86     async def init(self):
---> 87         response = await self.server.create_subscription(self.parameters, callback=self.publish_callback)
     88         self.subscription_id = response.SubscriptionId  # move to data class

~/github/opcua-asyncio/asyncua/client/ua_client.py in create_subscription(self, params, callback)
    450         request.Parameters = params
--> 451         data = await self.protocol.send_request(request)
    452         response = struct_from_binary(ua.CreateSubscriptionResponse, data)

~/github/opcua-asyncio/asyncua/client/ua_client.py in send_request(self, request, timeout, message_type)
    153
--> 154         self.check_answer(data, f" in response to {request.__class__.__name__}")
    155         return data

~/github/opcua-asyncio/asyncua/client/ua_client.py in check_answer(self, data, context)
    162             hdr = struct_from_binary(ua.ResponseHeader, data)
--> 163             hdr.ServiceResult.check()
    164             return False

~/github/opcua-asyncio/asyncua/ua/uatypes.py in check(self)
    334         if not self.is_good():
--> 335             raise UaStatusCodeError(self.value)
    336

BadInvalidTimestamp: "The timestamp is outside the range allowed by the server."(BadInvalidTimestamp)

During handling of the above exception, another exception occurred:

BadInvalidTimestamp                       Traceback (most recent call last)
```

This diff reverts the headers TS to UTC as it is the time standard for OPC-UA: https://reference.opcfoundation.org/v104/Core/docs/Part3/8.38/

## Testing

Client in a different TZ can connect once patched:
```
In [1]: import sys
   ...: sys.path.insert(0, "../")
   ...: import asyncio
   ...: from asyncua import Node
   ...: from asyncua import ua
   ...: from asyncua import Client
   ...:
   ...: class SubscriptionHandler:
   ...:     """
   ...:     The SubscriptionHandler is used to handle the data that is received for the subscription.
   ...:     """
   ...:     def datachange_notification(self, node: Node, val, data):
   ...:         """
   ...:         Callback for asyncua Subscription.
   ...:         This method will be called when the Client received a data change message from the Server.
   ...:         """
   ...:         _logger.info('datachange_notification %r %s', node, val)
   ...: c = Client(url='opc.tcp://127.0.0.1:4901')
   ...: async with c:
   ...:         handler = SubscriptionHandler()
   ...:         subscription = await c.create_subscription(0.001, handler)
   ...:         print(subscription)
<asyncua.common.subscription.Subscription object at 0x7f65a3dc3400>
```