### PR TITLE
UaFile: Comfort method to write file

### DIFF
--- a/asyncua/client/ua_file.py
+++ b/asyncua/client/ua_file.py
@@ -8,6 +8,8 @@ class UaFile:
         self._handle = None
         if open_mode == 'r':
             self._init_open = ua.OpenFileMode.Read.value
+        elif open_mode == 'w':
+            self._init_open = ua.OpenFileMode.Write.value
         else:
             raise ValueError("file mode is not supported")
 
@@ -36,6 +38,13 @@ class UaFile:
         read_node = await self._file_node.get_child("Read")
         arg1 = ua.Variant(self._handle, ua.VariantType.UInt32)
         arg2 = ua.Variant(size, ua.VariantType.Int32)
+        return await self._file_node.call_method(read_node, arg1, arg2)
+
+    async def write(self, data: bytes):
+        """ writes file contents """
+        read_node = await self._file_node.get_child("Write")
+        arg1 = ua.Variant(self._handle, ua.VariantType.UInt32)
+        arg2 = ua.Variant(data, ua.VariantType.ByteString)
         return await self._file_node.call_method(read_node, arg1, arg2)
 
     async def get_size(self):

--- a/asyncua/client/ua_file.py
+++ b/asyncua/client/ua_file.py
@@ -42,10 +42,10 @@ class UaFile:
 
     async def write(self, data: bytes):
         """ writes file contents """
-        read_node = await self._file_node.get_child("Write")
+        write_node = await self._file_node.get_child("Write")
         arg1 = ua.Variant(self._handle, ua.VariantType.UInt32)
         arg2 = ua.Variant(data, ua.VariantType.ByteString)
-        return await self._file_node.call_method(read_node, arg1, arg2)
+        return await self._file_node.call_method(write_node, arg1, arg2)
 
     async def get_size(self):
         """ gets size of file """


### PR DESCRIPTION
Currently it is possible to write a file with the low-level file services, but the comfort function in `asyncua/client/ua_file.py` is missing.

I have now added the `write()` method to `asyncua/client/ua_file.py`. This allows to write a file comfortably without using the low-level functions.

```python
async with Client(url=url) as client:
    file_node = client.get_node("ns=2;s=NameOfNode")
    async with UaFile(file_node, 'w') as ua_file:
        with open("filename.txt", 'rb') as fd:
            data = fd.read()
            await ua_file.write(data) # write file
```