### PR TITLE
Don't use ua.Null

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -780,7 +780,7 @@ class AddressSpace:
         if value.StatusCode is not None and value.StatusCode.is_bad():
             # https://reference.opcfoundation.org/v104/Core/docs/Part4/7.7.1/
             # If the StatusCode indicates an error then the value is to be ignored and the Server shall set it to null.
-            value = dataclasses.replace(value, Value=ua.Variant(ua.Null(), ua.VariantType.Null))
+            value = dataclasses.replace(value, Value=ua.Variant(None, ua.VariantType.Null))
         elif not self._is_expected_variant_type(value, attval, node):
             # Only check datatype if no bad StatusCode is set
             return ua.StatusCode(ua.StatusCodes.BadTypeMismatch)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -131,7 +131,7 @@ async def test_read_and_write_status_check(server, client):
     # check that reading the value does not generate an error
     # with raise_on_bad_status set to False
     val = await v1.read_data_value(False)
-    assert type(val.Value.Value) is ua.Null, "Value should be Null if StatusCode is Bad"
+    assert val.Value.Value is None, "Value should be Null if StatusCode is Bad"
     assert val.StatusCode_ == testStatusCode, "StatusCode expected " \
         + str(val.StatusCode_) + ", but instead got " + str(testStatusCode)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -651,7 +651,7 @@ async def test_write_value(opc):
 async def test_write_value_statuscode_bad(opc):
     o = opc.opc.nodes.objects
     var = ua.Variant('Some value that should not be set!')
-    dvar = ua.DataValue(ua.Null(), StatusCode_=ua.StatusCode(ua.StatusCodes.BadDeviceFailure))
+    dvar = ua.DataValue(None, StatusCode_=ua.StatusCode(ua.StatusCodes.BadDeviceFailure))
     v = await o.add_variable(3, 'VariableValueBad', var)
     await v.write_value(dvar)
     with pytest.raises(ua.UaStatusCodeError) as error_read:


### PR DESCRIPTION
Prefer `None` over `ua.Null()`, otherwise a check in server code like `value.Value.Value is None` doesn't work