### PR TITLE
correct 1.04 struct basedatatype

### DIFF
--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -78,14 +78,15 @@ async def new_struct(
     sdef = ua.StructureDefinition()
     if is_union:
         sdef.StructureType = ua.StructureType.Union
+        sdef.BaseDataType = server.nodes.base_union_type.nodeid
     else:
+        sdef.BaseDataType = server.nodes.base_structure_type.nodeid
         sdef.StructureType = ua.StructureType.Structure
         for sfield in fields:
             if sfield.IsOptional:
                 sdef.StructureType = ua.StructureType.StructureWithOptionalFields
                 break
     sdef.Fields = fields
-    sdef.BaseDataType = server.nodes.base_data_type.nodeid
     sdef.DefaultEncodingId = enc.nodeid
 
     await dtype.write_data_type_definition(sdef)

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -512,6 +512,8 @@ class XmlImporter:
             attrs.ValueRank = obj.rank
         if obj.abstract:
             attrs.IsAbstract = obj.abstract
+        else:
+            obj.abstract = False
         if obj.dimensions:
             attrs.ArrayDimensions = obj.dimensions
         node.NodeAttributes = attrs
@@ -550,6 +552,8 @@ class XmlImporter:
             attrs.InverseName = ua.LocalizedText(obj.inversename)
         if obj.abstract:
             attrs.IsAbstract = obj.abstract
+        else:
+            obj.abstract = False
         if obj.symmetric:
             attrs.Symmetric = obj.symmetric
         node.NodeAttributes = attrs
@@ -566,6 +570,8 @@ class XmlImporter:
         attrs.DisplayName = ua.LocalizedText(obj.displayname)
         if obj.abstract:
             attrs.IsAbstract = obj.abstract
+        else:
+            obj.abstract = False
         if not obj.definitions:
             pass
         else:

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -513,7 +513,7 @@ class XmlImporter:
         if obj.abstract:
             attrs.IsAbstract = obj.abstract
         else:
-            obj.abstract = False
+            attrs.IsAbstract = False
         if obj.dimensions:
             attrs.ArrayDimensions = obj.dimensions
         node.NodeAttributes = attrs
@@ -553,7 +553,7 @@ class XmlImporter:
         if obj.abstract:
             attrs.IsAbstract = obj.abstract
         else:
-            obj.abstract = False
+            attrs.IsAbstract = False
         if obj.symmetric:
             attrs.Symmetric = obj.symmetric
         node.NodeAttributes = attrs
@@ -571,7 +571,7 @@ class XmlImporter:
         if obj.abstract:
             attrs.IsAbstract = obj.abstract
         else:
-            obj.abstract = False
+            attrs.IsAbstract = False
         if not obj.definitions:
             pass
         else:


### PR DESCRIPTION
Fixes #1051
As of spec basedatatype should be:
<html>
<body>
<!--StartFragment-->

baseDataType | NodeId | The NodeId of the direct supertype of the DataType. This might be the abstract Structure or the Union DataType.
-- | -- | --


<!--EndFragment-->
</body>
</html>

In the xml importer abstract has to False as default value:
``` XML
 <xs:attribute name="IsAbstract" type="xs:boolean" default="false" />
```
