### PR TITLE
[Subscription creation] adjust MaxKeepAliveCount based on RevisedPublishingInterval

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -14,7 +14,7 @@ from ..common.shortcuts import Shortcuts
 from ..common.structures import load_type_definitions, load_enums
 from ..common.structures104 import load_data_type_definitions
 from ..common.utils import create_nonce
-from ..common.ua_utils import value_to_datavalue
+from ..common.ua_utils import value_to_datavalue, copy_dataclass_attr
 from ..crypto import uacrypto, security_policies
 
 _logger = logging.getLogger(__name__)
@@ -531,7 +531,9 @@ class Client:
         """
         return Node(self.uaclient, nodeid)
 
-    async def create_subscription(self, period, handler, publishing=True):
+    async def create_subscription(
+        self, period, handler, publishing=True
+    ) -> Subscription:
         """
         Create a subscription.
         Returns a Subscription object which allows to subscribe to events or data changes on server.
@@ -551,8 +553,53 @@ class Client:
             params.PublishingEnabled = publishing
             params.Priority = 0
         subscription = Subscription(self.uaclient, params, handler)
-        await subscription.init()
+        results = await subscription.init()
+        new_params = self.get_subscription_revised_params(params, results)
+        if new_params:
+            results = await subscription.update(new_params)
+            _logger.info(f"Result from subscription update: {results}")
         return subscription
