### PR TITLE
__bytes__ on the Buffer returning non-bytes

### DIFF
--- a/asyncua/common/utils.py
+++ b/asyncua/common/utils.py
@@ -49,7 +49,7 @@ class Buffer:
 
     def __bytes__(self):
         """Return remains of buffer as bytes."""
-        return self._data[self._cur_pos:]
+        return bytes(self._data[self._cur_pos:])
 
     def read(self, size):
         """


### PR DESCRIPTION
__bytes__ on the Buffer object is sometimes returning a bytearray instead of bytes.

Traceback (most recent call last):
  File "C:\Users\ddeason\PycharmProjects\opcua_test\venv\lib\site-packages\asyncua\client\ua_client.py", line 88, in _process_received_data
    data = bytes(buf)
TypeError: __bytes__ returned non-bytes (type bytearray)