### PR TITLE
Enable usage of certificates that are already loaded into memory

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -159,10 +159,10 @@ class Client:
     async def set_security(
         self,
         policy: Type[ua.SecurityPolicy],
-        certificate: Union[str, uacrypto.CertProperties],
-        private_key: Union[str, uacrypto.CertProperties],
+        certificate: Union[str, uacrypto.CertProperties, bytes],
+        private_key: Union[str, uacrypto.CertProperties, bytes],
         private_key_password: Optional[Union[str, bytes]] = None,
-        server_certificate: Optional[Union[str, uacrypto.CertProperties]] = None,
+        server_certificate: Optional[Union[str, uacrypto.CertProperties, bytes]] = None,
         mode: ua.MessageSecurityMode = ua.MessageSecurityMode.SignAndEncrypt,
     ):
         """
@@ -196,10 +196,10 @@ class Client:
     ):
 
         if isinstance(server_cert, uacrypto.CertProperties):
-            server_cert = await uacrypto.load_certificate(server_cert.path, server_cert.extension)
-        cert = await uacrypto.load_certificate(certificate.path, certificate.extension)
+            server_cert = await uacrypto.load_certificate(server_cert.path_or_content, server_cert.extension)
+        cert = await uacrypto.load_certificate(certificate.path_or_content, certificate.extension)
         pk = await uacrypto.load_private_key(
-            private_key.path,
+            private_key.path_or_content,
             private_key.password,
             private_key.extension,
         )

--- a/asyncua/crypto/uacrypto.py
+++ b/asyncua/crypto/uacrypto.py
@@ -17,18 +17,27 @@ from dataclasses import dataclass
 
 @dataclass
 class CertProperties:
-    path: str
+    path_or_content: Union[str, bytes]
     extension: Optional[str] = None
     password: Optional[Union[str, bytes]] = None
 
 
-async def load_certificate(path: str, extension: Optional[str] = None):
-    _, ext = os.path.splitext(path)
-    async with aiofiles.open(path, mode='rb') as f:
-        if ext == ".pem" or extension == 'pem' or extension == 'PEM':
-            return x509.load_pem_x509_certificate(await f.read(), default_backend())
-        else:
-            return x509.load_der_x509_certificate(await f.read(), default_backend())
+async def get_content(path_or_content: Union[str, bytes]) -> bytes:
+    if isinstance(path_or_content, bytes):
+        return path_or_content
+
+    async with aiofiles.open(path_or_content, mode='rb') as f:
+        return await f.read()
+
+
+async def load_certificate(path_or_content: Union[str, bytes], extension: Optional[str] = None):
+    _, ext = os.path.splitext(path_or_content)
+
+    content = await get_content(path_or_content)
+    if ext == ".pem" or extension == 'pem' or extension == 'PEM':
+        return x509.load_pem_x509_certificate(content, default_backend())
+    else:
+        return x509.load_der_x509_certificate(content, default_backend())
 
 
 def x509_from_der(data):
@@ -37,17 +46,18 @@ def x509_from_der(data):
     return x509.load_der_x509_certificate(data, default_backend())
 
 
-async def load_private_key(path: str,
+async def load_private_key(path_or_content: Union[str, bytes],
                            password: Optional[Union[str, bytes]] = None,
                            extension: Optional[str] = None):
-    _, ext = os.path.splitext(path)
+    _, ext = os.path.splitext(path_or_content)
     if isinstance(password, str):
         password = password.encode('utf-8')
-    async with aiofiles.open(path, mode='rb') as f:
-        if ext == ".pem" or extension == 'pem' or extension == 'PEM':
-            return serialization.load_pem_private_key(await f.read(), password=password, backend=default_backend())
-        else:
-            return serialization.load_der_private_key(await f.read(), password=password, backend=default_backend())
+
+    content = await get_content(path_or_content)
+    if ext == ".pem" or extension == 'pem' or extension == 'PEM':
+        return serialization.load_pem_private_key(content, password=password, backend=default_backend())
+    else:
+        return serialization.load_der_private_key(content, password=password, backend=default_backend())
 
 
 def der_from_x509(certificate):

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -7,7 +7,7 @@ import logging
 import math
 from datetime import timedelta, datetime
 from urllib.parse import urlparse
-from typing import Coroutine, Optional, Tuple
+from typing import Coroutine, Optional, Tuple, Union
 
 from asyncua import ua
 from .binary_server_asyncio import BinaryServer
@@ -206,14 +206,14 @@ class Server:
         return f"OPC UA Server({self.endpoint.geturl()})"
     __repr__ = __str__
 
-    async def load_certificate(self, path: str, format: str = None):
+    async def load_certificate(self, path_or_content: Union[str, bytes], format: str = None):
         """
         load server certificate from file, either pem or der
         """
-        self.certificate = await uacrypto.load_certificate(path, format)
+        self.certificate = await uacrypto.load_certificate(path_or_content, format)
 
-    async def load_private_key(self, path, password=None, format=None):
-        self.iserver.private_key = await uacrypto.load_private_key(path, password, format)
+    async def load_private_key(self, path_or_content: Union[str, bytes], password=None, format=None):
+        self.iserver.private_key = await uacrypto.load_private_key(path_or_content, password, format)
 
     def disable_clock(self, val: bool = True):
         """


### PR DESCRIPTION
Certificates, that are already loaded into memory as bytes, can now directly be handed over to set_security and load_certificate.

Renaming the parameter to `path_or_content` might not be that beautiful, but not too cumbersome and does the job. But I'm open for other names.

My first intention was to offer an `io`-based alternative instead of bytes, but during the implementation, `bytes` felt more natural. 