### PR TITLE
Interpret Null UserIdentityToken as Anonymous during ActivateSession

### DIFF
--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -89,6 +89,10 @@ class InternalSession(AbstractSession):
         for _ in params.ClientSoftwareCertificates:
             result.Results.append(ua.StatusCode())
         id_token = params.UserIdentityToken
+        if isinstance(id_token, ua.ExtensionObject) and id_token.TypeId == ua.NodeId(ua.ObjectIds.Null):
+            # https://reference.opcfoundation.org/Core/Part4/v104/docs/5.6.3
+            # Null or empty user token shall always be interpreted as anonymous.
+            id_token = ua.AnonymousIdentityToken()
         # Check if security policy is supported
         if not isinstance(id_token, self.iserver.supported_tokens):
             self.logger.error('Rejected active session UserIdentityToken not supported')

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -769,3 +769,19 @@ class TestServerStartError(unittest.TestCase):
         server1.stop()
         server2.stop()
 """
+
+async def test_null_auth(server):
+    """
+    OPC-UA Specification Part 4, 5.6.3 specifies that a:
+    > Null or empty user token shall always be interpreted as anonymous
+
+    Ensure a Null token is accepted as an anonymous connection token.
+    """
+    client = Client(server.endpoint.geturl())
+    # Modify the authentication creation in the client request
+    def _add_null_auth(self, params):
+        params.UserIdentityToken = ua.ExtensionObject(ua.NodeId(ua.ObjectIds.Null))
+    client._add_anonymous_auth = _add_null_auth.__get__(client, Client)
+    # Attempt to connect, this should be accepted without error
+    async with client:
+        pass


### PR DESCRIPTION
OPC-UA specification Part 4, 5.6.3 specifies that a Null or empty user token shall always be interpreted as anonymous. Add a test for this case and a fix to properly handle it.

I have a client that uses a Null token when connecting that is refused by the server. I don't know if the empty case would be different.

I'm not sure if the fix should remain in `internal_session.py` or move somewhere in the parser or accepted tokens, feel free to point me toward a more suitable place if needed.