+
+    def get_subscription_revised_params(
+        self,
+        params: ua.CreateSubscriptionParameters,
+        results: ua.CreateSubscriptionResult,
+    ) -> None:
+        if (
+            results.RevisedPublishingInterval == params.RequestedPublishingInterval
+            and results.RevisedLifetimeCount == params.RequestedLifetimeCount
+            and results.RevisedMaxKeepAliveCount == params.RequestedMaxKeepAliveCount
+        ):
+            return
+        _logger.warning(
+            f"Revised values returned differ from subscription values: {results}"
+        )
+        revised_interval = results.RevisedPublishingInterval
+        # Adjust the MaxKeepAliveCount based on the RevisedPublishInterval when necessary
+        new_keepalive_count = self.get_keepalive_count(revised_interval)
+        if (
+            revised_interval != params.RequestedPublishingInterval
+            and new_keepalive_count != params.RequestedMaxKeepAliveCount
+        ):
+            _logger.info(
+                f"KeepAliveCount will be updated to {new_keepalive_count} "
+                f"for consistency with RevisedPublishInterval"
+            )
+            modified_params = ua.ModifySubscriptionParameters()
+            # copy the existing subscription parameters
+            copy_dataclass_attr(params, modified_params)
+            # then override with the revised values
+            modified_params.RequestedMaxKeepAliveCount = new_keepalive_count
+            modified_params.SubscriptionId = results.SubscriptionId
+            modified_params.RequestedPublishingInterval = (
+                results.RevisedPublishingInterval
+            )
+            modified_params.RequestedPublishingInterval = (
+                results.RevisedPublishingInterval
+            )
+            # update LifetimeCount but chances are it will be re-revised again
+            modified_params.RequestedLifetimeCount = results.RevisedLifetimeCount
+            return modified_params
 
     def get_keepalive_count(self, period) -> int:
         """

--- a/asyncua/common/ua_utils.py
+++ b/asyncua/common/ua_utils.py
@@ -297,3 +297,11 @@ def data_type_to_string(dtype):
     else:
         string = dtype.to_string()
     return string
+
+def copy_dataclass_attr(dc_source, dc_dest) -> None:
+    """
+    Copy the common attributes of dc_source to dc_dest
+    """
+    common_params = set(vars(dc_source)) & set(vars(dc_dest))
+    for c in common_params:
+        setattr(dc_dest, c, getattr(dc_source, c))

--- a/tests/test_uautils.py
+++ b/tests/test_uautils.py
@@ -1,0 +1,30 @@
+import pytest
+from dataclasses import dataclass
+from asyncua.common.ua_utils import copy_dataclass_attr
+
+
+def test_copy_dataclass_attr():
+    @dataclass
+    class A:
+        x: int = 1
+        y: int = 2
+
+    @dataclass
+    class B:
+        y: int = 12
+        z: int = 13
+
+    b = B()
+    a = A()
+
+    assert a.y != b.y
+    copy_dataclass_attr(a, b)
+    assert a.y == b.y == 2
+    assert a.x == 1
+    assert b.z == 13
+
+    b.y = 9
+    copy_dataclass_attr(b, a)
+    assert a.y == b.y == 9
+    assert a.x == 1
+    assert b.z == 13


### PR DESCRIPTION
## Problem statement 
As discussed in #557, the MaxKeepAliveCount has to be adjusted once the server replies with a different `RevisedPublishingInterval` value. 

This change adds the methods to update the parameters of existing subscriptions. Hence, we can capture the `CreateSubscriptionResult`, re-calculate the `MaxKeepAliveCount` when needed and update the sub accordingly.

## Testing
Let's set a PublishInterval of 1ms for a server which only supports 100ms and above, then check that the `MaxKeepAliveCount` value is recalculated and the subscription is modified:
```
2021-06-02 14:19:47,596 - asyncua.client.ua_client.UaClient - DEBUG - create_subscription
2021-06-02 14:19:47,596 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: CreateSubscriptionRequest(TypeId=FourByteNodeId(Identifier=787, NamespaceIndex=0, NodeIdType=<NodeIdType.FourByte: 1>), RequestHeader_=RequestHeader(AuthenticationToken=NodeId(Identifier=b'\x9e\xebjY\x10\xf0\x88ej)\xdc pf\xd1\xec\xbd\xf0W.I\x9c\x84pUH\xf0U"\xa4\xdf\x8c', NamespaceIndex=0, NodeIdType=<NodeIdType.ByteString: 5>), Timestamp=datetime.datetime(2021, 6, 2, 21, 19, 47, 596143), RequestHandle=4, ReturnDiagnostics=0, AuditEntryId=None, TimeoutHint=4000, AdditionalHeader=ExtensionObject(TypeId=NodeId(Identifier=0, NamespaceIndex=0, NodeIdType=<NodeIdType.TwoByte: 0>), Body=None)), Parameters=CreateSubscriptionParameters(RequestedPublishingInterval=1, RequestedLifetimeCount=10000, RequestedMaxKeepAliveCount=2700000, MaxNotificationsPerPublish=10000, PublishingEnabled=True, Priority=0))
2021-06-02 14:19:47,720 - asyncua.client.ua_client.UaClient - INFO - create_subscription success SubscriptionId 48
2021-06-02 14:19:47,720 - asyncua.common.subscription - INFO - Response from subscription creation is CreateSubscriptionResult(SubscriptionId=48, RevisedPublishingInterval=100.0, RevisedLifetimeCount=108000, RevisedMaxKeepAliveCount=36000)
2021-06-02 14:19:47,720 - asyncua.common.subscription - INFO - Subscription created 48
CreateSubscriptionParameters(RequestedPublishingInterval=1, RequestedLifetimeCount=10000, RequestedMaxKeepAliveCount=2700000, MaxNotificationsPerPublish=10000, PublishingEnabled=True, Priority=0)
2021-06-02 14:19:47,720 - asyncua.client.client - WARNING - Revised values returned differ from subscription values: CreateSubscriptionResult(SubscriptionId=48, RevisedPublishingInterval=100.0, RevisedLifetimeCount=108000, RevisedMaxKeepAliveCount=36000)
2021-06-02 14:19:47,720 - asyncua.client.client - INFO - KeepAliveCount will be updated to 27000 for consistency with RevisedPublishInterval
2021-06-02 14:19:47,721 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: ModifySubscriptionRequest(TypeId=FourByteNodeId(Identifier=793, NamespaceIndex=0, NodeIdType=<NodeIdType.FourByte: 1>), RequestHeader_=RequestHeader(AuthenticationToken=NodeId(Identifier=b'\x9e\xebjY\x10\xf0\x88ej)\xdc pf\xd1\xec\xbd\xf0W.I\x9c\x84pUH\xf0U"\xa4\xdf\x8c', NamespaceIndex=0, NodeIdType=<NodeIdType.ByteString: 5>), Timestamp=datetime.datetime(2021, 6, 2, 21, 19, 47, 721012), RequestHandle=5, ReturnDiagnostics=0, AuditEntryId=None, TimeoutHint=4000, AdditionalHeader=ExtensionObject(TypeId=NodeId(Identifier=0, NamespaceIndex=0, NodeIdType=<NodeIdType.TwoByte: 0>), Body=None)), Parameters=ModifySubscriptionParameters(SubscriptionId=48, RequestedPublishingInterval=100.0, RequestedLifetimeCount=108000, RequestedMaxKeepAliveCount=27000, MaxNotificationsPerPublish=10000, Priority=0))
2021-06-02 14:19:47,721 - asyncua.client.ua_client.UaClient - DEBUG - publish []
2021-06-02 14:19:47,721 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: PublishRequest(TypeId=FourByteNodeId(Identifier=826, NamespaceIndex=0, NodeIdType=<NodeIdType.FourByte: 1>), RequestHeader_=RequestHeader(AuthenticationToken=NodeId(Identifier=b'\x9e\xebjY\x10\xf0\x88ej)\xdc pf\xd1\xec\xbd\xf0W.I\x9c\x84pUH\xf0U"\xa4\xdf\x8c', NamespaceIndex=0, NodeIdType=<NodeIdType.ByteString: 5>), Timestamp=datetime.datetime(2021, 6, 2, 21, 19, 47, 721724), RequestHandle=6, ReturnDiagnostics=0, AuditEntryId=None, TimeoutHint=0, AdditionalHeader=ExtensionObject(TypeId=NodeId(Identifier=0, NamespaceIndex=0, NodeIdType=<NodeIdType.TwoByte: 0>), Body=None)), Parameters=PublishParameters(SubscriptionAcknowledgements=[]))
2021-06-02 14:19:47,845 - asyncua.client.ua_client.UaClient - INFO - update_subscription success SubscriptionId 48
2021-06-02 14:19:47,845 - asyncua.common.subscription - INFO - Response from subscription update is ModifySubscriptionResult(RevisedPublishingInterval=100.0, RevisedLifetimeCount=81000, RevisedMaxKeepAliveCount=27000)
2021-06-02 14:19:47,845 - asyncua.common.subscription - INFO - Subscription updated 48
2021-06-02 14:19:47,845 - asyncua.common.subscription - INFO - New parameters attributes: CreateSubscriptionParameters(RequestedPublishingInterval=100.0, RequestedLifetimeCount=108000, RequestedMaxKeepAliveCount=27000, MaxNotificationsPerPublish=10000, PublishingEnabled=True, Priority=0)
2021-06-02 14:19:47,845 - asyncua.client.client - INFO - Result from subscription update: ModifySubscriptionResult(RevisedPublishingInterval=100.0, RevisedLifetimeCount=81000, RevisedMaxKeepAliveCount=27000)
```
Also make sure it's a noop when the value is already in the expected range, here with a `PublishingInterval` of 1000ms:
```
2021-06-02 14:18:33,719 - asyncua.client.ua_client.UaClient - DEBUG - create_subscription
2021-06-02 14:18:33,719 - asyncua.client.ua_client.UASocketProtocol - DEBUG - Sending: CreateSubscriptionRequest(TypeId=FourByteNodeId(Identifier=787, NamespaceIndex=0, NodeIdType=<NodeIdType.FourByte: 1>), RequestHeader_=RequestHeader(AuthenticationToken=NodeId(Identifier=b'\xa0c=`(r\xed\x83\xba\x91\xa03U\x93\xb5\x80\xeb\xc3\xf94N\xec\x94G\x08\xa9\x06\xfa$lC\x91', NamespaceIndex=0, NodeIdType=<NodeIdType.ByteString: 5>), Timestamp=datetime.datetime(2021, 6, 2, 21, 18, 33, 719942), RequestHandle=4, ReturnDiagnostics=0, AuditEntryId=None, TimeoutHint=4000, AdditionalHeader=ExtensionObject(TypeId=NodeId(Identifier=0, NamespaceIndex=0, NodeIdType=<NodeIdType.TwoByte: 0>), Body=None)), Parameters=CreateSubscriptionParameters(RequestedPublishingInterval=1000, RequestedLifetimeCount=10000, RequestedMaxKeepAliveCount=2700, MaxNotificationsPerPublish=10000, PublishingEnabled=True, Priority=0))
2021-06-02 14:18:33,843 - asyncua.client.ua_client.UaClient - INFO - create_subscription success SubscriptionId 47
2021-06-02 14:18:33,843 - asyncua.common.subscription - INFO - Response from subscription creation is CreateSubscriptionResult(SubscriptionId=47, RevisedPublishingInterval=1000.0, RevisedLifetimeCount=8100, RevisedMaxKeepAliveCount=2700)
2021-06-02 14:18:33,843 - asyncua.common.subscription - INFO - Subscription created 47
CreateSubscriptionParameters(RequestedPublishingInterval=1000, RequestedLifetimeCount=10000, RequestedMaxKeepAliveCount=2700, MaxNotificationsPerPublish=10000, PublishingEnabled=True, Priority=0)
2021-06-02 14:18:33,843 - asyncua.client.client - WARNING - Revised values returned differ from subscription values: CreateSubscriptionResult(SubscriptionId=47, RevisedPublishingInterval=1000.0, RevisedLifetimeCount=8100, RevisedMaxKeepAliveCount=2700)
2021-06-02 14:18:33,843 - asyncua.client.ua_client.UaClient - DEBUG - publish []
```
