### PR TITLE
enable mypy

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest
+        python -m pip install flake8 pytest mypy
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         if [ -f dev_requirements.txt ]; then pip install -r dev_requirements.txt; fi
     - name: Lint with flake8
@@ -35,6 +35,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --statistics
+    - name: Lint with mypy
+      run: |
+        python -m pip install types-aiofiles types-python-dateutil types-pytz
+        python -m mypy --show-error-code asyncua/
     - name: Test with pytest
       run: |
         pytest -v -s

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -566,7 +566,7 @@ class Client:
             _logger.info(f"Result from subscription update: {results}")
         return subscription
 
-    def get_subscription_revised_params(
+    def get_subscription_revised_params(  # type: ignore
         self,
         params: ua.CreateSubscriptionParameters,
         results: ua.CreateSubscriptionResult,
@@ -576,7 +576,7 @@ class Client:
             and results.RevisedLifetimeCount == params.RequestedLifetimeCount
             and results.RevisedMaxKeepAliveCount == params.RequestedMaxKeepAliveCount
         ):
-            return None
+            return  # type: ignore
         _logger.warning(
             f"Revised values returned differ from subscription values: {results}"
         )
@@ -603,7 +603,6 @@ class Client:
             # update LifetimeCount but chances are it will be re-revised again
             modified_params.RequestedLifetimeCount = results.RevisedLifetimeCount
             return modified_params
-        return None
 
     def get_keepalive_count(self, period) -> int:
         """

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -177,7 +177,7 @@ class Client:
             private_key.password,
             private_key.extension,
         )
-        self.security_policy = policy(server_cert, cert, pk, mode)
+        self.security_policy = policy(server_cert, cert, pk, mode)  # type: ignore
         self.uaclient.set_security(self.security_policy)
 
     async def load_client_certificate(self, path: str, extension: Optional[str] = None):
@@ -570,13 +570,13 @@ class Client:
         self,
         params: ua.CreateSubscriptionParameters,
         results: ua.CreateSubscriptionResult,
-    ) -> None:
+    ) -> Optional[ua.ModifySubscriptionParameters]:
         if (
             results.RevisedPublishingInterval == params.RequestedPublishingInterval
             and results.RevisedLifetimeCount == params.RequestedLifetimeCount
             and results.RevisedMaxKeepAliveCount == params.RequestedMaxKeepAliveCount
         ):
-            return
+            return None
         _logger.warning(
             f"Revised values returned differ from subscription values: {results}"
         )
@@ -603,6 +603,7 @@ class Client:
             # update LifetimeCount but chances are it will be re-revised again
             modified_params.RequestedLifetimeCount = results.RevisedLifetimeCount
             return modified_params
+        return None
 
     def get_keepalive_count(self, period) -> int:
         """

--- a/asyncua/client/ha/ha_client.py
+++ b/asyncua/client/ha/ha_client.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from enum import IntEnum
 from functools import partial
 from itertools import chain
-from sortedcontainers import SortedDict
+from sortedcontainers import SortedDict  # type: ignore
 from asyncua import Node, ua, Client
 from asyncua.client.ua_client import UASocketProtocol
 from asyncua.ua.uaerrors import BadSessionClosed, BadSessionNotActivated

--- a/asyncua/client/ha/reconciliator.py
+++ b/asyncua/client/ha/reconciliator.py
@@ -8,7 +8,7 @@ from dataclasses import astuple
 from enum import Enum
 from functools import partial
 from typing import TYPE_CHECKING, Dict, Set, Union, List, Optional
-from sortedcontainers import SortedDict
+from sortedcontainers import SortedDict  # type: ignore
 from asyncua import ua, Client
 from pickle import PicklingError
 
@@ -179,8 +179,8 @@ class Reconciliator:
 
     def _subs_to_del(
         self, url: str, real_map: SubMap, ideal_map: SubMap
-    ) -> List[Optional[asyncio.Task]]:
-        to_del = []
+    ) -> List[asyncio.Task]:
+        to_del: List[asyncio.Task] = []
         sub_to_del = set(real_map[url]) - set(ideal_map[url])
         if sub_to_del:
             _logger.info(f"Removing {len(sub_to_del)} subscriptions")
