### PR TITLE
XMLImport - add namespace meta if missing in nodeset

### DIFF
--- a/asyncua/common/xmlparser.py
+++ b/asyncua/common/xmlparser.py
@@ -5,6 +5,7 @@ import re
 import asyncio
 import base64
 import logging
+from typing import List, Tuple
 import xml.etree.ElementTree as ET
 
 from pytz import utc
@@ -439,3 +440,20 @@ class XMLParser:
                 # check if ModelUri X, in Version Y from time Z was already imported
                 required_models.append(child.attrib)
         return required_models
+
+    def get_nodeset_namespaces(self) -> List[Tuple[str, ua.String, ua.DateTime]]:
+        """
+        Get all namespaces that are registered with version and date_time
+        """
+        ns = []
+        for model in self.root.findall('base:Models/base:Model', self.ns):
+            uri = model.attrib.get('ModelUri')
+            if uri is not None:
+                version = model.attrib.get('Version', ua.String())
+                date_time = model.attrib.get('PublicationDate')
+                if date_time is None:
+                    date_time = ua.DateTime(1, 1, 1)
+                else:
+                    date_time = ua.DateTime.strptime(date_time, "%Y-%m-%dT%H:%M:%SZ")
+                ns.append((uri, version, date_time))
+        return ns

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -582,3 +582,17 @@ async def test_disable_xml_export_without_value(opc, tmpdir):
     assert dv.Value != v.Value
     assert v.Value.Value is None
     await opc.opc.delete_nodes([o2])
+
+
+async def test_if_missing_meta_data_is_added(opc):
+    # check if missing namespace infos are added
+    urn = "http://yourorganisation.org/testenum104/"
+    idx = await opc.opc.register_namespace(urn)
+    await opc.opc.import_xml(CUSTOM_REQ_XML_PASS_PATH)
+    o = await opc.opc.nodes.namespaces.get_child([f"{idx}:{urn}"])
+    assert await (await o.get_child("NamespaceUri")).read_value() == urn
+    assert await (await o.get_child("NamespaceVersion")).read_value() == "1.0.0"
+    dt = await (await o.get_child("NamespacePublicationDate")).read_value()
+    assert dt.year == 2020
+    assert dt.month == 8
+    assert dt.day == 11

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -564,6 +564,16 @@ async def test_xml_required_models_fail(opc):
 
 async def test_xml_required_models_pass(opc):
     await opc.opc.import_xml(CUSTOM_REQ_XML_PASS_PATH)
+    # check if missing namespace infos are added
+    urn = "http://yourorganisation.org/testenum104/"
+    idx = await opc.opc.register_namespace(urn)
+    o = await opc.opc.nodes.namespaces.get_child([f"{idx}:{urn}"])
+    assert await (await o.get_child("NamespaceUri")).read_value() == urn
+    assert await (await o.get_child("NamespaceVersion")).read_value() == "1.0.0"
+    dt = await (await o.get_child("NamespacePublicationDate")).read_value()
+    assert dt.year == 2020
+    assert dt.month == 8
+    assert dt.day == 11
 
 
 async def test_disable_xml_export_without_value(opc, tmpdir):
@@ -582,17 +592,3 @@ async def test_disable_xml_export_without_value(opc, tmpdir):
     assert dv.Value != v.Value
     assert v.Value.Value is None
     await opc.opc.delete_nodes([o2])
-
-
-async def test_if_missing_meta_data_is_added(opc):
-    # check if missing namespace infos are added
-    urn = "http://yourorganisation.org/testenum104/"
-    idx = await opc.opc.register_namespace(urn)
-    await opc.opc.import_xml(CUSTOM_REQ_XML_PASS_PATH)
-    o = await opc.opc.nodes.namespaces.get_child([f"{idx}:{urn}"])
-    assert await (await o.get_child("NamespaceUri")).read_value() == urn
-    assert await (await o.get_child("NamespaceVersion")).read_value() == "1.0.0"
-    dt = await (await o.get_child("NamespacePublicationDate")).read_value()
-    assert dt.year == 2020
-    assert dt.month == 8
-    assert dt.day == 11


### PR DESCRIPTION
Add missing namepace meta if missing, to the server. Otherwise depending namespaces will fail.
See #846 