### PR TITLE
Add missing attribute to node data

### DIFF
--- a/asyncua/common/xmlparser.py
+++ b/asyncua/common/xmlparser.py
@@ -58,6 +58,7 @@ class NodeData:
         self.accesslevel = None
         self.useraccesslevel = None
         self.minsample = None
+        self.historizing = False
 
         # referencetype
         self.inversename = ""


### PR DESCRIPTION
Attribute id 20, historizing is missing from NodeData class.
https://reference.opcfoundation.org/v104/Core/docs/Part6/A.1/