### PR TITLE
Avoid false warning when deleting subscription

### DIFF
--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -69,9 +69,9 @@ class SubscriptionService:
         stop_results = await asyncio.gather(
             *[sub.stop() for sub in existing_subs], return_exceptions=True
         )
-        for res in stop_results:
+        for stop_result in stop_results:
             if isinstance(res, Exception):
-                self.logger.warning("Exception while stopping subscription", exc_info=res)
+                self.logger.warning("Exception while stopping subscription", exc_info=stop_result)
         return res
 
     def publish(self, acks: Iterable[ua.SubscriptionAcknowledgement]):

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -66,11 +66,12 @@ class SubscriptionService:
             else:
                 existing_subs.append(sub)
                 res.append(ua.StatusCode())
-        exceptions = await asyncio.gather(
+        stop_results = await asyncio.gather(
             *[sub.stop() for sub in existing_subs], return_exceptions=True
         )
-        for exc in exceptions:
-            self.logger.warning("Exception while stopping subscription", exc_info=exc)
+        for res in stop_results:
+            if isinstance(res, Exception):
+                self.logger.warning("Exception while stopping subscription", exc_info=res)
         return res
 
     def publish(self, acks: Iterable[ua.SubscriptionAcknowledgement]):


### PR DESCRIPTION
In https://github.com/FreeOpcUa/opcua-asyncio/pull/648, I added logic to ignore and log errors when deleting subscriptions. In that change, I made a mistake in assuming that `asyncio.gather` would only return a list of exceptions when using `return_exceptions`, when in reality it returns a list containing either the return value or an `Exception` object for each coroutine. This meant that when all the subscriptions were successfully deleted, it would return a list of `None` objects, which then led to the warning message being logged with an empty `exc_info`. In this PR, I added a check to determine if any of the return values from `asyncio.gather` were `Exception`s, and then only log the warning if the subscription deletion actually failed.