### PR TITLE
fix tools/uaserver with populate arg

### DIFF
--- a/asyncua/tools.py
+++ b/asyncua/tools.py
@@ -644,6 +644,7 @@ async def _uaserver():
     logging.basicConfig(format="%(levelname)s: %(message)s", level=getattr(logging, args.loglevel))
 
     server = Server()
+    await server.init()
     server.set_endpoint(args.url)
     if args.certificate:
         await server.load_certificate(args.certificate)
@@ -659,17 +660,16 @@ async def _uaserver():
         def multiply(parent, x, y):
             print("multiply method call with parameters: ", x, y)
             return x * y
-
         uri = "http://examples.freeopcua.github.io"
-        idx = server.register_namespace(uri)
+        idx = await server.register_namespace(uri)
         objects = server.nodes.objects
-        myobj = objects.add_object(idx, "MyObject")
-        mywritablevar = myobj.add_variable(idx, "MyWritableVariable", 6.7)
-        mywritablevar.set_writable()  # Set MyVariable to be writable by clients
-        myvar = myobj.add_variable(idx, "MyVariable", 6.7)
-        myarrayvar = myobj.add_variable(idx, "MyVarArray", [6.7, 7.9])
-        myprop = myobj.add_property(idx, "MyProperty", "I am a property")
-        mymethod = myobj.add_method(
+        myobj = await objects.add_object(idx, "MyObject")
+        mywritablevar = await myobj.add_variable(idx, "MyWritableVariable", 6.7)
+        await mywritablevar.set_writable()  # Set MyVariable to be writable by clients
+        myvar = await myobj.add_variable(idx, "MyVariable", 6.7)
+        myarrayvar = await myobj.add_variable(idx, "MyVarArray", [6.7, 7.9])
+        myprop = await myobj.add_property(idx, "MyProperty", "I am a property")
+        mymethod = await myobj.add_method(
             idx,
             "MyMethod",
             multiply,
@@ -678,17 +678,15 @@ async def _uaserver():
         )
 
     try:
-        await server.init()
         async with server:
-
             if args.shell:
                 embed()
             elif args.populate:
                 count = 0
                 while True:
                     await asyncio.sleep(1)
-                    myvar.write_value(math.sin(count / 10))
-                    myarrayvar.write_value([math.sin(count / 10), math.sin(count / 100)])
+                    await myvar.write_value(math.sin(count / 10))
+                    await myarrayvar.write_value([math.sin(count / 10), math.sin(count / 100)])
                     count += 1
             else:
                 while True:


### PR DESCRIPTION
The populate option was broken since most of the calls were missing `await`.

## Test
Server
```
[(fix_tools)]> ./uaserver -p
DEBUG:asyncio:Using selector: EpollSelector
INFO:root:No user manager specified. Using default permissive manager instead.
INFO:asyncua.server.internal_session:Created internal session Internal
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=11715, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=15958, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=15959, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=15960, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=15961, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=15962, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=15963, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=15964, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=16134, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=16135, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.server.address_space:add_node: while adding node NumericNodeId(Identifier=16136, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>), requested parent node NumericNodeId(Identifier=15957, NamespaceIndex=0, NodeIdType=<NodeIdType.Numeric: 2>) does not exists
INFO:asyncua.common.manage_nodes:create_method Node(NodeId(Identifier=1, NamespaceIndex=2, NodeIdType=<NodeIdType.FourByte: 1>))
WARNING:asyncua.server.server:Endpoints other than open requested but private key and certificate are not set.
INFO:asyncua.server.internal_server:starting internal server
INFO:asyncua.server.binary_server_asyncio:Listening on 0.0.0.0:4840
DEBUG:asyncua.server.server:OPC UA Server(opc.tcp://0.0.0.0:4840) server started
```
Client
```
In [4]: client = asyncua.Client(url="opc.tcp://admin@0.0.0.0:4840")
    ...: await client.connect()
    ...: uri = 'http://examples.freeopcua.github.io'
    ...: idx = await client.get_namespace_index(uri)
    ...: var = await client.nodes.root.get_child(["0:Objects", f"{idx}:MyObject", f"{idx}:MyVariable"])
    ...: arr = await client.nodes.root.get_child(["0:Objects", f"{idx}:MyObject", f"{idx}:MyVarArray"])
    ...: for i in range(3):
    ...:     print("My variable", var, await var.read_value())
    ...:     print("My var array", arr, await arr.read_value())
    ...:     time.sleep(1)
    ...: met = await client.nodes.root.get_child(["0:Objects", f"{idx}:MyObject", f"{idx}:MyMethod"])
    ...: print(f"123*123 = {await meth.call_method(meth.nodeid, 123, 123)}")
My variable ns=2;i=3 -0.975430723573431
My var array ns=2;i=4 [-0.975430723573431, -0.6912267715971271]
My variable ns=2;i=3 -0.9485636937183082
My var array ns=2;i=4 [-0.9485636937183082, -0.6839659518769007]
My variable ns=2;i=3 -0.9122189289890194
My var array ns=2;i=4 [-0.9122189289890194, -0.6766367361314569]
123*123 = 15129
```