### PR TITLE
[Client] Add watchdog for connection status

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -63,7 +63,8 @@ class Client:
         self.secure_channel_timeout = 3600000  # 1 hour
         self.session_timeout = 3600000  # 1 hour
         self._policy_ids = []
-        self.uaclient: UaClient = UaClient(timeout, self.check_connection)
+        self.uaclient: UaClient = UaClient(timeout)
+        self.uaclient.pre_request_hook = self.check_connection
         self.user_certificate = None
         self.user_private_key = None
         self._server_nonce = None

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -29,11 +29,7 @@ class Client:
     use UaClient object, available as self.uaclient
     which offers the raw OPC-UA services interface.
     """
-
-    _username = None
-    _password = None
-
-    def __init__(self, url: str, timeout: float = 4):
+    def __init__(self, url: str, timeout: float = 4, watchdog_intervall: float = 10):
         """
         :param url: url of the server.
             if you are unsure of url, write at least hostname
@@ -41,6 +37,8 @@ class Client:
         :param timeout:
             Each request sent to the server expects an answer within this
             time. The timeout is specified in seconds.
+        :param watchdog_intervall:
+            The time between checking if the server is still alive. The timeout is specified in seconds.
         Some other client parameters can be changed by setting
         attributes on the constructed object:
         See the source code for the exhaustive list.
@@ -65,7 +63,7 @@ class Client:
         self.secure_channel_timeout = 3600000  # 1 hour
         self.session_timeout = 3600000  # 1 hour
         self._policy_ids = []
-        self.uaclient: UaClient = UaClient(timeout)
+        self.uaclient: UaClient = UaClient(timeout, self._check_tasks)
         self.user_certificate = None
         self.user_private_key = None
         self._server_nonce = None
@@ -74,7 +72,9 @@ class Client:
         self.max_messagesize = 0  # No limits
         self.max_chunkcount = 0  # No limits
         self._renew_channel_task = None
+        self._watch_task = None
         self._locale = ["en"]
+        self._watchdog_intervall = watchdog_intervall
 
     async def __aenter__(self):
         await self.connect()
@@ -421,11 +421,39 @@ class Client:
             _logger.warning("Requested session timeout to be %dms, got %dms instead", self.secure_channel_timeout, response.RevisedSessionTimeout)
             self.session_timeout = response.RevisedSessionTimeout
         self._renew_channel_task = asyncio.create_task(self._renew_channel_loop())
+        self._watch_task = asyncio.create_task(self._watchdog_loop())
         return response
+
+    async def _check_tasks(self):
+        # Check if a background task has finished and if a exception is thrown rethrow it with result
+        # use half the session timeout or the supply value from constructor
+        if self._renew_channel_task is not None:
+            if self._renew_channel_task.done():
+                await self._renew_channel_task
+        if self._watch_task is not None:
+            if self._watch_task.done():
+                await self._watch_task
+
+    async def _watchdog_loop(self):
+        """
+        Checks if the server is alive
+        """
+        timeout = min(self.session_timeout / 1000 / 2, self._watchdog_intervall)
+        try:
+            while True:
+                await asyncio.sleep(timeout)
+                # @FIXME handle state change
+                _ = await self.nodes.server_state.read_value()
+
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            _logger.exception("Error in watchdog loop")
+            raise
 
     async def _renew_channel_loop(self):
         """
-        Renew the SecureChannel before the SessionTimeout will happen.
+        Renew the SecureChannel before the SecureChannelTimeout will happen.
         In theory we could do that only if no session activity
         but it does not cost much..
         """
@@ -549,6 +577,12 @@ class Client:
         """
         Close session
         """
+        if self._watch_task:
+            self._watch_task.cancel()
+            try:
+                await self._watch_task
+            except Exception:
+                _logger.exception("Error while closing watch_task")
         if self._renew_channel_task:
             self._renew_channel_task.cancel()
             try:

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -426,7 +426,8 @@ class Client:
         return response
 
     async def check_connection(self):
-        # Check if a background task has finished and if a exception is thrown rethrow it with result
+        # can be used to check if the client is still connected
+        # if not it throws the underlying exception
         if self._renew_channel_task is not None:
             if self._renew_channel_task.done():
                 await self._renew_channel_task

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -432,6 +432,9 @@ class Client:
         if self._monitor_server_task is not None:
             if self._monitor_server_task.done():
                 await self._monitor_server_task
+        if self.uaclient._publish_task is not None:
+            if self.uaclient._publish_task.done():
+                await self.uaclient._publish_task
 
     async def _monitor_server_loop(self):
         """

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -579,10 +579,10 @@ class Client:
         """
         Close session
         """
-        if self._watch_task:
-            self._watch_task.cancel()
+        if self._monitor_server_task:
+            self._monitor_server_task.cancel()
             try:
-                await self._watch_task
+                await self._monitor_server_task
             except Exception:
                 _logger.exception("Error while closing watch_task")
         if self._renew_channel_task:

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -29,6 +29,10 @@ class Client:
     use UaClient object, available as self.uaclient
     which offers the raw OPC-UA services interface.
     """
+
+    _username = None
+    _password = None
+
     def __init__(self, url: str, timeout: float = 4, watchdog_intervall: float = 1.0):
         """
         :param url: url of the server.

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -20,11 +20,10 @@ class UASocketProtocol(asyncio.Protocol):
     OPEN = 'open'
     CLOSED = 'closed'
 
-    def __init__(self, timeout: float = 1, security_policy: ua.SecurityPolicy = ua.SecurityPolicy(), before_request_hook: Callable[[], Awaitable[None]] = None):
+    def __init__(self, timeout: float = 1, security_policy: ua.SecurityPolicy = ua.SecurityPolicy()):
         """
         :param timeout: Timeout in seconds
         :param security_policy: Security policy (optional)