@@ -195,8 +195,8 @@ class Reconciliator:
 
     def _subs_to_add(
         self, url: str, real_map: SubMap, ideal_map: SubMap
-    ) -> List[Optional[asyncio.Task]]:
-        to_add = []
+    ) -> List[asyncio.Task]:
+        to_add: List[asyncio.Task] = []
         sub_to_add = set(ideal_map[url]) - set(real_map[url])
         if sub_to_add:
             _logger.info(f"Adding {len(sub_to_add)} subscriptions")
@@ -254,8 +254,8 @@ class Reconciliator:
         client: Client,
         vs_real: VirtualSubscription,
         vs_ideal: VirtualSubscription,
-    ) -> List[Optional[asyncio.Task]]:
-        tasks = []
+    ) -> List[asyncio.Task]:
+        tasks: List[asyncio.Task] = []
         real_sub = self.name_to_subscription[url].get(sub_name)
         monitoring = vs_real.monitoring
         node_to_add = set(vs_ideal.nodes) - set(vs_real.nodes)
@@ -301,8 +301,8 @@ class Reconciliator:
         sub_name: str,
         vs_real: VirtualSubscription,
         vs_ideal: VirtualSubscription,
-    ) -> List[Optional[asyncio.Task]]:
-        to_del = []
+    ) -> List[asyncio.Task]:
+        to_del: List[asyncio.Task] = []
         node_to_del = set(vs_real.nodes) - set(vs_ideal.nodes)
         real_sub = self.name_to_subscription[url].get(sub_name)
         if node_to_del:

--- a/asyncua/client/ha/virtual_subscription.py
+++ b/asyncua/client/ha/virtual_subscription.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 from typing import Any, Iterable, Optional, Set
 
 from asyncua import ua
-from sortedcontainers import SortedDict
+from sortedcontainers import SortedDict  # type: ignore
 
 
 TypeSubHandler = Any

--- a/asyncua/common/connection.py
+++ b/asyncua/common/connection.py
@@ -9,7 +9,7 @@ from ..ua.ua_binary import struct_from_binary, struct_to_binary, header_from_bin
 try:
     from ..crypto.uacrypto import InvalidSignature
 except ImportError:
-    class InvalidSignature(Exception):
+    class InvalidSignature(Exception):  # type: ignore
         pass
 
 logger = logging.getLogger('asyncua.uaprotocol')

--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -5,7 +5,7 @@ import uuid
 import logging
 import re
 import keyword
-from typing import Union, List, TYPE_CHECKING, Tuple, Optional, Any
+from typing import Union, List, TYPE_CHECKING, Tuple, Optional, Any, Dict
 from dataclasses import dataclass, field
 
 from asyncua import ua
