### PR TITLE
fix: ArrayDimensions of Structures xml_importer

### DIFF
--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -596,7 +596,7 @@ class XmlImporter:
             f.IsOptional = field.optional
             if f.IsOptional:
                 optional = True
-            if field.arraydim == "" or field.arraydim is None:
+            if field.arraydim is None:
                 f.ArrayDimensions = field.arraydim
             else:
                 f.ArrayDimensions = [int(i) for i in field.arraydim.split(",")]

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -596,7 +596,10 @@ class XmlImporter:
             f.IsOptional = field.optional
             if f.IsOptional:
                 optional = True
-            f.ArrayDimensions = field.arraydim
+            if field.arraydim == "" or field.arraydim is None:
+                f.ArrayDimensions = field.arraydim
+            else:
+                f.ArrayDimensions = [int(i) for i in field.arraydim.split(",")]
             f.Description = ua.LocalizedText(Text=field.desc)
             sdef.Fields.append(f)
         if optional:

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -596,10 +596,11 @@ class XmlImporter:
             f.IsOptional = field.optional
             if f.IsOptional:
                 optional = True
-            if field.arraydim is None:
+            try:
+                dimensions_list = [int(i) for i in field.arraydim.split(",")]
+                f.ArrayDimensions = dimensions_list
+            except Exception:
                 f.ArrayDimensions = field.arraydim
-            else:
-                f.ArrayDimensions = [int(i) for i in field.arraydim.split(",")]
             f.Description = ua.LocalizedText(Text=field.desc)
             sdef.Fields.append(f)
         if optional:


### PR DESCRIPTION
Closes: https://github.com/FreeOpcUa/opcua-asyncio/issues/774

I think that after importing of XML with custom structures, ArrayDimension attribute is set as a String, rather than List.Thus, in the issue 774, server writes `1 is not a instance of "list"!` (1 here is ArrayDimension), and send DataType Node to client with None attribute of ArrayDimension. Thus client loads `await client.load_data_type_definitions() `  without any infromation about Dimension.

This is my fix to this problem, not 100% sure though. I ran pytest on version 0.9.92 with and without a fix, and it yelled same result. 
