### PR TITLE
Only set value to Null if status code is bad

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -771,7 +771,7 @@ class AddressSpace:
         attval = node.attributes.get(attr, None)
         if attval is None:
             return ua.StatusCode(ua.StatusCodes.BadAttributeIdInvalid)
-        if value.StatusCode is not None and not value.StatusCode.is_good():
+        if value.StatusCode is not None and value.StatusCode.is_bad():
             # https://reference.opcfoundation.org/v104/Core/docs/Part4/7.7.1/
             # If the StatusCode indicates an error then the value is to be ignored and the Server shall set it to null.
             value = dataclasses.replace(value, Value=ua.Variant(ua.Null(), ua.VariantType.Null))

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -329,12 +329,33 @@ class StatusCode:
 
     def is_good(self):
         """
-        return True if status is Good.
+        return True if status is Good (00).
         """
         mask = 3 << 30
-        if mask & self.value:
-            return False
-        return True
+        if mask & self.value == 0x00000000:
+            return True
+        return False
+
+    def is_bad(self):
+        """
+        https://reference.opcfoundation.org/v104/Core/docs/Part4/7.34.1/
+        11   Reserved for future use. All Clients should treat a StatusCode with this severity as “Bad”.
+
+        return True if status is Bad (10) or (11).
+        """
+        mask = 3 << 30
+        if mask & self.value in (0x80000000, 0xc0000000):
+            return True
+        return False
+
+    def is_uncertain(self):
+        """
+        return True if status is Uncertain (01).
+        """
+        mask = 3 << 30
+        if mask & self.value == 0x40000000:
+            return True
+        return False
 
     @property
     def name(self):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -182,6 +182,30 @@ def test_nodeid_ordering():
     assert mylist == expected
 
 
+def test_status_code_severity():
+    good_statuscodes = (ua.StatusCodes.Good, ua.StatusCodes.GoodLocalOverride)
+    bad_statuscodes = (ua.StatusCodes.Bad, ua.StatusCodes.BadConditionDisabled)
+    uncertain_statuscodes = (ua.StatusCodes.Uncertain, ua.StatusCodes.UncertainSimulatedValue)
+
+    for good_statuscode in good_statuscodes:
+        statuscode = ua.StatusCode(good_statuscode)
+        assert statuscode.is_good()
+        assert not statuscode.is_bad()
+        assert not statuscode.is_uncertain()
+
+    for bad_statuscode in bad_statuscodes:
+        statuscode = ua.StatusCode(bad_statuscode)
+        assert not statuscode.is_good()
+        assert statuscode.is_bad()
+        assert not statuscode.is_uncertain()
+
+    for uncertain_statuscode in uncertain_statuscodes:
+        statuscode = ua.StatusCode(uncertain_statuscode)
+        assert not statuscode.is_good()
+        assert not statuscode.is_bad()
+        assert statuscode.is_uncertain()
+
+
 def test_string_to_variant_int():
     s_arr_uint = "[1, 2, 3, 4]"
     arr_uint = [1, 2, 3, 4]


### PR DESCRIPTION
Previously it also did so for uncertain status code.

Fixes #1102 