### PR TITLE
Fixes #929 activate_session(without arguments) discards previously set certificate.

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -443,11 +443,11 @@ class Client:
                 return self.security_policy.URI
         return self.security_policy.URI
 
-    async def activate_session(self, username: str = None, password: str = None, user_certificate=None):
+    async def activate_session(self, username: str = None, password: str = None, certificate=None):
         """
         Activate session using either username and password or private_key
         """
-        certificate = user_certificate or self.user_certificate
+        user_certificate = certificate or self.user_certificate
         params = ua.ActivateSessionParameters()
         challenge = b""
         if self.security_policy.peer_certificate is not None:
@@ -460,10 +460,10 @@ class Client:
             params.ClientSignature.Algorithm = (security_policies.SecurityPolicyBasic256.AsymmetricSignatureURI)
         params.ClientSignature.Signature = self.security_policy.asymmetric_cryptography.signature(challenge)
         params.LocaleIds = self._locale
-        if not username and not certificate:
+        if not username and not user_certificate:
             self._add_anonymous_auth(params)
-        elif certificate:
-            self._add_certificate_auth(params, certificate, challenge)
+        elif user_certificate:
+            self._add_certificate_auth(params, user_certificate, challenge)
         else:
             self._add_user_auth(params, username, password)
         return await self.uaclient.activate_session(params)


### PR DESCRIPTION
Now you can call activate_session() without arguments without discarding a certificate previously set with load_client_certificate().