### PR TITLE
[HaClient] Allow init from executor

### DIFF
--- a/asyncua/client/ha/ha_client.py
+++ b/asyncua/client/ha/ha_client.py
@@ -116,9 +116,7 @@ class HaClient:
         self._reconciliator_task: Dict[Reconciliator, asyncio.Task] = {}
         self._gen_sub: Generator[str, None, None] = self.generate_sub_name()
 
-        # The locks must be created in async method!
-        # caling get_running_loop just to make sure we crash if not called in async method
-        _ = asyncio.get_running_loop()
+        # An event loop must be set in the current thread
         self._url_to_reset_lock = asyncio.Lock()
         self._ideal_map_lock: asyncio.Lock = asyncio.Lock()
         self._client_lock: asyncio.Lock = asyncio.Lock()

--- a/asyncua/client/ha/reconciliator.py
+++ b/asyncua/client/ha/reconciliator.py
@@ -54,7 +54,7 @@ class Reconciliator:
         self.timer = timer
         self.ha_client = ha_client
         self.is_running = False
-        _ = asyncio.get_running_loop()  # jsut to ensure we are inside async method
+        # An event loop must be set in the current thread
         self.stop_event = asyncio.Event()
 
         self.real_map: Dict[str, SortedDict] = {}


### PR DESCRIPTION
With py3.10, high level asyncio API can't specify the event_loop argument anymore.

Consequently, When using thread dedicated to run the event_.loop, we now need to instantiate object like asyncio.Lock within the thread. However, the event loop can't be running before creating these objects as `loop.run_for_ever()` must be the background running thread process. Therefore, we can't have "get_running_loop()" calls in object constructors (like HaClient) when used with executors.

Before
```
In [15]: def get_t():
    ...:     loop = asyncio.new_event_loop()
    ...:     t = T()
    ...:     loop.run_for_ever()

In [16]: class T:
    ...:     def __init__(self, loop):
    ...:         asyncio.set_event_loop(loop)
    ...:         asyncio.get_running_loop()
    ...:         self.l = asyncio.Lock()
    ...:         print("Lock created")
    ...:

In [17]: t = Thread(target=get_t);t.start()

Exception in thread Thread-9:
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/threading.py", line 932, in _bootstrap_inner
In [41]:     self.run()
  File "/usr/local//lib/python3.10/threading.py", line 870, in run
In [41]:     self._target(*self._args, **self._kwargs)
  File "<ipython-input-32-c4a1ea4cfdac>", line 3, in get_t
  File "<ipython-input-39-ebeae10dd173>", line 4, in __init__
RuntimeError: no running event loop
```
After

```
In [15]: def get_t():
    ...:     loop = asyncio.new_event_loop()
    ...:     t = T()
    ...:     loop.run_for_ever()

In [16]: class T:
    ...:     def __init__(self, loop):
    ...:         asyncio.set_event_loop(loop)
    ...:         self.l = asyncio.Lock()
    ...:         print("Lock created")
    ...:

In [17]: t = Thread(target=get_t);t.start()

Lock created

```