### PR TITLE
[PyPi] Missing files

### DIFF
--- a/asyncua/client/ha/__init__.py
+++ b/asyncua/client/ha/__init__.py
@@ -1,0 +1,5 @@
+"""
+Pure Python OPC-UA library
+"""
+
+from .ha_client import HaClient, HaMode, HaSecurityConfig, ConnectionStates

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     author="Olivier Roulet-Dubonnet",
     author_email="olivier.roulet@gmail.com",
     url='http://freeopcua.github.io/',
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     provides=["asyncua"],
     license="GNU Lesser General Public License v3 or later",
     install_requires=["aiofiles", "aiosqlite", "python-dateutil", "pytz", "cryptography", "sortedcontainers"],

--- a/tests/test_ha_client.py
+++ b/tests/test_ha_client.py
@@ -6,7 +6,7 @@ from asyncua.client.ua_client import UASocketProtocol
 from asyncua.common.subscription import Subscription
 from asyncua.crypto import security_policies
 from asyncua.ua.uaerrors import BadSessionClosed
-from asyncua.client.ha.ha_client import (
+from asyncua.client.ha import (
     ConnectionStates,
     HaClient,
     HaMode,
@@ -336,6 +336,7 @@ class TestKeepAlive:
         await ha_client.start()
         for client in ha_client.get_clients():
             await wait_for_status_change(ha_client, client, ConnectionStates.NO_DATA)
+        await ha_client.stop()
 
 
 class TestHaManager:


### PR DESCRIPTION
## Description
The HaClient is missing from the PyPi package

## Repro
```
[/tmp]> curl https://codeload.github.com/FreeOpcUa/opcua-asyncio/tar.gz/refs/tags/v0.9.91 -s -o v0.9.91.tar.gz
[/tmp]> tar xvf v0.9.91.tar.gz > /dev/null 2>&1
[/tmp]> cd opcua-asyncio-0.9.91/
[/tmp/opcua-asyncio-0.9.91]> python setup.py install > /dev/null 2>&1
[/tmp/opcua-asyncio-0.9.91]> find build/ -type f |grep -i ha
build//lib/tests/test_ha_client.py
build//lib/asyncua/ua/uaprotocol_hand.py
```

## Fix
The build rules only look for the packages via `find_packages` in setup.py, making the `ha` subdirectory a package fixes it:
```
[/tmp/opcua-asyncio-0.9.91]> rm -rf build/
[/tmp/opcua-asyncio-0.9.91]> cat asyncua/client/ha/__init__.py
"""
Pure Python OPC-UA library
"""

from .ha_client import HaClient, HaMode, HaSecurityConfig, ConnectionStatesing
[/tmp/opcua-asyncio-0.9.91]> python setup.py build > /dev/null 2>&1
[/tmp/opcua-asyncio-0.9.91]> find build/ -type f |grep -i ha
build//lib/tests/test_ha_client.py
build//lib/asyncua/ua/uaprotocol_hand.py
build//lib/asyncua/client/ha/__init__.py
build//lib/asyncua/client/ha/common.py
build//lib/asyncua/client/ha/ha_client.py
build//lib/asyncua/client/ha/reconciliator.py
build//lib/asyncua/client/ha/virtual_subscription.py
```
## Test
Changing the HaClient test import path to ensure no regression.

@oroulet 2 things:
- Can we republish the release once this has landed?
- Not sure there's much value having the tests included in the build/repository if there are missing dependencies that prevent them from being executed successfully, i.e:
```
[/tmp/opcua-asyncio-0.9.91/build/lib/tests]> pytest .
================================================================= test session starts ==================================================================
platform darwin -- Python 3.8.3, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
rootdir: /private/tmp/opcua-asyncio-0.9.91, configfile: pytest.ini
plugins: asyncio-0.16.0, mock-3.6.1, cov-3.0.0
collected 565 items

test_callback_service.py .                                                                                                                       [  0%]
test_client.py EEEEEEEEE                                                                                                                         [  1%]
test_common.py ...................................................................F.F..........FF............................................... [ 24%]
........................F.F..........FF.....                                                                                                     [ 32%]
test_connections.py ..                                                                                                                           [ 32%]
test_crypto_connect.py ..EEEEEEssEEEEEEEEEEEEEEF                                                                                                 [ 37%]
test_custom_structures.py ..EEEsEEEEEEEEEEEEEEEsEE                                                                                               [ 41%]
test_ha_client.py EEEEEEEEEEEEEEEE                                                                                                               [ 44%]
test_history.py ........................                                                                                                         [ 48%]
test_history_events.py ..................                                                                                                        [ 51%]
test_history_limits.py ......                                                                                                                    [ 52%]
test_permissions.py EEE                                                                                                                          [ 53%]
test_server.py EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE.EEEE                                                                                       [ 60%]
[...]
```
We should probably take a stance on this.

