### PR TITLE
rework struct1_04 resolution

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -1062,6 +1062,23 @@ def get_default_value(vtype):
     raise RuntimeError(f"function take a uatype as argument, got: {vtype}")
 
 
+basetype_by_datatype = {}
+basetype_datatypes = {}
+
+
+# register of alias of basetypes
+def register_basetype(name, nodeid, class_type):
+    """
+    Register a new allias of basetypes for automatic decoding and make them available in ua module
+    """
+    logger.info("registring new basetype alias: %s %s %s", name, nodeid, class_type)
+    basetype_by_datatype[nodeid] = class_type
+    basetype_datatypes[class_type] = nodeid
+    import asyncua.ua
+
+    setattr(asyncua.ua, name, class_type)
+
+
 # register of custom enums (Those loaded with load_enums())
 enums_by_datatype = {}
 enums_datatypes = {}

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -923,7 +923,7 @@ async def test_get_endpoints(opc):
 
 
 async def test_copy_node(opc):
-    dev_t = await opc.opc.nodes.base_data_type.add_object_type(0, "MyDevice")
+    dev_t = await opc.opc.nodes.base_structure_type.add_object_type(0, "MyDevice")
     v_t = await dev_t.add_variable(0, "sensor", 1.0)
     p_t = await dev_t.add_property(0, "sensor_id", "0340")
     ctrl_t = await dev_t.add_object(0, "controller")

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -534,7 +534,7 @@ async def test_xml_struct_optional(opc, tmpdir):
         new_struct_field("MyString", ua.VariantType.String, optional=True),
         new_struct_field("MyInt64", ua.VariantType.Int64, optional=True),
     ])
-    tmp_path = tmpdir.join("export-union.xml").strpath
+    tmp_path = tmpdir.join("export-optional.xml").strpath
     await opc.opc.export_xml([o], tmp_path)
     await opc.opc.delete_nodes([o])
     new_nodes = await opc.opc.import_xml(tmp_path)
@@ -547,9 +547,18 @@ async def test_xml_struct_optional(opc, tmpdir):
     assert t.MyInt64 == 5
 
 
+async def test_basetype_alias(opc):
+    idx = 4
+    # Alias double
+    _ = await opc.opc.get_node(ua.NodeId(11)).add_data_type(ua.NodeId(NamespaceIndex=idx), '4:MyDouble')
+    await opc.opc.load_data_type_definitions()
+    assert ua.MyDouble(4.0) == ua.Double(4.0)
+
+
 async def test_xml_required_models_fail(opc):
     with pytest.raises(ValueError):
         await opc.opc.import_xml(CUSTOM_REQ_XML_FAIL_PATH)
+
 
 async def test_xml_required_models_pass(opc):
     await opc.opc.import_xml(CUSTOM_REQ_XML_PASS_PATH)


### PR DESCRIPTION
- Load union subtypes, they were ignored before.
- Load alias for basic datatypes, for example in #899 where WORD is UInt16
- Added a retries up to 10 times to resolve all custom structes

test the new code against opc.tcp://opcuademo.sterfive.com:26543
with multiple companion specs loaded.

Need to implement some basic testing