### PR TITLE
Respect DataChangeTrigger in server

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -779,14 +779,9 @@ class AddressSpace:
             # Only check datatype if no bad StatusCode is set
             return ua.StatusCode(ua.StatusCodes.BadTypeMismatch)
 
-        old = attval.value
         attval.value = value
-        cbs = []
-        # only send call callback when a value or status code change has happened
-        if (old.Value != value.Value) or (old.StatusCode != value.StatusCode):
-            cbs = list(attval.datachange_callbacks.items())
 
-        for k, v in cbs:
+        for k, v in attval.datachange_callbacks.items():
             try:
                 await v(k, value)
             except Exception as ex:


### PR DESCRIPTION
Moves DataChange filtering from address_space to monitored_item_service, and uses the configured DataChangeTrigger instead of always detecting changes in status/value.

Solves #1098