### PR TITLE
Fix misplaced error message

### DIFF
--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -368,7 +368,6 @@ class {name}({enum_type}):
         name = clean_name(sfield.Name)
         value = sfield.Value if not option_set else (1 << sfield.Value)
         code += f"    {name} = {value}\n"
-    logger.error(f"{name} - {sfield} {option_set} {code}")
     return code
 
 


### PR DESCRIPTION
Parsing custom enumerations no longer logs an error in case of success. Same as in parsing of custom structures.