### PR TITLE
Introduce type hinting into address_space.py for online discussion

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -508,16 +508,16 @@ class NodeManagementService:
 
     def _add_node_attr(
         self,
-        item: __TYPE_ATTRIBUTES,
+        attributes: __TYPE_ATTRIBUTES,
         nodedata: NodeData,
         name: str,
         vtype: VariantType = None,
         add_timestamps: bool = False,
         is_array: bool = False
     ):
-        if item.SpecifiedAttributes & getattr(ua.NodeAttributesMask, name):
+        if attributes.SpecifiedAttributes & getattr(ua.NodeAttributesMask, name):
             dv = ua.DataValue(
-                ua.Variant(getattr(item, name), vtype, is_array=is_array),
+                ua.Variant(getattr(attributes, name), vtype, is_array=is_array),
                 SourceTimestamp=datetime.utcnow() if add_timestamps else None,
             )
             nodedata.attributes[getattr(ua.AttributeIds, name)] = AttributeValue(dv)

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -15,7 +15,7 @@ from asyncua.ua.attribute_ids import AttributeIds
 if TYPE_CHECKING:
     from typing import Callable, Dict, List, Union
     from asyncua.ua.uaprotocol_auto import AddNodesItem
-    from asyncua.ua.uatypes import ExtensionObject, NodeId, DataValue, NumericNodeId
+    from asyncua.ua.uatypes import ExtensionObject, NodeId, DataValue
     from asyncua.ua.uaprotocol_auto import (
         BrowsePath, BrowseParameters, RelativePathElement, BrowseResult,
         BrowseDescription, ReadParameters, WriteParameters, ReferenceDescription
@@ -153,14 +153,14 @@ class ViewService(object):
             oktypes.remove(ua.NodeId(ua.ObjectIds.HasSubtype))
         return ref2 in oktypes
 
-    def _get_sub_ref(self, ref: NodeId):
-        res = []
+    def _get_sub_ref(self, ref: NodeId) -> List[NodeId]:
+        res: List[NodeId] = []
         nodedata = self._aspace[ref]
         if nodedata is not None:
-            for ref in nodedata.references:
-                if ref.ReferenceTypeId.Identifier == ua.ObjectIds.HasSubtype and ref.IsForward:
-                    res.append(ref.NodeId)
-                    res += self._get_sub_ref(ref.NodeId)
+            for ref_desc in nodedata.references:
+                if ref_desc.ReferenceTypeId.Identifier == ua.ObjectIds.HasSubtype and ref_desc.IsForward:
+                    res.append(ref_desc.NodeId)
+                    res += self._get_sub_ref(ref_desc.NodeId)
         return res
 
     def _suitable_direction(self, direction: ua.BrowseDirection, isforward: bool) -> bool:
@@ -577,28 +577,28 @@ class AddressSpace:
 
     def __init__(self):
         self.logger = logging.getLogger(__name__)
-        self._nodes: Dict[NumericNodeId, NodeData] = {}
+        self._nodes: Dict[NodeId, NodeData] = {}
         self._datachange_callback_counter = 200
         self._handle_to_attribute_map = {}
         self._default_idx = 2
         self._nodeid_counter = {0: 20000, 1: 2000}
 
-    def __getitem__(self, nodeid: NumericNodeId) -> NodeData:
+    def __getitem__(self, nodeid: NodeId) -> NodeData:
         return self._nodes.__getitem__(nodeid)
 
-    def get(self, nodeid: NumericNodeId) -> Union[NodeData, None]:
+    def get(self, nodeid: NodeId) -> Union[NodeData, None]:
         return self._nodes.get(nodeid, None) # Fixme This is another behaviour than __getitem__ where an exception is thrown, right?
 
-    def __setitem__(self, nodeid: NumericNodeId, value: NodeData):
+    def __setitem__(self, nodeid: NodeId, value: NodeData):
         return self._nodes.__setitem__(nodeid, value)
 
-    def __contains__(self, nodeid: NumericNodeId) -> bool:
+    def __contains__(self, nodeid: NodeId) -> bool:
         return self._nodes.__contains__(nodeid)
 
-    def __delitem__(self, nodeid: NumericNodeId):
+    def __delitem__(self, nodeid: NodeId):
         self._nodes.__delitem__(nodeid)
 
-    def generate_nodeid(self, idx: Union[int, None] = None):
+    def generate_nodeid(self, idx: Union[int, None] = None) -> NodeId:
         if idx is None:
             idx = self._default_idx
         if idx in self._nodeid_counter:

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -97,7 +97,10 @@ class AttributeService:
                 al = self._aspace.read_attribute_value(writevalue.NodeId, ua.AttributeIds.AccessLevel)
                 ual = self._aspace.read_attribute_value(writevalue.NodeId, ua.AttributeIds.UserAccessLevel)
                 if (
-                    not al.StatusCode.is_good() # FIXME Check al and ual for None or prevent them from being None
+                    al.StatusCode is None
+                    or al.Value is None
+                    or ual.Value is None
+                    or not al.StatusCode.is_good()
                     or not ua.ua_binary.test_bit(al.Value.Value, ua.AccessLevel.CurrentWrite)
                     or not ua.ua_binary.test_bit(ual.Value.Value, ua.AccessLevel.CurrentWrite)
                 ):

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -27,7 +27,9 @@ _logger = logging.getLogger(__name__)
 
 
 class AttributeValue(object):
-    # FIXME: What is the purpose of this class?
+    """
+    This class implements the value of an attribute.
+    """
     def __init__(self, value: DataValue):
         self.value = value
         self.value_callback: Union[Callable[[], None], None] = None
@@ -40,7 +42,9 @@ class AttributeValue(object):
 
 
 class NodeData:
-    # FIXME: What is the purpose of this class?
+    """
+    This class implements a node in the address space.
+    """
     def __init__(self, nodeid: NodeId):
         self.nodeid = nodeid
         self.attributes: Dict[AttributeIds, AttributeValue] = {}
@@ -93,7 +97,10 @@ class AttributeService:
 
 
 class ViewService(object):
-    # FIXME: What is the purpose of this class?
+    """
+    This class implements the view service set of the opc ua standard.
+    https://reference.opcfoundation.org/v104/Core/docs/Part4/5.8.1/
+    """
     def __init__(self, aspace: AddressSpace):
         self.logger = logging.getLogger(__name__)
         self._aspace: AddressSpace = aspace

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -54,7 +54,10 @@ class NodeData:
 
 
 class AttributeService:
-    # FIXME: What is the purpose of this class?
+    """
+    This class implements the attribute service set defined in the opc ua standard.
+    https://reference.opcfoundation.org/v104/Core/docs/Part4/5.10.1/
+    """
     def __init__(self, aspace: AddressSpace):
         self.logger = logging.getLogger(__name__)
         self._aspace: AddressSpace = aspace

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -668,9 +668,9 @@ class AddressSpace:
     def keys(self):
         return self._nodes.keys()
 
-    def empty(self): # FIXME: missleading name empty, better clear or reset, but could be braking change
+    def clear(self): # FIXME: missleading name empty, better clear or reset, but could be braking change
         """Delete all nodes in address space"""
-        self._nodes = {}
+        self._nodes.clear()
 
     def dump(self, path):
         """

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -671,7 +671,7 @@ class AddressSpace:
     def keys(self):
         return self._nodes.keys()
 
-    def clear(self): # FIXME: missleading name empty, better clear or reset, but could be braking change
+    def clear(self):
         """Delete all nodes in address space"""
         self._nodes.clear()
 

--- a/asyncua/ua/uaprotocol_auto.py
+++ b/asyncua/ua/uaprotocol_auto.py
@@ -5019,7 +5019,7 @@ class ReferenceDescription:
     data_type = NodeId(ObjectIds.ReferenceDescription)
 
     ReferenceTypeId: NodeId = field(default_factory=NodeId)
-    IsForward: Boolean = True
+    IsForward: Boolean = True # FIXME This should be bool, right? We cannot work with Boolean because this raises linter errors and the solution Boolean(True) is unaccetable
     NodeId: ExpandedNodeId = field(default_factory=ExpandedNodeId)
     BrowseName: QualifiedName = field(default_factory=QualifiedName)
     DisplayName: LocalizedText = field(default_factory=LocalizedText)

--- a/asyncua/ua/uaprotocol_auto.py
+++ b/asyncua/ua/uaprotocol_auto.py
@@ -5300,7 +5300,7 @@ class BrowsePathTarget:
 
     data_type = NodeId(ObjectIds.BrowsePathTarget)
 
-    TargetId: ExpandedNodeId = field(default_factory=ExpandedNodeId)
+    TargetId: ExpandedNodeId = field(default_factory=ExpandedNodeId) # FIXME: ExpandedNodeId raises type hinting errors because we assign the parent class NodeId and childs to this attribute.
     RemainingPathIndex: Index = 0
 
 

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -942,7 +942,7 @@ class DataValue:
     Encoding: Byte = field(default=0, repr=False, init=False, compare=False)
     Value: Optional[Variant] = None
     StatusCode_: Optional[StatusCode] = field(default_factory=StatusCode)
-    SourceTimestamp: Optional[DateTime] = None
+    SourceTimestamp: Optional[DateTime] = None # FIXME type DateType raises type hinting errors because datetime is assigned
     ServerTimestamp: Optional[DateTime] = None
     SourcePicoseconds: Optional[UInt16] = None
     ServerPicoseconds: Optional[UInt16] = None


### PR DESCRIPTION
Hi everybody,
I started with issue #594 but got stuck in the code because I had to double check each call to understand parameters and whats going on. I started to add some type hinting for each discovery and at the end I was adding type hinting instead of fixing the issue.

Please let me know, if your are interested in code quality improvements. - Feel free to stop it here. But for me, things are getting much better now and this was only the start of this journey.. :-)

While swimming through the code i got some points (see added Fixme/ question comments) I would like to ask the community.

1. The access to _nodes look ugly and complicated to me. Is there a reason why we do it this way?
2. ua.StatusCode is typed as UInt32 but the constructor is called with int. Is this UInt32 data type forced by the standard? - I assume yes, I would like to think about an type hinting correct form.

Thanks!
