### PR TITLE
Add missing await in uals -l -d

### DIFF
--- a/asyncua/tools.py
+++ b/asyncua/tools.py
@@ -428,7 +428,7 @@ async def _lsprint_long(pnode, depth, indent=""):
         )
         print("")
     for node in await pnode.get_children():
-        attrs = node.read_attributes(
+        attrs = await node.read_attributes(
             [
                 ua.AttributeIds.DisplayName,
                 ua.AttributeIds.BrowseName,


### PR DESCRIPTION
Running uals recursively with -l option gives RuntimeWarning:

```
$ uals -d 3 -l
Browsing node i=84 at opc.tcp://localhost:4840

DisplayName                    NodeId                    BrowseName                DataType   Timestamp                      Value

Traceback (most recent call last):
  File ".../opcua-asyncio/tools/uals", line 11, in <module>
    uals()
  File ".../opcua-asyncio/asyncua/tools.py", line 342, in uals
    asyncio.run(_uals())
  File "/usr/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File ".../opcua-asyncio/asyncua/tools.py", line 368, in _uals
    await _lsprint_long(node, args.depth - 1)
  File ".../opcua-asyncio/asyncua/tools.py", line 442, in _lsprint_long
    name, bname, nclass, mask, umask, dtype, val = [attr.Value.Value for attr in attrs]
TypeError: 'coroutine' object is not iterable
sys:1: RuntimeWarning: coroutine 'Node.read_attributes' was never awaited
```

This was missed in #366.