### PR TITLE
Fix typo in in XmlImporte._check_if_namespace_meta_information_is_add ed which results in an exception

### DIFF
--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -103,7 +103,7 @@ class XmlImporter:
         for uri, version, pub_date in self.parser.get_nodeset_namespaces():
             if uri not in ns_objs:
                 idx = await self.server.register_namespace(uri)
-                obj = await self.nodes.namespaces.add_object(idx, uri, ua.ObjectIds.NamespaceMetadataType, False)
+                obj = await self.server.nodes.namespaces.add_object(idx, uri, ua.ObjectIds.NamespaceMetadataType, False)
                 ns_uri = await obj.get_child('NamespaceUri')
                 await ns_uri.write_value(uri, ua.VariantType.String)
                 ns_ver = await obj.get_child('NamespaceVersion')

--- a/tests/custom_ns_meta_add.xml
+++ b/tests/custom_ns_meta_add.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd" xmlns:s1="http://foobar.org/struct_optional/Types.xsd" xmlns:ua="http://unifiedautomation.com/Configuration/NodeSet.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <NamespaceUris>
+        <Uri>http://foobar.org/struct_optional/</Uri>
+    </NamespaceUris>
+    <Models>
+        <Model ModelUri="http://foobar.org/struct_optional/" PublicationDate="2022-10-03T11:29:34Z" Version="1.0.0">
+            <RequiredModel ModelUri="http://opcfoundation.org/UA/" PublicationDate="2022-01-24T00:00:00Z" Version="1.05.01"/>
+        </Model>
+    </Models>
+</UANodeSet>

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -23,6 +23,7 @@ CUSTOM_NODES_NS_XML_PATH = BASE_DIR / "custom_nodesns.xml"
 CUSTOM_NODES_NS_XML_PATH1 = BASE_DIR / "custom_nodesns_2.xml"
 CUSTOM_NODES_NS_XML_PATH2 = BASE_DIR / "custom_nodesns_3.xml"
 CUSTOM_NODES_NS_XML_PATH3 = BASE_DIR / "custom_nodesns_4.xml"
+CUSTOM_NS_META_ADD_XML_PATH = BASE_DIR / "custom_ns_meta_add.xml"
 CUSTOM_REQ_XML_PASS_PATH = BASE_DIR / "test_requirement_pass.xml"
 CUSTOM_REQ_XML_FAIL_PATH = BASE_DIR / "test_requirement_fail.xml"
 
@@ -592,3 +593,9 @@ async def test_disable_xml_export_without_value(opc, tmpdir):
     assert dv.Value != v.Value
     assert v.Value.Value is None
     await opc.opc.delete_nodes([o2])
+
+async def test_xml_namespace_meta_add(opc):
+    with pytest.raises(ValueError):
+        await opc.opc.get_namespace_index("http://foobar.org/struct_optional/")
+    await opc.opc.import_xml(CUSTOM_NS_META_ADD_XML_PATH)
+    assert await opc.opc.get_namespace_index("http://foobar.org/struct_optional/") == 2

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -598,4 +598,4 @@ async def test_xml_namespace_meta_add(opc):
     with pytest.raises(ValueError):
         await opc.opc.get_namespace_index("http://foobar.org/struct_optional/")
     await opc.opc.import_xml(CUSTOM_NS_META_ADD_XML_PATH)
-    assert await opc.opc.get_namespace_index("http://foobar.org/struct_optional/") == 2
+    assert await opc.opc.get_namespace_index("http://foobar.org/struct_optional/") > 0


### PR DESCRIPTION
Fix typo in in `XmlImporte._check_if_namespace_meta_information_is_add` ed which results in an exception.

In case it was required after the import to still add an ns an exception occured. On normal flow the line `_check_if_namespace_meta_information_is_added`s  with the typo isn't executed and no test was available to test the behaviour.

* Added test for `_check_if_namespace_meta_information_is_added`
* Fix the typo:
```python
obj = await self.nodes.namespaces.add_object(idx, uri, ua.ObjectIds.NamespaceMetadataType, False)
```
should be:
```python
obj = await self.server.nodes.namespaces.add_object(idx, uri, ua.ObjectIds.NamespaceMetadataType, False)
```