### PR TITLE
added the parameter to the parser and xml importer

### DIFF
--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -644,6 +644,7 @@ class XmlImporter:
             f.DataType = field.datatype
             f.ValueRank = field.valuerank
             f.IsOptional = field.optional
+            f.MaxStringLength = field.max_str_len
             if f.IsOptional:
                 optional = True
             if field.arraydim is None:

--- a/asyncua/common/xmlparser.py
+++ b/asyncua/common/xmlparser.py
@@ -84,6 +84,7 @@ class Field:
         self.arraydim = data.get("ArrayDimensions", None)  # FIXME: check type
         self.value = int(data.get("Value", 0))
         self.desc = data.get("Description", "")
+        self.max_str_len = int(data.get("MaxStringLength", 0))
 
 
 class RefStruct:


### PR DESCRIPTION
The parameter/metadata MaxStringSize for string fields in structures is missing. This PR fixes that.