### PR TITLE
Set _closing to False in create_session.

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -393,6 +393,7 @@ class Client:
         If you want o modify settings look at code of this methods
         and make your own
         """
+        self._closing = False
         desc = ua.ApplicationDescription()
         desc.ApplicationUri = self.application_uri
         desc.ProductUri = self.product_uri

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -318,6 +318,7 @@ class UaClient:
 
     async def create_session(self, parameters):
         self.logger.info("create_session")
+        self._closing = False
         # FIXME: setting a value on an object to set it its state is suspicious,
         # especially when that object has its own state
         self.protocol.closed = False


### PR DESCRIPTION
One of our tests revealed a problem with the latest 0.9.98 where if doing `close_session` followed by `create_session` no subscription updates would be received after creating a subscription. The cause seems to be that `self._closing` is not set to False when recreating a session, so the `publish_loop` won't run.