### PR TITLE
Fixes/fix xml import recursive struct

### DIFF
--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -201,6 +201,8 @@ class {struct_name}{base_class}:
             uatype = ua.enums_by_datatype[sfield.DataType].__name__
         elif sfield.DataType in ua.basetype_by_datatype:
             uatype = ua.basetype_by_datatype[sfield.DataType]
+        elif sfield.DataType == data_type:
+            uatype = struct_name
         else:
             if log_error:
                 logger.error(f"Unknown datatype for field: {sfield} in structure:{struct_name}, please report")
@@ -211,7 +213,11 @@ class {struct_name}{base_class}:
         else:
             default_value = get_default_value(uatype)
 
-        uatype = f"ua.{uatype}"
+        if sfield.DataType != data_type:
+            uatype = f"ua.{uatype}"
+        else:
+            # when field point to itself datatype use forward reference for typing
+            uatype = f"'ua.{uatype}'"
         if sfield.ValueRank >= 1 and uatype == 'Char':
             uatype = 'String'
         elif sfield.ValueRank >= 1 or sfield.ArrayDimensions:

--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -314,7 +314,7 @@ class DataTypeSorter:
             if dep_nodeid not in self.dtype_index:
                 continue
             dep = self.dtype_index[dep_nodeid]
-            if dep.depends_on(other):
+            if dep != self and dep.depends_on(other):
                 return True
         return False
 

--- a/tests/custom_struct_recursive.xml
+++ b/tests/custom_struct_recursive.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd" xmlns:ua="http://unifiedautomation.com/Configuration/NodeSet.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <NamespaceUris>
+        <Uri>http://examples.freeopcua.github.io</Uri>
+    </NamespaceUris>
+    <Aliases>
+        <!-- <Alias Alias="String">i=12</Alias> -->
+        <Alias Alias="MyParameterType">ns=1;i=1001</Alias>
+        <Alias Alias="MyParameterAlsoType">ns=1;i=1002</Alias>
+    </Aliases>
+    <Extensions>
+        <Extension>
+            <ua:ModelInfo Tool="UaModeler" Hash="N9NP1ZtvG/6K4zwcil7BIw==" Version="1.6.7"/>
+        </Extension>
+    </Extensions>
+
+    <UADataType NodeId="ns=1;i=1001" BrowseName="1:MyParameterType">
+        <DisplayName>MyParameterType</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+        </References>
+        <Definition Name="1:MyParameterType">
+            <Field DataType="MyParameterType" ValueRank="1" ArrayDimensions="0" Name="Subparameters"/>
+        </Definition>
+    </UADataType>
+
+  <UADataType NodeId="ns=1;i=1002" BrowseName="1:MyParameterAlsoType">
+        <DisplayName>MyParameterAlsoType</DisplayName>
+        <References>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+        </References>
+        <Definition Name="1:MyParameterAlsoType">
+            <Field DataType="MyParameterAlsoType" ValueRank="1" ArrayDimensions="0" Name="Subparameters"/>
+        </Definition>
+    </UADataType>
+
+
+
+</UANodeSet>

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1460,6 +1460,20 @@ async def test_custom_struct_import(opc):
     with expect_file_creation("custom_enum_v2.xml") as path:
         await opc.opc.export_xml(nodes, path)
 
+async def test_custom_struct_recursive_import(opc):
+    nodes = await opc.opc.import_xml("tests/custom_struct_recursive.xml")
+    await opc.opc.load_data_type_definitions()
+
+    nodes = [opc.opc.get_node(node) for node in nodes]  # FIXME why does it return nodeids and not nodes?
+    node = nodes[0]  # FIXME: make that more robust
+    sdef = await node.read_data_type_definition()
+
+    assert sdef.StructureType == ua.StructureType.Structure
+    assert sdef.Fields[0].Name == "Subparameters"
+    with expect_file_creation("custom_struct_recursive_export.xml") as path:
+        await opc.opc.export_xml(nodes, path)
+
+
 
 async def test_enum_string_identifier_and_spaces(opc):
     idx = 4


### PR DESCRIPTION
When trying to import xml nodeset with a struct that is recursive `load_data_type_definitions()` will fail.

Example of such a struct:
```
<UADataType NodeId="ns=1;i=1001" BrowseName="1:MyParameterType">
        <DisplayName>MyParameterType</DisplayName>
        <References>
            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
        </References>
        <Definition Name="1:MyParameterType">
            <Field DataType="MyParameterType" ValueRank="1" ArrayDimensions="0" Name="Subparameters"/>
        </Definition>
 </UADataType>
```

There are two issues with the load_data_type_definitions that are fixed:
* The depends_on function results in an unlimited recursive call ending with an exception
* Creating of the type information for the dataclass can find the datatype (because it doesn't exits)

Test is added to validate the behaviour.

PR is not yet squashed, so separeate commits for the fixes.

