### PR TITLE
reraise exception in _process_received_data()

### DIFF
--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -87,10 +87,10 @@ class UASocketProtocol(asyncio.Protocol):
                     return
                 # Buffer still has bytes left, try to process again
                 data = bytes(buf)
-            except Exception:
+            except Exception as ex:
                 self.logger.exception('Exception raised while parsing message from server')
                 self.disconnect_socket()
-                return
+                raise ex
 
     def _process_received_message(self, msg: Union[ua.Message, ua.Acknowledge, ua.ErrorMessage]):
         if msg is None:


### PR DESCRIPTION
Hi there! 

I had a problem like this:
```
2022-06-26 01:46:24.606: ERROR    Exception raised while parsing message from server
Traceback (most recent call last):
  File "/opt/maddox/.venv/lib/python3.8/site-packages/asyncua/client/ua_client.py", line 82, in _process_received_data
    self._open_secure_channel_exchange = struct_from_binary(ua.OpenSecureChannelResponse, msg.body())
  File "/opt/maddox/.venv/lib/python3.8/site-packages/asyncua/ua/ua_binary.py", line 593, in struct_from_binary
    return _create_dataclass_deserializer(objtype)(data)
  File "/opt/maddox/.venv/lib/python3.8/site-packages/asyncua/ua/ua_binary.py", line 584, in decode
    kwargs[field.name] = deserialize_field(data)
  File "/opt/maddox/.venv/lib/python3.8/site-packages/asyncua/ua/ua_binary.py", line 584, in decode
    kwargs[field.name] = deserialize_field(data)
  File "/opt/maddox/.venv/lib/python3.8/site-packages/asyncua/ua/ua_binary.py", line 472, in extensionobject_from_binary
    typeid = nodeid_from_binary(data)
  File "/opt/maddox/.venv/lib/python3.8/site-packages/asyncua/ua/ua_binary.py", line 388, in nodeid_from_binary
    nidtype = ua.NodeIdType(encoding & 0b00111111)
  File "/usr/local/lib/python3.8/enum.py", line 339, in __call__
    return cls.__new__(cls, value)
  File "/usr/local/lib/python3.8/enum.py", line 663, in __new__
    raise ve_exc
ValueError: 63 is not a valid NodeIdType
2022-06-26 01:46:24.607: WARNING  disconnect_socket was called but connection is closed
```

which I need to handle. So I modified the `_process_received_data()` to re-raise the exception. In the current implementation, that exception is catched inside the library and there is no way for me to handle it in my code.

I you have a better idea please let me know :)