### PR TITLE
Always take NamespaceIndex into account when comparing NodeIds

### DIFF
--- a/asyncua/common/events.py
+++ b/asyncua/common/events.py
@@ -216,7 +216,7 @@ async def select_event_attributes_from_type_node(node: "Node", attributeSelector
     curr_node = node
     while True:
         attributes.extend(await attributeSelector(curr_node))
-        if curr_node.nodeid.Identifier == ua.ObjectIds.BaseEventType:
+        if curr_node.nodeid == ua.NodeId(ua.ObjectIds.BaseEventType):
             break
         parents = await curr_node.get_referenced_nodes(
             refs=ua.ObjectIds.HasSubtype, direction=ua.BrowseDirection.Inverse
@@ -247,7 +247,7 @@ async def get_event_obj_from_type_node(node):
         if node.nodeid.Identifier in asyncua.common.event_objects.IMPLEMENTED_EVENTS.keys():
             return asyncua.common.event_objects.IMPLEMENTED_EVENTS[node.nodeid.Identifier]()
 
-    parent_identifier, parent_eventtype = await _find_parent_eventtype(node)
+    parent_nodeid, parent_eventtype = await _find_parent_eventtype(node)
 
     class CustomEvent(parent_eventtype):
 
@@ -270,7 +270,7 @@ async def get_event_obj_from_type_node(node):
 
         async def init(self):
             curr_node = node
-            while curr_node.nodeid.Identifier != parent_identifier:
+            while curr_node.nodeid != parent_nodeid:
                 for prop in await curr_node.get_properties():
                     await self._add_new_property(prop, None)
                 for var in await curr_node.get_variables():
@@ -298,5 +298,5 @@ async def _find_parent_eventtype(node):
         raise UaError("Parent of event type could not be found")
     if parents[0].nodeid.NamespaceIndex == 0:
         if parents[0].nodeid.Identifier in asyncua.common.event_objects.IMPLEMENTED_EVENTS.keys():
-            return parents[0].nodeid.Identifier, asyncua.common.event_objects.IMPLEMENTED_EVENTS[parents[0].nodeid.Identifier]
+            return parents[0].nodeid, asyncua.common.event_objects.IMPLEMENTED_EVENTS[parents[0].nodeid.Identifier]
     return await _find_parent_eventtype(parents[0])

--- a/asyncua/common/xmlexporter.py
+++ b/asyncua/common/xmlexporter.py
@@ -357,7 +357,7 @@ class XmlExporter:
         refs = await obj.get_references()
         refs_el = Et.SubElement(parent_el, 'References')
         for ref in refs:
-            if ref.ReferenceTypeId.Identifier in o_ids.ObjectIdNames:
+            if ref.ReferenceTypeId.NamespaceIndex == 0 and ref.ReferenceTypeId.Identifier in o_ids.ObjectIdNames:
                 ref_name = o_ids.ObjectIdNames[ref.ReferenceTypeId.Identifier]
             else:
                 ref_name = self._node_to_string(ref.ReferenceTypeId)

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -173,7 +173,7 @@ class XmlImporter:
                 dangling_refs_to_missing_nodes.discard(new_node_id)
                 dangling_refs_to_missing_nodes.discard(ref.NodeId)
 
-                if ref.ReferenceTypeId.Identifier not in __unidirectional_types:
+                if ref.ReferenceTypeId.NamespaceIndex != 0 or ref.ReferenceTypeId.Identifier not in __unidirectional_types:
                     ref_key = (new_node_id, ref.NodeId, ref.ReferenceTypeId)
                     node_reference_map[ref_key] = ref
 

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -298,7 +298,7 @@ class NodeManagementService:
 
             # check properties
             for ref in self._aspace[item.ParentNodeId].references:
-                if ref.ReferenceTypeId.Identifier == ua.ObjectIds.HasProperty:
+                if ref.ReferenceTypeId == ua.NodeId(ua.ObjectIds.HasProperty):
                     if item.BrowseName.Name == ref.BrowseName.Name:
                         self.logger.warning(
                             f"AddNodesItem: Requested Browsename {item.BrowseName.Name}"

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -823,16 +823,16 @@ async def test_add_node_with_type(opc):
     f = await objects.add_folder(3, 'MyFolder_TypeTest')
 
     o = await f.add_object(3, 'MyObject1', ua.ObjectIds.BaseObjectType)
-    assert ua.ObjectIds.BaseObjectType == (await o.read_type_definition()).Identifier
+    assert ua.NodeId(ua.ObjectIds.BaseObjectType) == await o.read_type_definition()
 
     o = await f.add_object(3, 'MyObject2', ua.NodeId(ua.ObjectIds.BaseObjectType, 0))
-    assert ua.ObjectIds.BaseObjectType == (await o.read_type_definition()).Identifier
+    assert ua.NodeId(ua.ObjectIds.BaseObjectType) == await o.read_type_definition()
 
     base_otype = opc.opc.get_node(ua.ObjectIds.BaseObjectType)
     custom_otype = await base_otype.add_object_type(2, 'MyFooObjectType2')
 
     o = await f.add_object(3, 'MyObject3', custom_otype.nodeid)
-    assert custom_otype.nodeid.Identifier == (await o.read_type_definition()).Identifier
+    assert custom_otype.nodeid == await o.read_type_definition()
 
     references = await o.get_references(refs=ua.ObjectIds.HasTypeDefinition, direction=ua.BrowseDirection.Forward)
     assert 1 == len(references)
@@ -852,7 +852,7 @@ async def test_references_for_added_nodes(opc):
     )
     assert objects in nodes
     assert objects == await o.get_parent()
-    assert ua.ObjectIds.BaseObjectType == (await o.read_type_definition()).Identifier
+    assert ua.NodeId(ua.ObjectIds.BaseObjectType) == await o.read_type_definition()
     assert [] == await o.get_references(ua.ObjectIds.HasModellingRule)
 
     o2 = await o.add_object(3, 'MySecondObject')
@@ -865,7 +865,7 @@ async def test_references_for_added_nodes(opc):
     )
     assert o in nodes
     assert o == await o2.get_parent()
-    assert ua.ObjectIds.BaseObjectType == (await o2.read_type_definition()).Identifier
+    assert ua.NodeId(ua.ObjectIds.BaseObjectType) == await o2.read_type_definition()
     assert [] == await o2.get_references(ua.ObjectIds.HasModellingRule)
 
     v = await o.add_variable(3, 'MyVariable', 6)
@@ -878,7 +878,7 @@ async def test_references_for_added_nodes(opc):
     )
     assert o in nodes
     assert o == await v.get_parent()
