### PR TITLE
asyncua.ua.uatypes.SByte and asyncua.ua.uatypes.Byte inherit from int instead of bytes

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -77,11 +77,11 @@ def type_string_from_type(uatype):
     return uatype.__name__
 
 
-class SByte(bytes):
+class SByte(int):
     pass
 
 
-class Byte(bytes):
+class Byte(int):
     pass
 
 


### PR DESCRIPTION
This fixes a bug I discovered.

Steps to reproduce:
1) run the script below

        import asyncio
        from asyncua import ua, Server
        
        
        async def main():
            server = Server()
            await server.init()
            server.set_endpoint('opc.tcp://0.0.0.0:4840/')
        
            uri = 'http://bugs.freeopcua.github.io'
            idx = await server.register_namespace(uri)
        
            myobj = await server.nodes.objects.add_object(idx, 'MyObject')
        
            await myobj.add_variable(idx, 'SByte', ua.uatypes.SByte(-128))  # TODO: raises an exception
            # await myobj.add_variable(idx, 'SByte', ua.uatypes.SByte(127))  # TODO: the value is not an integer but a byte-string
            await myobj.add_variable(idx, 'Byte', ua.uatypes.Byte(255))  # TODO: the value is not an integer but a byte-string
        
            await myobj.add_variable(idx, 'Int16', ua.uatypes.Int16(-32768))
            await myobj.add_variable(idx, 'UInt16', ua.uatypes.UInt16(65535))
        
            async with server:
                while True:
                    await asyncio.sleep(1)
        
        
        if __name__ == '__main__':
            asyncio.run(main(), debug=True)

2) connect with an OPC UA client (i.e. opcua-client) and check that `SByte` and `Byte` can be read.