### PR TITLE
server: exit on malformed packet

### DIFF
--- a/asyncua/server/binary_server_asyncio.py
+++ b/asyncua/server/binary_server_asyncio.py
@@ -74,6 +74,7 @@ class OPCUAProtocol(asyncio.Protocol):
                     # malformed header prevent invalid access of your buffer
                     logger.error(f'Got malformed header {header}')
                     self.transport.close()
+                    return
                 else:
                     if len(buf) < header.body_size:
                         logger.debug('We did not receive enough data from client. Need %s got %s', header.body_size, len(buf))

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -27,7 +27,6 @@ async def test_max_connections_1(opc):
     opc.server.iserver.isession.__class__.max_connections = 1000
 
 
-@pytest.mark.skip("disabled for now, sending too small packet does not break anything")
 async def test_dos_server(opc):
     # See issue 1013 a crafted packet triggered dos
     port = opc.server.endpoint.port


### PR DESCRIPTION
enable test for malformed header again and add missing return to prevent endless loop.