-    assert ua.ObjectIds.BaseDataVariableType == (await v.read_type_definition()).Identifier
+    assert ua.NodeId(ua.ObjectIds.BaseDataVariableType) == await v.read_type_definition()
     assert [] == await v.get_references(ua.ObjectIds.HasModellingRule)
 
     p = await o.add_property(3, 'MyProperty', 2)
@@ -891,7 +891,7 @@ async def test_references_for_added_nodes(opc):
     )
     assert o in nodes
     assert o == await p.get_parent()
-    assert ua.ObjectIds.PropertyType == (await p.read_type_definition()).Identifier
+    assert ua.NodeId(ua.ObjectIds.PropertyType) == await p.read_type_definition()
     assert [] == await p.get_references(ua.ObjectIds.HasModellingRule)
 
     m = await objects.get_child("2:ServerMethod")
@@ -943,7 +943,7 @@ async def test_copy_node(opc):
     assert 4 == len(await mydevice.get_children())
     _ = await mydevice.get_child(["0:controller"])
     prop = await mydevice.get_child(["0:controller", "0:state"])
-    assert ua.ObjectIds.PropertyType == (await prop.read_type_definition()).Identifier
+    assert ua.NodeId(ua.ObjectIds.PropertyType) == await prop.read_type_definition()
     assert "Running" == await prop.read_value()
     assert prop.nodeid != prop_t.nodeid
 
@@ -985,7 +985,7 @@ async def test_instantiate_1(opc):
     with pytest.raises(ua.uaerrors.BadNoMatch):
         await mydevice.get_child(["0:MyDeviceDerived"])
 
-    assert ua.ObjectIds.PropertyType == (await prop.read_type_definition()).Identifier
+    assert ua.NodeId(ua.ObjectIds.PropertyType) == await prop.read_type_definition()
     assert "Running" == await prop.read_value()
     assert prop.nodeid != prop_t.nodeid
 
@@ -1022,7 +1022,7 @@ async def test_instantiate_string_nodeid(opc):
     obj_nodeid_ident = obj.nodeid.Identifier
     prop = await mydevice.get_child(["0:controller", "0:state"])
     assert "InstDevice.controller" == obj_nodeid_ident
-    assert ua.ObjectIds.PropertyType == (await prop.read_type_definition()).Identifier
+    assert ua.NodeId(ua.ObjectIds.PropertyType) == await prop.read_type_definition()
     assert "Running" == await prop.read_value()
     assert prop.nodeid != prop_t.nodeid
     await opc.opc.delete_nodes([dev_t])


### PR DESCRIPTION
This fix mostly applies to custom event or reference types, which coincidentally have the same Identifier than a predefined type with NamespaceIndex 0.