### PR TITLE
reject not supported identity tokens

### DIFF
--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -10,7 +10,7 @@ from struct import unpack_from
 import os
 import logging
 from urllib.parse import urlparse
-from typing import Coroutine
+from typing import Coroutine, Tuple
 
 from asyncua import ua
 from .user_managers import PermissiveUserManager, UserManager
@@ -72,7 +72,8 @@ class InternalServer:
         self.current_time_node = Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
         self.time_task = None
         self._time_task_stop = False
-        self.match_discovery_source_ip: bool = True 
+        self.match_discovery_source_ip: bool = True
+        self.supported_tokens = []
 
     async def init(self, shelffile=None):
         await self.load_standard_address_space(shelffile)
@@ -352,3 +353,9 @@ class InternalServer:
             password = password.decode('utf-8')
 
         return user_name, password
+
+    def get_supported_tokens(self) -> Tuple[type]:
+        return self._supported_tokens
+
+    def set_supported_tokens(self, token_classes: Tuple[type]) -> None:
+        self._supported_tokens = token_classes

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -87,6 +87,10 @@ class InternalSession:
         self.state = SessionState.Activated
         InternalSession._current_connections += 1
         id_token = params.UserIdentityToken
+        # Check if security policy is supported
+        if not isinstance(id_token, self.iserver.get_supported_tokens()):
+            self.logger.error('Rejected active session UserIdentityToken not supported')
+            raise ServiceError(ua.StatusCodes.BadIdentityTokenRejected)
         if self.iserver.user_manager is not None:
             if isinstance(id_token, ua.UserNameIdentityToken):
                 username, password = self.iserver.check_user_token(self, id_token)

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -357,23 +357,27 @@ class Server:
 
     def _set_endpoints(self, policy=ua.SecurityPolicy, mode=ua.MessageSecurityMode.None_):
         idtokens = []
+        supported_token_classes = []
         if "Anonymous" in self._policyIDs:
             idtoken = ua.UserTokenPolicy()
             idtoken.PolicyId = "anonymous"
             idtoken.TokenType = ua.UserTokenType.Anonymous
             idtokens.append(idtoken)
+            supported_token_classes.append(ua.AnonymousIdentityToken)
 
         if "Basic256Sha256" in self._policyIDs:
             idtoken = ua.UserTokenPolicy()
             idtoken.PolicyId = 'certificate_basic256sha256'
             idtoken.TokenType = ua.UserTokenType.Certificate
             idtokens.append(idtoken)
+            supported_token_classes.append(ua.X509IdentityToken)
 
         if "Username" in self._policyIDs:
             idtoken = ua.UserTokenPolicy()
             idtoken.PolicyId = "username"
             idtoken.TokenType = ua.UserTokenType.UserName
             idtokens.append(idtoken)
+            supported_token_classes.append(ua.UserNameIdentityToken)
 
         appdesc = ua.ApplicationDescription()
         appdesc.ApplicationName = ua.LocalizedText(self.name)
@@ -393,6 +397,7 @@ class Server:
         edp.TransportProfileUri = "http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary"
         edp.SecurityLevel = 0
         self.iserver.add_endpoint(edp)
+        self.iserver.set_supported_tokens(tuple(supported_token_classes))
 
     def set_server_name(self, name):
         self.name = name


### PR DESCRIPTION
prevents unsupported identity tokens to create a session.
For example reject anonymous connection if not set via set_security_IDs, currently this was possible and was a security issue.
See: https://github.com/FreeOpcUa/python-opcua/issues/1457#issuecomment-1109502689_