@@ -44,7 +44,7 @@ def new_struct_field(
         raise ValueError(f"DataType of a field must be a NodeId, not {dtype} of type {type(dtype)}")
     if array:
         field.ValueRank = ua.ValueRank.OneOrMoreDimensions
-        field.ArrayDimensions = [1]
+        field.ArrayDimensions = [1]  # type: ignore
     else:
         field.ValueRank = ua.ValueRank.Scalar
         field.ArrayDimensions = None
@@ -339,7 +339,7 @@ async def load_custom_struct(node: Node) -> Any:
     return env[name]
 
 
-async def load_data_type_definitions(server: Union["Server", "Client"], base_node: Node = None, overwrite_existing=False) -> None:
+async def load_data_type_definitions(server: Union["Server", "Client"], base_node: Node = None, overwrite_existing=False) -> Dict:
     """
     Read DataTypeDefition attribute on all Structure  and Enumeration  defined
     on server and generate Python objects in ua namespace to be used to talk with server
@@ -355,7 +355,7 @@ async def load_data_type_definitions(server: Union["Server", "Client"], base_nod
         try:
             env = await _generate_object(dts.name, dts.sdef, data_type=dts.data_type)
             ua.register_extension_object(dts.name, dts.encoding_id, env[dts.name], dts.data_type)
-            new_objects[dts.name] = env[dts.name]
+            new_objects[dts.name] = env[dts.name]  # type: ignore
         except NotImplementedError:
             logger.exception("Structure type %s not implemented", dts.sdef)
     return new_objects
@@ -403,7 +403,7 @@ class {name}({enum_type}):
     return code
 
 
-async def load_enums(server: Union["Server", "Client"], base_node: Node = None, option_set: bool = False) -> None:
+async def load_enums(server: Union["Server", "Client"], base_node: Node = None, option_set: bool = False) -> Dict:
     if base_node is None:
         base_node = server.nodes.enum_data_type
     new_enums = {}

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -221,7 +221,7 @@ class Subscription:
         sourcenode = Node(self.server, sourcenode)
         if evfilter is None:
             evfilter = await self._create_eventfilter(evtypes)
-        return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)
+        return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)  # type: ignore
 
     async def subscribe_alarms_and_conditions(self,
                                               sourcenode: Node = ua.ObjectIds.Server,
@@ -252,7 +252,7 @@ class Subscription:
             conditionIdOperand.TypeDefinitionId = ua.NodeId(ua.ObjectIds.ConditionType)
             conditionIdOperand.AttributeId = ua.AttributeIds.NodeId
             evfilter.SelectClauses.append(conditionIdOperand)
-        return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)
+        return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)  # type: ignore
 
     async def _subscribe(self,
                          nodes: Union[Node, Iterable[Node]],
@@ -291,7 +291,7 @@ class Subscription:
         # Check and return result for single node (raise `UaStatusCodeError` if subscription failed)
         if type(mids[0]) == ua.StatusCode:
             mids[0].check()
-        return mids[0]
+        return mids[0]  # type: ignore
 
     def _make_monitored_item_request(self,
                                      node: Node,
@@ -463,7 +463,7 @@ class Subscription:
         """
         self.logger.info("set_publishing_mode")
         params = ua.SetPublishingModeParameters()
-        params.SubscriptionIds = [self.subscription_id]
+        params.SubscriptionIds = [self.subscription_id]  # type: ignore
         params.PublishingEnabled = publishing
         result = await self.server.set_publishing_mode(params)
         if result[0].is_good():

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -275,7 +275,7 @@ class XmlImporter:
             node.RequestedNewNodeId)
         return node
 
-    def _to_migrated_nodeid(self, nodeid: Union[ua.NodeId, None, str]) -> ua.NodeId:
+    def _to_migrated_nodeid(self, nodeid: Union[ua.NodeId, None, str]) -> Union[ua.NodeId, ua.QualifiedName]:
         nodeid = self._to_nodeid(nodeid)
         return self._migrate_ns(nodeid)
 

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -642,7 +642,7 @@ class AddressSpace:
             self._nodeid_counter[idx] += 1
         else:
             # get the biggest identifier number from the existed nodes in address space
