### PR TITLE
Set ServerTimestamp when attributes/values are written

### DIFF
--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -110,7 +110,7 @@ class InternalServer:
             attr.Value = ua.DataValue(
                 ua.Variant(10000, ua.VariantType.UInt32),
                 StatusCode_=ua.StatusCode(ua.StatusCodes.Good),
-                ServerTimestamp=datetime.utcnow(),
+                SourceTimestamp=datetime.utcnow(),
             )
             params.NodesToWrite.append(attr)
         result = await self.isession.write(params)

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -139,6 +139,12 @@ class Server:
         """
         self.iserver.match_discovery_source_ip = match_discovery_client_ip
 
+    def set_force_server_timestamp(self, force_server_timestamp: bool):
+        """
+        Enables or disables automatically setting ServerTimestamp on Value attributes
+        """
+        self.iserver.aspace.force_server_timestamp = force_server_timestamp
+
     async def set_build_info(self, product_uri, manufacturer_name, product_name, software_version,
                              build_number, build_date):
 


### PR DESCRIPTION
This is a follow up on #461.

According to [7.11.4 ServerTimestamp](https://reference.opcfoundation.org/Core/Part4/7.11.4/): The serverTimestamp is used to reflect the time that the Server received a Variable value or knew it to be accurate.

I think it shouldn't be set by a client, so it gets overwritten if specified. After working with some historian systems, I came to the conclusion, that it's essential to always use the same clock for each kind of timestamp.

SourceTimestamp is only set for Value Attributes, the spec doesn't specify this for ServerTimestamp, so I assume it's ok to be set for all attributes.