### PR TITLE
Fix User Authentication with certificates from UAExpert. Relates to #430

### DIFF
--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -90,6 +90,9 @@ class InternalSession:
         if self.iserver.user_manager is not None:
             if isinstance(id_token, ua.UserNameIdentityToken):
                 username, password = self.iserver.check_user_token(self, id_token)
+            elif isinstance(id_token, ua.X509IdentityToken):
+                peer_certificate = id_token.CertificateData
+                username, password = None, None
             else:
                 username, password = None, None
 


### PR DESCRIPTION
UAExpert sends its application certificate as client certificate in the initial `CreateSessionRequest`.
The user certificate is sent as `ua.X509IdentityToken` in the request body and has to be looked up there.