### PR TITLE
Fix default value of LocalTime field

### DIFF
--- a/asyncua/common/event_objects.py
+++ b/asyncua/common/event_objects.py
@@ -6,7 +6,7 @@ Model Uri:http://opcfoundation.org/UA/"
 Version:1.04.10"
 Publication date:2021-09-15T00:00:00Z"
 
-File creation Date:2022-04-30 13:47:49.823843"
+File creation Date:2022-08-18 16:12:45.602922"
 """
 from asyncua import ua
 from .events import Event
@@ -28,7 +28,7 @@ class BaseEvent(Event):
         self.add_property('SourceName', None, ua.VariantType.String)
         self.add_property('Time', None, ua.VariantType.DateTime)
         self.add_property('ReceiveTime', None, ua.VariantType.DateTime)
-        self.add_property('LocalTime', ua.NodeId(ua.ObjectIds.TimeZoneDataType), ua.VariantType.ExtensionObject)
+        self.add_property('LocalTime', ua.uaprotocol_auto.TimeZoneDataType(), ua.VariantType.ExtensionObject)
         self.add_property('Message', ua.LocalizedText(message), ua.VariantType.LocalizedText)
         self.add_property('Severity', severity, ua.VariantType.UInt16)
 

--- a/schemas/generate_event_objects.py
+++ b/schemas/generate_event_objects.py
@@ -79,7 +79,7 @@ from .events import Event
         elif reference.refBrowseName == "Message":
             return "ua.LocalizedText(message)"
         elif reference.refBrowseName == "LocalTime":
-            return "ua.NodeId(ua.ObjectIds.TimeZoneDataType)"
+            return "ua.uaprotocol_auto.TimeZoneDataType()"
         elif reference.refDataType == "NodeId":
             return "ua.NodeId(ua.ObjectIds.{0})".format(
                 str(ob_ids.ObjectIdNames[int(str(reference.refId).split("=")[1])]).split("_")[0])


### PR DESCRIPTION
Fix default value of LocalTime field in BaseEvent
    
The first argument to add_property sets the default value of the property on the Event. In the case of LocalTime, this should be a python TimeZoneDataType object instead of the NodeId of the TimeZoneDataType ObjectType Node.