### PR TITLE
speed up eventfilter creation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true,
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/asyncua/common/events.py
+++ b/asyncua/common/events.py
@@ -177,14 +177,6 @@ async def select_clauses_from_evtype(evtypes: List["Node"]):
         refs = await select_event_attributes_from_type_node(evtype, lambda n: n.get_references(ua.ObjectIds.Aggregates, ua.BrowseDirection.Forward, ua.NodeClass.Object | ua.NodeClass.Variable, True))
         if refs:
             await _select_clause_from_childs(evtype, refs, select_clauses, already_selected, [])
-        ''' for property in await select_event_attributes_from_type_node(evtype, lambda n: n.get_children_descriptions(refs=ua.ObjectIds.HasProperty, nodeclassmask=ua.NodeClass.Variable)):
-            await _append_new_attribute_to_select_clauses(select_clauses, already_selected, [property.BrowseName])
-        for variable in await select_event_attributes_from_type_node(evtype, lambda n: n.get_children_descriptions(ua.ObjectIds.HasComponent, ua.NodeClass.Variable)):
-            await _append_new_attribute_to_select_clauses(select_clauses, already_selected, [variable.BrowseName])
-            await _select_clause_from_childs(evtype.init_child_node(variable.NodeId), select_clauses, already_selected, [variable.BrowseName])
-        for object in await select_event_attributes_from_type_node(evtype, lambda n: n.get_children_descriptions(ua.ObjectIds.HasComponent, ua.NodeClass.Object)):
-            await _select_clause_from_childs(evtype.init_child_node(object.NodeId), select_clauses, already_selected, [object.BrowseName])
-            '''
     return select_clauses
 
 

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -725,3 +725,9 @@ class Node:
         await self.server.unregister_nodes([self.nodeid])
         self.nodeid = self.basenodeid
         self.basenodeid = None
+
+    def init_child_node(self, nodeid: ua.NodeId):
+        """
+        Helper function to init nodes with out importing Node
+        """
+        return Node(self.server, nodeid)

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -369,8 +369,8 @@ class Node:
         """
         return self.get_children(refs=ua.ObjectIds.HasComponent, nodeclassmask=ua.NodeClass.Method)
 
-    async def get_children_descriptions(self, refs=ua.ObjectIds.HierarchicalReferences, nodeclassmask=ua.NodeClass.Unspecified, includesubtypes=True):
-        return await self.get_references(refs, ua.BrowseDirection.Forward, nodeclassmask, includesubtypes)
+    async def get_children_descriptions(self, refs=ua.ObjectIds.HierarchicalReferences, nodeclassmask=ua.NodeClass.Unspecified, includesubtypes=True, result_mask=ua.BrowseResultMask.All):
+        return await self.get_references(refs, ua.BrowseDirection.Forward, nodeclassmask, includesubtypes, result_mask)
 
     def get_encoding_refs(self):
         return self.get_referenced_nodes(ua.ObjectIds.HasEncoding, ua.BrowseDirection.Forward)
@@ -378,7 +378,7 @@ class Node:
     def get_description_refs(self):
         return self.get_referenced_nodes(ua.ObjectIds.HasDescription, ua.BrowseDirection.Forward)
 
-    async def get_references(self, refs=ua.ObjectIds.References, direction=ua.BrowseDirection.Both, nodeclassmask=ua.NodeClass.Unspecified, includesubtypes=True):
+    async def get_references(self, refs=ua.ObjectIds.References, direction=ua.BrowseDirection.Both, nodeclassmask=ua.NodeClass.Unspecified, includesubtypes=True, result_mask=ua.BrowseResultMask.All):
         """
         returns references of the node based on specific filter defined with:
 
@@ -386,13 +386,14 @@ class Node:
         direction = Browse direction for references
         nodeclassmask = filter nodes based on specific class
         includesubtypes = If true subtypes of the reference (ref) are also included
+        result_mask = define what results information are requested
         """
         desc = ua.BrowseDescription()
         desc.BrowseDirection = direction
         desc.ReferenceTypeId = _to_nodeid(refs)
         desc.IncludeSubtypes = includesubtypes
         desc.NodeClassMask = nodeclassmask
-        desc.ResultMask = ua.BrowseResultMask.All
+        desc.ResultMask = result_mask
         desc.NodeId = self.nodeid
         params = ua.BrowseParameters()
         params.View.Timestamp = ua.get_win_epoch()
@@ -726,8 +727,9 @@ class Node:
         self.nodeid = self.basenodeid
         self.basenodeid = None
 
-    def init_child_node(self, nodeid: ua.NodeId):
+    @staticmethod
+    def new_node(server, nodeid: ua.NodeId):
         """
         Helper function to init nodes with out importing Node
         """
-        return Node(self.server, nodeid)
+        return Node(server, nodeid)

--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -470,6 +470,7 @@ class {name}({enum_type}):
         name = clean_name(sfield.Name)
         value = sfield.Value if not option_set else (1 << sfield.Value)
         code += f"    {name} = {value}\n"
+    logger.error(f"{name} - {sfield} {option_set} {code}")
     return code
 
 


### PR DESCRIPTION
Reduced network transactions:
- instead of 3 browse request (get_properties, get_variables, get_objects) use 1.
- no read_browse_name 
- refactored logic into 1 function

The addition to Node is needed because in events.py you can't import node because of circular dependency.