### PR TITLE
union allow multiple fields with the same type

### DIFF
--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -221,6 +221,7 @@ class {struct_name}{base_class}:
     if is_union:
         # Generate getter and setter to mimic opc ua union access
         names = [f[1] for f in fields]
+        code += "    _union_types = [" + ','.join(names) + "]\n"
         code += "    Value: Union[None, " + ','.join(names) + "] = field(default=None, init=False)"
         for enc_idx, fd in enumerate(fields):
             name, uatype, _ = fd

--- a/asyncua/ua/ua_binary.py
+++ b/asyncua/ua/ua_binary.py
@@ -281,8 +281,7 @@ def create_dataclass_serializer(dataclazz):
     if issubclass(dataclazz, ua.UaUnion):
         # Union is a class with Encoding and Value field
         # the value is depended of encoding
-        union_field = next(filter(lambda f: type_is_union(f.type), data_fields))
-        encoding_funcs = [field_serializer(types) for types in types_from_union(union_field.type)]
+        encoding_funcs = [field_serializer(t) for t in dataclazz._union_types]
 
         def union_serialize(obj):
             bin = Primitives.UInt32.pack(obj.Encoding)
@@ -609,8 +608,7 @@ def _create_dataclass_deserializer(objtype):
     if issubclass(objtype, ua.UaUnion):
         # unions are just objects with encoding and value field
         typefields = fields(objtype)
-        union_types = next(types_from_union(f.type) for f in typefields if f.name == "Value")
-        field_deserializers = [_create_type_deserializer(type) for type in union_types]
+        field_deserializers = [_create_type_deserializer(t) for t in objtype._union_types]
         byte_decode = next(_create_type_deserializer(f.type) for f in typefields if f.name == "Encoding")
 
         def decode_union(data):


### PR DESCRIPTION
In the conversation of #839 we found the following:
A union datatype with multiple fields that contain the same datatype wasn't possible. 
An example that didn't work in pseudo code:
```
Union{
    Error: ua.UInt16
    GoodString: ua.String
    Good: ua.UInt16
}
```
To fix it I added a field **_union_types** that contained a list with all types in the correct order