-            identifier_list = sorted(
+            identifier_list = sorted(  # type: ignore
                 [
                     nodeid.Identifier
                     for nodeid in self._nodes.keys()

--- a/asyncua/server/history.py
+++ b/asyncua/server/history.py
@@ -210,7 +210,7 @@ class HistoryDict(HistoryStorageInterface):
         pass
 
 
-class SubHandler(SubHandler):
+class SubHandler(SubHandler):  # type: ignore
     def __init__(self, storage):
         self.storage = storage
 

--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -133,7 +133,7 @@ class InternalServer:
             # path was supplied, but file doesn't exist - create one for next start up
             await asyncio.get_running_loop().run_in_executor(None, self.aspace.make_aspace_shelf, shelf_file)
 
-    async def _address_space_fixes(self) -> Coroutine:
+    async def _address_space_fixes(self) -> Coroutine:  # type: ignore
         """
         Looks like the xml definition of address space has some error. This is a good place to fix them
         """

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -415,7 +415,7 @@ class Server:
         else:
             _logger.debug("%s server started", self)
 
-    def _get_bind_socket_info(self) -> Tuple[str, int]:
+    def _get_bind_socket_info(self) -> Tuple[Optional[str], Optional[int]]:
         if self.socket_address is not None:
             return self.socket_address
         else:

--- a/asyncua/tools.py
+++ b/asyncua/tools.py
@@ -8,7 +8,7 @@ import time
 import concurrent.futures
 
 try:
-    from IPython import embed
+    from IPython import embed  # type: ignore
 except ImportError:
     import code
 

--- a/asyncua/ua/uaprotocol_auto.py
+++ b/asyncua/ua/uaprotocol_auto.py
@@ -2575,7 +2575,7 @@ class OptionSet:
     ValidBits: ByteString = None
 
 
-@dataclass(frozen=FROZEN)
+@dataclass(frozen=FROZEN)  # type: ignore
 class Union:  # type: ignore
     """
     https://reference.opcfoundation.org/v104/Core/docs/Part3/8.42

--- a/asyncua/ua/uaprotocol_auto.py
+++ b/asyncua/ua/uaprotocol_auto.py
@@ -2576,7 +2576,7 @@ class OptionSet:
 
 
 @dataclass(frozen=FROZEN)
-class Union:
+class Union:  # type: ignore
     """
     https://reference.opcfoundation.org/v104/Core/docs/Part3/8.42
 
@@ -8539,11 +8539,11 @@ class BuildInfo:
 
     data_type = NodeId(ObjectIds.BuildInfo)
 
-    ProductUri: String = None
-    ManufacturerName: String = None
-    ProductName: String = None
-    SoftwareVersion: String = None
-    BuildNumber: String = None
+    ProductUri: String = None  # type: ignore
+    ManufacturerName: String = None  # type: ignore
+    ProductName: String = None  # type: ignore
+    SoftwareVersion: String = None  # type: ignore
+    BuildNumber: String = None  # type: ignore
     BuildDate: UtcTime = field(default_factory=datetime.utcnow)
 
 

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -30,7 +30,7 @@ if sys.version_info.minor < 10:
             return res
         return ()
 else:
-    from typing import get_origin, get_args
+    from typing import get_origin, get_args  # type: ignore
 
 
 from asyncua.ua import status_codes

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ per-file-ignores =
     __init__.py: F401
 [pycodestyle]
 max-line-length = 160
+[mypy]
+disable_error_code = misc, arg-type, attr-defined, assignment, union-attr, var-annotated, override


### PR DESCRIPTION
- mirror change from mypy
- ignore mypy errors
  - better to fix issues step by step
  
## rough summary of the errors ( not complete )

```python
# I'm not find stubs package for mypy
from sortedcontainers import SortedDict  # type: ignore

# Optinal[String]
ProductUri: String = None  # type: ignore

# "frozen" argument must be True or False. I guess it's false posetive 
disable_error_code = misc

# Name "SubHandler" already defined (possibly by an import)  [no-redef]
class SubHandler(SubHandler):  # type: ignore
# asyncua/ua/uaprotocol_auto.py:2579: error: Name "Union" already defined (possibly by an import)  [no-redef]
# asyncua/common/connection.py:12: error: Name "InvalidSignature" already defined (possibly by an import)  [no-redef]
class Union:  # type: ignore


# Cannot find implementation or library stub for module named "IPython"
from IPython import embed  # type: ignore

# Argument 1 to "NodeId" has incompatible type "int"; expected "Union[Int32, String, Guid, ByteString]"
# "FourByteNodeId" has incompatible type "int"; expected "Union[Int32, String, Guid, ByteString]"
disable_error_code = arg-type


# asyncua/client/ha/reconciliator.py:384: error: "Reconciliator" has no attribute "hook_add_to_map_error"  [attr-defined]
# asyncua/client/ha/reconciliator.py:411: error: "Reconciliator" has no attribute "hook_add_to_map"; maybe "add_to_map"?  [attr-defined]
# asyncua/client/ha/reconciliator.py:432: error: "Reconciliator" has no attribute "hook_del_from_map"; maybe "del_from_map"?  [attr-defined]
disable_error_code = attr-defined


# asyncua/ua/uaerrors/_base.py:39: error: Need type annotation for "_subclasses" (hint: "_subclasses: Dict[<type>, <type>] = ...")  [var-annotated]
# asyncua/server/address_space.py:42: error: Need type annotation for "datachange_callbacks" (hint: "datachange_callbacks: Dict[<type>, <type>] = ...")  [var-annotated]
disable_error_code = var-annotated


# asyncua/ua/uatypes.py:311: error: Incompatible types in assignment (expression has type "int", variable has type "UInt32")  [assignment]
# asyncua/ua/uatypes.py:380: error: Incompatible types in assignment (expression has type "int", variable has type "Union[Int32, String, Guid, ByteString]")  [assignment]
# asyncua/ua/uatypes.py:381: error: Incompatible types in assignment (expression has type "int", variable has type "Int16")  [assignment]

disable_error_code = attr-defined


# asyncua/server/address_space.py:379: error: Item "None" of "Optional[Variant]" has no attribute "Value"  [union-attr]
# asyncua/server/address_space.py:460: error: Item "None" of "Optional[Variant]" has no attribute "Value"  [union-attr]
# asyncua/server/address_space.py:465: error: Item "None" of "Optional[Variant]" has no attribute "Value"  [union-attr]
# asyncua/server/address_space.py:468: error: Item "None" of "Optional[Variant]" has no attribute "Value"  [union-attr]

disable_error_code = union-attr


# asyncua/common/xmlimporter.py:278: error: Name "NodeId" is not defined  [name-defined]
# asyncua/common/xmlimporter.py:278: error: Name "QualifiedName" is not defined  [name-defined]
def _to_migrated_nodeid(self, nodeid: Union[ua.NodeId, None, str]) -> Union[ua.NodeId, ua.QualifiedName]:

# asyncua/client/ua_client.py:44: error: Argument 1 of "connection_made" is incompatible with supertype "BaseProtocol"; supertype defines the argument type as "BaseTransport"  [override]
# asyncua/client/ua_client.py:48: error: Argument 1 of "connection_lost" is incompatible with supertype "BaseProtocol"; supertype defines the argument type as "Optional[Exception]"  [override]
disable_error_code = override

# asyncua/server/address_space.py:645: error: Value of type variable "SupportsRichComparisonT" of "sorted" cannot be "Union[Int32, String, Guid, ByteString]"  [type-var]
identifier_list = sorted(  # type: ignore

# asyncua/common/subscription.py:224: error: Incompatible return value type (got "Union[int, List[Union[int, StatusCode]]]", expected "int")  [return-value]
return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)  # type: ignore
# asyncua/common/subscription.py:255: error: Incompatible return value type (got "Union[int, List[Union[int, StatusCode]]]", expected "int")  [return-value]
return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)  # type: ignore


# asyncua/common/subscription.py:466: error: List item 0 has incompatible type "Optional[int]"; expected "UInt32"  [list-item]
params.SubscriptionIds = [self.subscription_id]  # type: ignore
# asyncua/common/structures104.py:47: error: List item 0 has incompatible type "int"; expected "UInt32"  [list-item]
field.ArrayDimensions = [1]  # type: ignore

# asyncua/server/internal_server.py:136: error: Missing return statement  [return]
async def _address_space_fixes(self) -> Coroutine:  # type: ignore

# asyncua/common/structures104.py:358: error: Unsupported target for indexed assignment ("None")  [index]
new_objects[dts.name] = env[dts.name]  # type: ignore

# asyncua/client/client.py:180: error: "SecurityPolicy" not callable  [operator]
self.security_policy = policy(server_cert, cert, pk, mode)  # type: ignore
```