### PR TITLE
[Sec_Policy] Handle server certificate renewal gracefully

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -144,6 +144,10 @@ class Client:
         Call this before connect()
         """
         if server_certificate is None:
+            # Force unencrypted/unsigned SecureChannel to list the endpoints
+            new_policy = ua.SecurityPolicy()
+            self.security_policy = new_policy
+            self.uaclient.security_policy = new_policy
             # load certificate from server's list of endpoints
             endpoints = await self.connect_and_get_server_endpoints()
             endpoint = Client.find_endpoint(endpoints, mode, policy.URI)

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -257,6 +257,13 @@ class TestHaClient:
                 assert isinstance(client.uaclient.security_policy, ua.SecurityPolicy)
                 assert client.security_policy.Mode == security_mode
                 assert client.security_policy.peer_certificate
+
+                # security policy should be cleared once reconnect is called
+                policy = client.security_policy
+                await ha_client.reconnect(client)
+                assert client.security_policy != policy
+                assert client.security_policy.Mode == security_mode
+                assert client.security_policy.peer_certificate
             await ha_client.stop()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
When a client wants to connect with encryption and doesn't provide the server certificate, it first catches the server cert by listing the [endpoints available](https://github.com/FreeOpcUa/opcua-asyncio/blob/fc09e423c7f3e49783b0788ad0933fd836175c15/asyncua/client/client.py#L148). Since the initial client creation has an empty `security_policy`, the SecureChannel required for this listing is unencrypted/unsigned (See [OPC-UA 6.7.4](https://reference.opcfoundation.org/v104/Core/docs/Part6/6.7.4/))

However when the same client instance reconnects, it re-uses the existing security policy (which now contains the server certificate) and creates an encrypted/signed [SecureChannel]((https://github.com/FreeOpcUa/opcua-asyncio/blob/master/asyncua/client/client.py#L289)) for all subsequent operations.

If the server renews its certificate, the client keeps this security policy and every attempt to reconnect (or anything else that requires a SecureChannel) with then fail.

What I suggest is to always reset the `security_policy` when a user wants to use security but doesn't specify a server_certificate. This way we support server cert update and we're consistent across our secure connection attempts.