### PR TITLE
fix hardcoded field serializer for Encoding field

### DIFF
--- a/asyncua/ua/ua_binary.py
+++ b/asyncua/ua/ua_binary.py
@@ -277,18 +277,18 @@ def create_dataclass_serializer(dataclazz):
         in enumerate(filter(lambda f: type_is_union(f.type), data_fields))
     ]
 
-    def serialize_encoding(obj):
+    def enc_value(obj):
         enc = 0
         for name, enc_val in union_fields_encodings:
             if obj.__dict__[name] is not None:
                 enc |= enc_val
-        return Primitives.Byte.pack(enc)
+        return enc
 
     encoding_functions = [(f.name, field_serializer(f)) for f in data_fields]
 
     def serialize(obj):
         return b''.join(
-            serialize_encoding(obj) if name == 'Encoding'
+            serializer(enc_value(obj)) if name == 'Encoding'
             else serializer(obj.__dict__[name])
             for name, serializer in encoding_functions
         )


### PR DESCRIPTION
The serializer for the Encoding field is hardcoded at the moment to "Byte". This prevented the use of Optionals and Unions as the OPCUA v104 specification expects it to be UInt32 in both cases, even tough the field type of the Encoding field was set correctly to UInt32 (see https://reference.opcfoundation.org/v104/Core/docs/Part6/5.2.7/ and https://reference.opcfoundation.org/v104/Core/docs/Part6/5.2.8/). This can simply be fixed by using the field serializer also for the encoding field and should still work correctly for Encoding field with type "Byte".