### PR TITLE
Create monitored items of objects of a EventType

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,11 @@ pytest_runner = ['pytest-runner'] if needs_pytest else []
 
 setup(
     name="asyncua",
-    version="0.9.92",
-    description="Pure Python OPC-UA client and server library",
+    version="0.9.92-kuz",
+    description="Pure Python OPC-UA client and server library modified by KUZ MSR-Members",
     long_description=long_description,
     long_description_content_type='text/markdown',
-    author="Olivier Roulet-Dubonnet",
+    author="Olivier Roulet-Dubonnet, Artur Jurk",
     author_email="olivier.roulet@gmail.com",
     url='http://freeopcua.github.io/',
     packages=find_packages(exclude=["tests"]),


### PR DESCRIPTION
The LocalCycleParametersEventType of Euromap83 Specification has its properties and variables wrapped into objects.  
To monitor these items on subscription, one needs to descend the tree of objects and add their properties and variables to the list of monitored items.  
In opcua-asyncio:0.9.92 the case of EventTypes having objects is not covered, only properties and variables with subproperties.  
  
Setting the TypeDefinitionId for the items to monitor to the EventType ID is fixed.  
In opcua-asyncio:0.9.92 it is set to the default value of 0, so that the client cannot find the type definition of some monitored items.