### PR TITLE
Server: prevent denial of service from malformed packet

### DIFF
--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -136,11 +136,11 @@ class XmlImporter:
         for nodedata in nodes_parsed:  # self.parser:
             try:
                 node = await self._add_node_data(nodedata, no_namespace_migration=True)
+                nodes.append(node)
             except Exception as e:
                 _logger.warning("failure adding node %s %s", nodedata, e)
                 if self.strict_mode:
                     raise
-            nodes.append(node)
         self.refs, remaining_refs = [], self.refs
         await self._add_references(remaining_refs)
         missing_nodes = await self._add_missing_reverse_references(nodes)

--- a/asyncua/server/binary_server_asyncio.py
+++ b/asyncua/server/binary_server_asyncio.py
@@ -67,12 +67,12 @@ class OPCUAProtocol(asyncio.Protocol):
                 except NotEnoughData:
                     # a packet should at least contain a header otherwise it is malformed (8 or 12 bytes)
                     logger.debug('Not enough data while parsing header from client, empty the buffer')
-                    self._buffer = b''
+                    self.transport.close()
                     return
                 if header.header_size + header.body_size <= header.header_size:
                     # malformed header prevent invalid access of your buffer
                     logger.error(f'Got malformed header {header}')
-                    self._buffer = b''
+                    self.transport.close()
                 else:
                     if len(buf) < header.body_size:
                         logger.debug('We did not receive enough data from client. Need %s got %s', header.body_size,

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,10 +1,9 @@
 # coding: utf-8
 import asyncio
 import pytest
-import asyncio
+import struct
 from asyncua import Client, Server, ua
 from asyncua.ua.uaerrors import BadMaxConnectionsReached
-import struct
 from .conftest import port_num, find_free_port
 
 pytestmark = pytest.mark.asyncio

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -34,9 +34,10 @@ async def test_dos_server(opc):
         c.uaclient.protocol.transport.write(struct.pack("<3scI", message_type, chunk_type, packet_size))
         # sleep to give the server time to handle the message because we bypass the asyncio
         await asyncio.sleep(1.0)
-        # now try to read a value to see if server is still alive
-        server_time_node = c.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
-        await server_time_node.read_value()
+        with pytest.raises(ConnectionError):
+            # now try to read a value to see if server is still alive
+            server_time_node = c.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
+            await server_time_node.read_value()
 
 
 async def test_safe_disconnect():

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,10 +1,10 @@
 # coding: utf-8
 import asyncio
 import pytest
-
-from asyncua import Client, Server
+import asyncio
+from asyncua import Client, Server, ua
 from asyncua.ua.uaerrors import BadMaxConnectionsReached
-
+import struct
 from .conftest import port_num, find_free_port
 
 pytestmark = pytest.mark.asyncio
@@ -24,6 +24,20 @@ async def test_max_connections_1(opc):
                 async with Client(f'opc.tcp://127.0.0.1:{port}'):
                     pass
     opc.server.iserver.isession.__class__.max_connections = 1000
+
+
+async def test_dos_server(opc):
+    # See issue 1013 a crafted packet triggered dos
+    port = opc.server.endpoint.port
+    async with Client(f'opc.tcp://127.0.0.1:{port}') as c:
+        # craft invalid packet that trigger dos
+        message_type, chunk_type, packet_size = [ua.MessageType.SecureOpen, b'E', 0]
+        c.uaclient.protocol.transport.write(struct.pack("<3scI", message_type, chunk_type, packet_size))
+        # sleep to give the server time to handle the message because we bypass the asyncio
+        await asyncio.sleep(1.0)
+        # now try to read a value to see if server is still alive
+        server_time_node = c.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
+        await server_time_node.read_value()
 
 
 async def test_safe_disconnect():


### PR DESCRIPTION
See #1013. Prevent packets with invalid content from tricking the internal buffer and trigger a denial of service.