### PR TITLE
External argument to server callbacks

### DIFF
--- a/asyncua/common/callback.py
+++ b/asyncua/common/callback.py
@@ -37,7 +37,7 @@ class Callback(object):
 
 
 class ServerItemCallback(Callback):
-    def __init__(self, request_params, response_params, is_internal=False, user=None):
+    def __init__(self, request_params, response_params, user=None, is_internal=False):
         self.request_params = request_params
         self.response_params = response_params
         self.event_comes_from_internal_session = is_internal

--- a/asyncua/common/callback.py
+++ b/asyncua/common/callback.py
@@ -37,10 +37,10 @@ class Callback(object):
 
 
 class ServerItemCallback(Callback):
-    def __init__(self, request_params, response_params, user=None, is_internal=False):
+    def __init__(self, request_params, response_params, user=None, is_external=False):
         self.request_params = request_params
         self.response_params = response_params
-        self.event_comes_from_internal_session = is_internal
+        self.is_external = is_external
         self.user = user
 
 

--- a/asyncua/common/callback.py
+++ b/asyncua/common/callback.py
@@ -37,9 +37,10 @@ class Callback(object):
 
 
 class ServerItemCallback(Callback):
-    def __init__(self, request_params, response_params, user=None):
+    def __init__(self, request_params, response_params, is_internal=False, user=None):
         self.request_params = request_params
         self.response_params = response_params
+        self.event_comes_from_internal_session = is_internal
         self.user = user
 
 

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -108,10 +108,10 @@ class InternalSession:
         else:
             user = self.user
         await self.iserver.callback_service.dispatch(CallbackType.PreRead,
-                                                     ServerItemCallback(params, None, user))
+                                                     ServerItemCallback(params, None, not self.external, user))
         results = self.iserver.attribute_service.read(params)
         await self.iserver.callback_service.dispatch(CallbackType.PostRead,
-                                                     ServerItemCallback(params, results, user))
+                                                     ServerItemCallback(params, results, not self.external, user))
         return results
 
     async def history_read(self, params) -> Coroutine:
@@ -123,10 +123,10 @@ class InternalSession:
         else:
             user = self.user
         await self.iserver.callback_service.dispatch(CallbackType.PreWrite,
-                                                     ServerItemCallback(params, None, user))
+                                                     ServerItemCallback(params, None, not self.external, user))
         write_result = await self.iserver.attribute_service.write(params, user=user)
         await self.iserver.callback_service.dispatch(CallbackType.PostWrite,
-                                                     ServerItemCallback(params, write_result, user))
+                                                     ServerItemCallback(params, write_result, not self.external, user))
         return write_result
 
     async def browse(self, params):
@@ -163,13 +163,13 @@ class InternalSession:
         """Returns Future"""
         subscription_result = await self.subscription_service.create_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionCreated,
-                                                     ServerItemCallback(params, subscription_result))
+                                                     ServerItemCallback(params, subscription_result, not self.external))
         return subscription_result
 
     async def modify_monitored_items(self, params):
         subscription_result = self.subscription_service.modify_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionModified,
-                                                     ServerItemCallback(params, subscription_result))
+                                                     ServerItemCallback(params, subscription_result, not self.external))
         return subscription_result
 
     def republish(self, params):
@@ -183,7 +183,7 @@ class InternalSession:
         # This is an async method, dues to symmetry with client code
         subscription_result = self.subscription_service.delete_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionDeleted,
-                                                     ServerItemCallback(params, subscription_result))
+                                                     ServerItemCallback(params, subscription_result, not self.external))
 
         return subscription_result
 

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -108,10 +108,10 @@ class InternalSession:
         else:
             user = self.user
         await self.iserver.callback_service.dispatch(CallbackType.PreRead,
-                                                     ServerItemCallback(params, None, not self.external, user))
+                                                     ServerItemCallback(params, None, user, not self.external))
         results = self.iserver.attribute_service.read(params)
         await self.iserver.callback_service.dispatch(CallbackType.PostRead,
-                                                     ServerItemCallback(params, results, not self.external, user))
+                                                     ServerItemCallback(params, results, user, not self.external))
         return results
 
     async def history_read(self, params) -> Coroutine:
