### PR TITLE
Truncate datetime

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -194,7 +194,7 @@ def win_epoch_to_datetime(epch):
         # FILETIMEs after 31 Dec 9999 are truncated to max value
         return MAX_FILETIME_EPOCH_DATETIME
     if epch < 0:
-        return 0
+        return FILETIME_EPOCH_AS_DATETIME
     return FILETIME_EPOCH_AS_DATETIME + timedelta(microseconds=epch // 10)
 
 

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -45,6 +45,8 @@ FILETIME_EPOCH_AS_DATETIME = datetime(1601, 1, 1)
 FILETIME_EPOCH_AS_UTC_DATETIME = FILETIME_EPOCH_AS_DATETIME.replace(tzinfo=timezone.utc)
 MAX_FILETIME_EPOCH_DATETIME = datetime(9999, 12, 31, 23, 59, 59)
 MAX_FILETIME_EPOCH_AS_UTC_DATETIME = MAX_FILETIME_EPOCH_DATETIME.replace(tzinfo=timezone.utc)
+MAX_OPC_FILETIME = int((MAX_FILETIME_EPOCH_DATETIME - FILETIME_EPOCH_AS_DATETIME).total_seconds()) * HUNDREDS_OF_NANOSECONDS
+MAX_INT64 = 2 ** 63 - 1
 
 
 def type_is_union(uatype):
@@ -180,7 +182,7 @@ def datetime_to_win_epoch(dt: datetime):
     # A date/time is encoded as the maximum value for an Int64 if either
     # The value is equal to or greater than 9999-12-31 11:59:59PM UTC,
     if dt >= max_ep:
-        return 9223372036854775807
+        return MAX_INT64
     return 10 * ((dt - ref) // _microsecond)
 
 
@@ -189,7 +191,7 @@ def get_win_epoch():
 
 
 def win_epoch_to_datetime(epch):
-    if epch >= 2650467743989999999:
+    if epch >= MAX_OPC_FILETIME:
         # FILETIMEs after 31 Dec 9999 are truncated to max value
         return MAX_FILETIME_EPOCH_DATETIME
     if epch < 0:

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -173,7 +173,6 @@ def datetime_to_win_epoch(dt: datetime):
     else:
         ref = FILETIME_EPOCH_AS_UTC_DATETIME
         max_ep = MAX_FILETIME_EPOCH_AS_UTC_DATETIME
-    ref = FILETIME_EPOCH_AS_DATETIME if dt.tzinfo is None else FILETIME_EPOCH_AS_UTC_DATETIME
     # Python datetime starts from year 1, opc ua only support dates starting 1601-01-01 12:00AM UTC
     # So we need to trunc the value to zero
     if ref >= dt:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -544,6 +544,9 @@ def test_datetime():
     assert epch == epch2
     epch = 0
     assert ua.datetime_to_win_epoch(ua.win_epoch_to_datetime(epch)) == epch
+    # Test if values that are out of range are either min or max
+    assert ua.datetime_to_win_epoch(datetime.min) == 0
+    assert ua.datetime_to_win_epoch(datetime.max) == (2**63) - 1
 
 
 def test_equal_nodeid():

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -546,7 +546,7 @@ def test_datetime():
     assert ua.datetime_to_win_epoch(ua.win_epoch_to_datetime(epch)) == epch
     # Test if values that are out of range are either min or max
     assert ua.datetime_to_win_epoch(datetime.min) == 0
-    assert ua.datetime_to_win_epoch(datetime.max) == (2**63) - 1
+    assert ua.datetime_to_win_epoch(datetime.max) == ua.MAX_INT64
 
 
 def test_equal_nodeid():


### PR DESCRIPTION
#1155
If a datetime is equal or before 1601-01-01 12:00AM UTC or equal or later  9999-12-31 11:59:59PM UTC return the correct values as of https://reference.opcfoundation.org/Core/Part6/v105/docs/5.2.2.5#_Ref400565610 .
Also removed the warning in win_epoch_to_datetime. Because the behavior is defined in the spec. 
