### PR TITLE
Always close session

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -261,15 +261,20 @@ class Client:
             await self.open_secure_channel()
             try:
                 await self.create_session()
+                try:
+                    await self.activate_session(username=self._username, password=self._password, certificate=self.user_certificate)
+                except Exception:
+                    # clean up session
+                    await self.close_session()
+                    raise
             except Exception:
                 # clean up secure channel
-                self.close_secure_channel()
+                await self.close_secure_channel()
                 raise
         except Exception:
             # clean up open socket
             self.disconnect_socket()
             raise
-        await self.activate_session(username=self._username, password=self._password, certificate=self.user_certificate)
 
     async def disconnect(self):
         """
@@ -290,8 +295,7 @@ class Client:
         await self.uaclient.connect_socket(self.server_url.hostname, self.server_url.port)
 
     def disconnect_socket(self):
-        if self.uaclient:
-            self.uaclient.disconnect_socket()
+        self.uaclient.disconnect_socket()
 
     async def send_hello(self):
         """

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -7,7 +7,7 @@ from typing import Dict, List, Optional, Union
 
 from asyncua import ua
 from ..ua.ua_binary import struct_from_binary, uatcp_to_binary, struct_to_binary, nodeid_from_binary, header_from_binary
-from ..ua.uaerrors import BadTimeout, BadNoSubscription, BadSessionClosed, UaStructParsingError
+from ..ua.uaerrors import BadTimeout, BadNoSubscription, BadSessionClosed, BadUserAccessDenied, UaStructParsingError
 from ..common.connection import SecureConnection
 
 
@@ -334,6 +334,9 @@ class UaClient:
             #          we can just ignore it therefore.
             #          Alternatively we could make sure that there are no publish requests in flight when
             #          closing the session.
+            pass
+        except BadUserAccessDenied:
+            # Problem: older versions of asyncua didn't allow closing non-activated sessions. just ignore it.
             pass
 
     async def browse(self, parameters):

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -272,7 +272,8 @@ class UaClient:
         if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
             self.logger.warning("disconnect_socket was called but connection is closed")
             return None
-        return self.protocol.disconnect_socket()
+        self.protocol.disconnect_socket()
+        self.protocol = None
 
     async def send_hello(self, url, max_messagesize: int = 0, max_chunkcount: int = 0):
         await self.protocol.send_hello(url, max_messagesize, max_chunkcount)

--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -149,6 +149,7 @@ class UaProcessor:
 
     async def _process_message(self, typeid, requesthdr, seqhdr, body):
         if typeid in [ua.NodeId(ua.ObjectIds.CreateSessionRequest_Encoding_DefaultBinary),
+                      ua.NodeId(ua.ObjectIds.CloseSessionRequest_Encoding_DefaultBinary),
                       ua.NodeId(ua.ObjectIds.ActivateSessionRequest_Encoding_DefaultBinary),
                       ua.NodeId(ua.ObjectIds.FindServersRequest_Encoding_DefaultBinary),
                       ua.NodeId(ua.ObjectIds.GetEndpointsRequest_Encoding_DefaultBinary)]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -390,6 +390,8 @@ async def ha_client(ha_config, ha_servers):
 async def wait_clients_socket(ha_client, state):
     for client in ha_client.get_clients():
         for _ in range(RETRY):
+            if state == UASocketProtocol.CLOSED and not client.uaclient.protocol:
+                break
             if client.uaclient.protocol and client.uaclient.protocol.state == state:
                 # for connection OPEN, also wait for the session to be established
                 # otherwise we can encounter failure on disconnect
@@ -399,7 +401,7 @@ async def wait_clients_socket(ha_client, state):
                 else:
                     break
             await sleep(SLEEP)
-        assert client.uaclient.protocol.state == state
+        assert (not client.uaclient.protocol and state == UASocketProtocol.CLOSED) or client.uaclient.protocol.state == state
 
 
 async def wait_sub_in_real_map(ha_client, sub, negation=False):

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -25,6 +25,8 @@ async def test_max_connections_1(opc):
     opc.server.iserver.isession.__class__.max_connections = 1000
 
 
-async def safe_disconnect():
+async def test_safe_disconnect():
     c = Client(url="opc.tcp://example:4840")
+    await c.disconnect()
+    # second disconnect should be noop
     await c.disconnect()

--- a/tests/test_crypto_connect.py
+++ b/tests/test_crypto_connect.py
@@ -248,10 +248,6 @@ async def test_certificate_handling_failure(srv_crypto_one_cert):
         async with clt:
             assert await clt.get_objects_node().get_children()
 
-    with pytest.raises(ua.uaerrors.BadUserAccessDenied):
-        # disconnect manually to close the event loop and appease pytest
-        await clt.disconnect()
-
 
 async def test_encrypted_private_key_handling_failure(srv_crypto_one_cert):
     _, cert = srv_crypto_one_cert
@@ -268,10 +264,6 @@ async def test_encrypted_private_key_handling_failure(srv_crypto_one_cert):
         )
         async with clt:
             assert await clt.get_objects_node().get_children()
-
-    with pytest.raises(ua.uaerrors.BadUserAccessDenied):
-        # disconnect manually to close the event loop and appease pytest
-        await clt.disconnect()
 
 
 async def test_certificate_handling_mismatched_creds(srv_crypto_one_cert):
@@ -413,9 +405,6 @@ async def test_anonymous_rejection():
         cert,
         mode=ua.MessageSecurityMode.SignAndEncrypt
     )
-    with pytest.raises(ua.UaStatusCodeError) as exc_info:
+    with pytest.raises(ua.uaerrors.BadIdentityTokenRejected):
         await clt.connect()
-    with pytest.raises(ua.UaStatusCodeError):
-        await clt.disconnect()
-    assert ua.StatusCodes.BadIdentityTokenRejected == exc_info.type.code
     await srv.stop()

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -125,8 +125,4 @@ async def test_permissions_anonymous(srv_crypto_one_cert):
     )
     await clt.connect()
     await clt.get_endpoints()
-    with pytest.raises(ua.uaerrors.BadUserAccessDenied):
-        # currently CloseSessionRequest ist not allowed so excpetion is expected
-        # why CloseSession is not allowed if CreateSession works?
-        # but to prevent leaking tasks we do disconnect and get the exception
-        await clt.disconnect()
+    await clt.disconnect()


### PR DESCRIPTION
Properly close session and cancel _renew_channel_task if connect() fails in activate_session(). This avoids the need for calling disconnect() after connect() failed, leading to better call semantics.

Unfortunately, CloseSessionRequest wasn't allowed to be called in an inactivated session (it is now).
For compatibility with older asyncua servers, BadUserAccessDenied gets ignored in CloseSessionResponse.

This also cleans up some tests, which needed to call disconnect() but expected it to fail.