### PR TITLE
Ignore errors during subscription deletion

### DIFF
--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -53,7 +53,10 @@ class InternalSubscription:
         if self._task:
             self.logger.info("stopping internal subscription %s", self.data.SubscriptionId)
             self._task.cancel()
-            await self._task
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
             self._task = None
         self.monitored_item_srv.delete_all_monitored_items()
 

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -66,7 +66,11 @@ class SubscriptionService:
             else:
                 existing_subs.append(sub)
                 res.append(ua.StatusCode())
-        await asyncio.gather(*[sub.stop() for sub in existing_subs])
+        exceptions = await asyncio.gather(
+            *[sub.stop() for sub in existing_subs], return_exceptions=True
+        )
+        for exc in exceptions:
+            self.logger.warning("Exception while stopping subscription", exc_info=exc)
         return res
 
     def publish(self, acks: Iterable[ua.SubscriptionAcknowledgement]):


### PR DESCRIPTION
When I try to delete subscriptions, I run into `CancelledError` as shown below. I believe this is because we are trying to await the subscription task immediately after cancelling it, which raises the error. When `asyncio.gather` is run the error crashes the server.

```python
Traceback (most recent call last):
  File "...\asyncua\server\uaprocessor.py", line 126, in process_message
    return await self._process_message(typeid, requesthdr, seqhdr, body)
  File "...\asyncua\server\uaprocessor.py", line 190, in _process_message
    await self.session.close_session(deletesubs)
  File "...\asyncua\server\internal_session.py", line 74, in close_session
    await self.delete_subscriptions(self.subscriptions)
  File "...\asyncua\server\internal_session.py", line 180, in delete_subscriptions
    return await self.subscription_service.delete_subscriptions(ids)
  File "...\asyncua\server\subscription_service.py", line 70, in delete_subscriptions
    await asyncio.gather(*[sub.stop() for sub in existing_subs])
concurrent.futures._base.CancelledError
```

This PR adds two safeguards against this:
* `pass` on the `CancelledError` that is raised when you delete the subscription
* Guard against exceptions in `asyncio.gather` and instead log them as warnings