### PR TITLE
remove DeprecationWarning

### DIFF
--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -433,7 +433,7 @@ class Server:
         if self._discovery_handle:
             self._discovery_handle.cancel()
         if self._discovery_clients:
-            await asyncio.wait([client.disconnect() for client in self._discovery_clients.values()])
+            await asyncio.wait(*[client.disconnect() for client in self._discovery_clients.values()])
         await self.bserver.stop()
         await self.iserver.stop()
         _logger.debug("%s Internal server stopped, everything closed", self)


### PR DESCRIPTION
DeprecationWarning: The explicit passing of coroutine objects to asyncio.wait() is deprecated since Python 3.8, and scheduled for removal in Python 3.11.