### PR TITLE
Changes to xmlimporter to load customn data types when needed

### DIFF
--- a/asyncua/common/ua_utils.py
+++ b/asyncua/common/ua_utils.py
@@ -132,6 +132,9 @@ def string_to_val(string, vtype):
         val = ua.StatusCode(string)
     elif vtype == ua.VariantType.Guid:
         val = uuid.UUID(string)
+    elif issubclass(vtype, Enum):
+        enum_int = int(string.rsplit('_', 1)[1])
+        val = vtype(enum_int)
     else:
         # FIXME: Some types are probably missing!
         raise NotImplementedError

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -355,7 +355,11 @@ class XmlImporter:
         raise Exception("Error no alias found for extension class", name)
 
     def _make_ext_obj(self, obj):
-        extclass = self._get_ext_class(obj.objname)
+        try:
+            extclass = self._get_ext_class(obj.objname)
+        except Exception:
+            await self.server.load_data_type_definitions()      # load new data type definitions since a customn class should be created
+            extclass = self._get_ext_class(obj.objname)
         args = {}
         for name, val in obj.body:
             if not isinstance(val, list):

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -326,7 +326,7 @@ class XmlImporter:
         attrs.DisplayName = ua.LocalizedText(obj.displayname)
         attrs.DataType = obj.datatype
         if obj.value is not None:
-            attrs.Value = self._add_variable_value(obj, )
+            attrs.Value = await self._add_variable_value(obj, )
         if obj.rank:
             attrs.ValueRank = obj.rank
         if obj.accesslevel:
@@ -354,7 +354,7 @@ class XmlImporter:
             raise Exception("Error no extension class registered ", name, nodeid)
         raise Exception("Error no alias found for extension class", name)
 
-    def _make_ext_obj(self, obj):
+    async def _make_ext_obj(self, obj):
         try:
             extclass = self._get_ext_class(obj.objname)
         except Exception:
@@ -418,7 +418,7 @@ class XmlImporter:
         else:
             raise RuntimeError(f"Could not handle type {atttype} of type {type(atttype)}")
 
-    def _add_variable_value(self, obj):
+    async def _add_variable_value(self, obj):
         """
         Returns the value for a Variable based on the objects value type.
         """
@@ -426,7 +426,7 @@ class XmlImporter:
         if obj.valuetype == "ListOfExtensionObject":
             values = []
             for ext in obj.value:
-                extobj = self._make_ext_obj(ext)
+                extobj = await self._make_ext_obj(ext)
                 values.append(extobj)
             return ua.Variant(values, ua.VariantType.ExtensionObject)
         if obj.valuetype == "ListOfGuid":
@@ -439,7 +439,7 @@ class XmlImporter:
                 return ua.Variant([ua.LocalizedText(Text=item["Text"], Locale=item["Locale"]) for item in obj.value])
             return ua.Variant([getattr(ua, vtype)(v) for v in obj.value])
         if obj.valuetype == "ExtensionObject":
-            extobj = self._make_ext_obj(obj.value)
+            extobj = await self._make_ext_obj(obj.value)
             return ua.Variant(extobj, getattr(ua.VariantType, obj.valuetype))
         if obj.valuetype == "Guid":
             return ua.Variant(uuid.UUID(obj.value), getattr(ua.VariantType, obj.valuetype))

--- a/asyncua/common/xmlparser.py
+++ b/asyncua/common/xmlparser.py
@@ -17,10 +17,12 @@ def ua_type_to_python(val, uatype_as_str):
     """
     Converts a string value to a python value according to ua_utils.
     """
-    try:
+    if hasattr(ua.VariantType, uatype_as_str):
         return string_to_val(val, getattr(ua.VariantType, uatype_as_str))
-    except:
+    elif hasattr(ua, uatype_as_str):
         return string_to_val(val, getattr(ua, uatype_as_str))
+    else:
+        raise ValueError
 
 
 def _to_bool(val):

--- a/asyncua/common/xmlparser.py
+++ b/asyncua/common/xmlparser.py
@@ -17,7 +17,10 @@ def ua_type_to_python(val, uatype_as_str):
     """
     Converts a string value to a python value according to ua_utils.
     """
-    return string_to_val(val, getattr(ua.VariantType, uatype_as_str))
+    try:
+        return string_to_val(val, getattr(ua.VariantType, uatype_as_str))
+    except:
+        return string_to_val(val, getattr(ua, uatype_as_str))
 
 
 def _to_bool(val):


### PR DESCRIPTION
This is a fix I made concerning:

https://github.com/FreeOpcUa/python-opcua/issues/1368

It allows the xmlimporter to use customn data types that are imported in the same sequence when being used in variables. This was necessary for the I40AAS companion spec found here:

https://github.com/OPCFoundation/UA-Nodeset/tree/v1.04/I4AAS