@@ -123,10 +123,10 @@ class InternalSession:
         else:
             user = self.user
         await self.iserver.callback_service.dispatch(CallbackType.PreWrite,
-                                                     ServerItemCallback(params, None, not self.external, user))
+                                                     ServerItemCallback(params, None, user, not self.external))
         write_result = await self.iserver.attribute_service.write(params, user=user)
         await self.iserver.callback_service.dispatch(CallbackType.PostWrite,
-                                                     ServerItemCallback(params, write_result, not self.external, user))
+                                                     ServerItemCallback(params, write_result, user, not self.external))
         return write_result
 
     async def browse(self, params):
@@ -163,13 +163,15 @@ class InternalSession:
         """Returns Future"""
         subscription_result = await self.subscription_service.create_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionCreated,
-                                                     ServerItemCallback(params, subscription_result, not self.external))
+                                                     ServerItemCallback(params, subscription_result, None,
+                                                                        not self.external))
         return subscription_result
 
     async def modify_monitored_items(self, params):
         subscription_result = self.subscription_service.modify_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionModified,
-                                                     ServerItemCallback(params, subscription_result, not self.external))
+                                                     ServerItemCallback(params, subscription_result, None,
+                                                                        not self.external))
         return subscription_result
 
     def republish(self, params):
@@ -183,7 +185,8 @@ class InternalSession:
         # This is an async method, dues to symmetry with client code
         subscription_result = self.subscription_service.delete_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionDeleted,
-                                                     ServerItemCallback(params, subscription_result, not self.external))
+                                                     ServerItemCallback(params, subscription_result, None,
+                                                                        not self.external))
 
         return subscription_result
 

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -108,10 +108,10 @@ class InternalSession:
         else:
             user = self.user
         await self.iserver.callback_service.dispatch(CallbackType.PreRead,
-                                                     ServerItemCallback(params, None, user, not self.external))
+                                                     ServerItemCallback(params, None, user, self.external))
         results = self.iserver.attribute_service.read(params)
         await self.iserver.callback_service.dispatch(CallbackType.PostRead,
-                                                     ServerItemCallback(params, results, user, not self.external))
+                                                     ServerItemCallback(params, results, user, self.external))
         return results
 
     async def history_read(self, params) -> Coroutine:
@@ -123,10 +123,10 @@ class InternalSession:
         else:
             user = self.user
         await self.iserver.callback_service.dispatch(CallbackType.PreWrite,
-                                                     ServerItemCallback(params, None, user, not self.external))
+                                                     ServerItemCallback(params, None, user, self.external))
         write_result = await self.iserver.attribute_service.write(params, user=user)
         await self.iserver.callback_service.dispatch(CallbackType.PostWrite,
-                                                     ServerItemCallback(params, write_result, user, not self.external))
+                                                     ServerItemCallback(params, write_result, user, self.external))
         return write_result
 
     async def browse(self, params):
@@ -164,14 +164,14 @@ class InternalSession:
         subscription_result = await self.subscription_service.create_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionCreated,
                                                      ServerItemCallback(params, subscription_result, None,
-                                                                        not self.external))
+                                                                        self.external))
         return subscription_result
 
     async def modify_monitored_items(self, params):
         subscription_result = self.subscription_service.modify_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionModified,
                                                      ServerItemCallback(params, subscription_result, None,
-                                                                        not self.external))
+                                                                        self.external))
         return subscription_result
 
     def republish(self, params):
@@ -186,7 +186,7 @@ class InternalSession:
         subscription_result = self.subscription_service.delete_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionDeleted,
                                                      ServerItemCallback(params, subscription_result, None,
-                                                                        not self.external))
+                                                                        self.external))
 
         return subscription_result
 


### PR DESCRIPTION
Added a field to ServerItemCallback class used by CallbackManager to distinguish events triggered by server itself from one from external clients.