### PR TITLE
XMLExport: make export values optional

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -645,11 +645,12 @@ class Client:
         importer = XmlImporter(self)
         return await importer.import_xml(path, xmlstring)
 
-    async def export_xml(self, nodes, path):
+    async def export_xml(self, nodes, path, export_values: bool = False):
         """
         Export defined nodes to xml
+        :param export_values: exports values from variants
         """
-        exp = XmlExporter(self)
+        exp = XmlExporter(self, export_values=export_values)
         await exp.build_etree(nodes)
         await exp.write_xml(path)
 

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -589,26 +589,28 @@ class Server:
         importer = XmlImporter(self)
         return await importer.import_xml(path, xmlstring)
 
-    async def export_xml(self, nodes, path):
+    async def export_xml(self, nodes, path, export_values: bool = False):
         """
         Export defined nodes to xml
+        :param export_value: export values from variants
         """
-        exp = XmlExporter(self)
+        exp = XmlExporter(self, export_values=export_values)
         await exp.build_etree(nodes)
         await exp.write_xml(path)
 
-    async def export_xml_by_ns(self, path: str, namespaces: list = None):
+    async def export_xml_by_ns(self, path: str, namespaces: list = None, export_values: bool = False):
         """
         Export nodes of one or more namespaces to an XML file.
         Namespaces used by nodes are always exported for consistency.
         :param path: name of the xml file to write
         :param namespaces: list of string uris or int indexes of the namespace to export,
+        :param export_values: export values from variants
          if not provide all ns are used except 0
         """
         if namespaces is None:
             namespaces = []
         nodes = await get_nodes_of_namespace(self, namespaces)
-        await self.export_xml(nodes, path)
+        await self.export_xml(nodes, path, export_values=export_values)
 
     async def delete_nodes(self, nodes, recursive=False) -> Coroutine:
         return await delete_nodes(self.iserver.isession, nodes, recursive)


### PR DESCRIPTION
Allow disable of exporting values from variables.
Normally you don't need the values in the nodeset. As side effect it reduces the time need to export a nodeset and the xml size.

Because of the the incompleteness of the xml encoding I would disable the variable export per default. 