### PR TITLE
Make package version available at runtime

### DIFF
--- a/asyncua/__init__.py
+++ b/asyncua/__init__.py
@@ -1,6 +1,13 @@
 """
 Pure Python OPC-UA library
 """
+import sys
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
+__version__ = metadata.version("asyncua")
 
 from .common import Node, uamethod
 from .client import Client

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     provides=["asyncua"],
     license="GNU Lesser General Public License v3 or later",
-    install_requires=["aiofiles", "aiosqlite", "python-dateutil", "pytz", "cryptography", "sortedcontainers"],
+    install_requires=["aiofiles", "aiosqlite", "python-dateutil", "pytz", "cryptography", "sortedcontainers", "importlib-metadata;python_version<'3.8'"],
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Make the package version available as `asyncua.__version__` at runtime.