### PR TITLE
[Safe Client disconnect]

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -513,11 +513,12 @@ class Client:
         """
         Close session
         """
-        self._renew_channel_task.cancel()
-        try:
-            await self._renew_channel_task
-        except Exception:
-            _logger.exception("Error while closing secure channel loop")
+        if self._renew_channel_task:
+            self._renew_channel_task.cancel()
+            try:
+                await self._renew_channel_task
+            except Exception:
+                _logger.exception("Error while closing secure channel loop")
         return await self.uaclient.close_session(True)
 
     def get_root_node(self):

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -284,7 +284,7 @@ class UaClient:
         close secure channel. It seems to trigger a shutdown of socket
         in most servers, so be prepare to reconnect
         """
-        if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
+        if not self.protocol or self.protocol.state == UASocketProtocol.CLOSED:
             self.logger.warning("close_secure_channel was called but connection is closed")
             return
         return await self.protocol.close_secure_channel()
@@ -313,6 +313,9 @@ class UaClient:
 
     async def close_session(self, delete_subscriptions):
         self.logger.info("close_session")
+        if not self.protocol:
+            self.logger.warning("close_session but connection wasn't established")
+            return
         self.protocol.closed = True
         if self._publish_task and not self._publish_task.done():
             self._publish_task.cancel()

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -23,3 +23,7 @@ async def test_max_connections_1(opc):
                 async with Client(f'opc.tcp://127.0.0.1:{port}'):
                     pass
     opc.server.iserver.isession.__class__.max_connections = 1000
+
+async def safe_disconnect():
+    c = Client(url="opc.tcp://example:4840")
+    await c.disconnect()


### PR DESCRIPTION
Follow-up of #711 

Make sure calling disconnect is safe when connection isn't established or half-established (i.e: protocol/transport exist but session is not ready).

## Test1
Call to disconnect is safe when there's no existing connection
```
> python -m IPython
Python 3.10.0 (default, Oct 13 2021, 06:45:00) [Clang 13.0.0 (clang-1300.0.29.3)]

In [1]: import sys; sys.path.insert(0, "~/Documents/github/opcua-asyncio"); import asyncua; c = asyncua.Client(url="opc.tcp://localhost:4840",timeout=10
   ...: );

In [2]: await c.disconnect()
close_session but connection wasn't established
close_secure_channel was called but connection is closed

In [3]:
```
## Test2
Ensure that call to disconnect is safe when there's no session established.
To simulate this, I add delay to the server internal_session on session creation. I check that the client connects and disconnects from the server logs. Finally, the client doesn't raise any error.
```
> python -m IPython
Python 3.10.0 (default, Oct 13 2021, 06:45:00) [Clang 13.0.0 (clang-1300.0.29.3)]
In [1]: import sys; sys.path.insert(0, "~/Documents/github/opcua-asyncio"); import asyncua; c = asyncua.Client(url="opc.tcp://localhost:4840",timeout=10
   ...: ); import threading; import asyncio;

In [2]:

In [2]: async def connect(c):
   ...:     await c.connect()
   ...:

In [3]: async def disco(c):
   ...:     await c.disconnect()
   ...:

In [4]: L = await asyncio.gather(connect(c), disco(c))
close_session but connection wasn't established
close_secure_channel was called but connection is closed

In [5]: quit;
```