-        :param before_request_hook: Hook for upperlayer tasks before a request is send (optional)
         """
         self.logger = logging.getLogger(f"{__name__}.UASocketProtocol")
         self.transport: Optional[asyncio.Transport] = None
@@ -41,7 +40,8 @@ class UASocketProtocol(asyncio.Protocol):
         # needed to pass params from asynchronous request to synchronous data receive callback, as well as
         # passing back the processed response to the request so that it can return it.
         self._open_secure_channel_exchange: Union[ua.OpenSecureChannelResponse, ua.OpenSecureChannelParameters, None] = None
-        self._before_request_hook = before_request_hook
+        # Hook for upperlayer tasks before a request is send (optional)
+        self.pre_request_hook: Optional[Callable[[], Awaitable[None]]] = None
 
     def connection_made(self, transport: asyncio.Transport):  # type: ignore
         self.state = self.OPEN
@@ -145,17 +145,16 @@ class UASocketProtocol(asyncio.Protocol):
         Returns response object if no callback is provided.
         """
         timeout = self.timeout if timeout is None else timeout
-        if self._before_request_hook:
+        if self.pre_request_hook:
             # This will propagade exceptions from background tasks to the libary user before calling a request which will
             # timeout then.
-            await self._before_request_hook()
+            await self.pre_request_hook()
         try:
             data = await asyncio.wait_for(self._send_request(request, timeout, message_type), timeout if timeout else None)
         except Exception:
             if self.state != self.OPEN:
                 raise ConnectionError("Connection is closed") from None
             raise
-
         self.check_answer(data, f" in response to {request.__class__.__name__}")
         return data
 
@@ -247,10 +246,9 @@ class UaClient:
     In this Python implementation  most of the structures are defined in
     uaprotocol_auto.py and uaprotocol_hand.py available under asyncua.ua
     """
-    def __init__(self, timeout: float = 1, before_request_hook: Callable[[], Awaitable[None]] = None):
+    def __init__(self, timeout: float = 1.0):
         """
         :param timeout: Timout in seconds
-        :param before_request_hook: Hook to execute before a request
         """
         self.logger = logging.getLogger(f'{__name__}.UaClient')
         self._subscription_callbacks = {}
@@ -258,14 +256,25 @@ class UaClient:
         self.security_policy = ua.SecurityPolicy()
         self.protocol: UASocketProtocol = None
         self._publish_task = None
-        self._before_request_hook = before_request_hook
+        self._pre_request_hook: Optional[Callable[[], Awaitable[None]]] = None
 
     def set_security(self, policy: ua.SecurityPolicy):
         self.security_policy = policy
 
     def _make_protocol(self):
-        self.protocol = UASocketProtocol(self._timeout, security_policy=self.security_policy, before_request_hook=self._before_request_hook)
+        self.protocol = UASocketProtocol(self._timeout, security_policy=self.security_policy)
+        self.protocol.pre_request_hook = self._pre_request_hook
         return self.protocol
+
+    @property
+    def pre_request_hook(self) -> Callable[[], Awaitable[None]]:
+        return self._pre_request_hook
+
+    @pre_request_hook.setter
+    def pre_request_hook(self, hook: Optional[Callable[[], Awaitable[None]]]):
+        self._pre_request_hook = hook
+        if self.protocol:
+            self.protocol.pre_request_hook = self._pre_request_hook
 
     async def connect_socket(self, host: str, port: int):
         """Connect to server socket."""

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -44,4 +44,11 @@ async def test_client_connection_lost():
         await srv.stop()
         await asyncio.sleep(2)
         with pytest.raises(ConnectionError):
+            # check if connection is alive
+            await cl.check_connection()
+        # check if exception is correct rethrown on second call
+        with pytest.raises(ConnectionError):
+            await cl.check_connection()
+        # check if a exception is thrown when a normal function is called
+        with pytest.raises(ConnectionError):
             await cl.get_namespace_array()

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,10 +1,11 @@
 # coding: utf-8
+import asyncio
 import pytest
 
-from asyncua import Client
+from asyncua import Client, Server
 from asyncua.ua.uaerrors import BadMaxConnectionsReached
 
-from .conftest import port_num
+from .conftest import port_num, find_free_port
 
 pytestmark = pytest.mark.asyncio
 
@@ -30,3 +31,17 @@ async def test_safe_disconnect():
     await c.disconnect()
     # second disconnect should be noop
     await c.disconnect()
+
+
+async def test_client_connection_lost():
+    # Test the disconnect behavoir
+    port = find_free_port()
+    srv = Server()
+    await srv.init()
+    srv.set_endpoint(f'opc.tcp://127.0.0.1:{port}')
+    await srv.start()
+    async with Client(f'opc.tcp://127.0.0.1:{port}', timeout=0.5, watchdog_intervall=1) as cl:
+        await srv.stop()
+        await asyncio.sleep(2)
+        with pytest.raises(ConnectionError):
+            await cl.get_namespace_array()


### PR DESCRIPTION
This adds a new task to pull the connection status, which will prevent a session timeout as of #977. Is also used in the next step to inform all subscriptions about a connection lose. 
Also add a hook to check if this task an `_renew_channel_loop` thrown a exception. See #974.