### PR TITLE
Windows: Crypto Type Error Fix

### DIFF
--- a/asyncua/common/events.py
+++ b/asyncua/common/events.py
@@ -14,7 +14,7 @@ class Event:
     Events are used to trigger events on server side and are
     sent to clients for every events from server
 
-    Developper Warning:
+    Developer Warning:
     On server side the data type of attributes should be known, thus
     add properties using the add_property method!!!
     """

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -263,7 +263,7 @@ class Subscription:
                         ) -> Union[int, List[Union[int, ua.StatusCode]]]:
         """
         Private low level method for subscribing.
-        :param nodes: One Node or an Iterable og Nodes.
+        :param nodes: One Node or an Iterable of Nodes.
         :param attr: ua.AttributeId
         :param mfilter: MonitoringFilter
         :param queuesize: queue size

--- a/asyncua/crypto/uacrypto.py
+++ b/asyncua/crypto/uacrypto.py
@@ -121,7 +121,7 @@ def encrypt_rsa15(public_key, data):
 
 def decrypt_rsa_oaep(private_key, data):
     text = private_key.decrypt(
-        data,
+        bytes(data),
         padding.OAEP(
             mgf=padding.MGF1(algorithm=hashes.SHA1()),
             algorithm=hashes.SHA1(),


### PR DESCRIPTION
# Description

This pull request should contain a fix for issue #752. I am really not sure, if I should also add additional `bytes` calls to the other encryption and decryption functions of `uacrypto.py`? 

At least for my command line tool – based on `opcua-asyncio` – the additional `bytes` call did not introduce problems on my other testing platform (macOS).