### PR TITLE
Fix crash if server does not provide DiscoveryUrls

### DIFF
--- a/asyncua/tools.py
+++ b/asyncua/tools.py
@@ -525,8 +525,9 @@ def application_to_strings(app):
     for (n, v) in optionals:
         if v:
             result.append((n, v))
-    for url in app.DiscoveryUrls:
-        result.append(("Discovery URL", url))
+    if app.DiscoveryUrls:
+        for url in app.DiscoveryUrls:
+            result.append(("Discovery URL", url))
     return result  # ['{}: {}'.format(n, v) for (n, v) in result]
 
 


### PR DESCRIPTION
The OPC UA specification does not forbid that a server does not offer DiscoveryUrls. This can lead to a crash when calling the function application_to_strings().

Check DiscoveryUrls for None or empty before iterating to avoid the crash described in #1127 (project python-opcua).