### PR TITLE
fix-register-server-sessionless

### DIFF
--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -444,7 +444,6 @@ class UaClient(AbstractSession):
         self.logger.debug("register_server")
         request = ua.RegisterServerRequest()
         request.Server = registered_server
-        request.Server.IsOnline = True
         data = await self.protocol.send_request(request)
         response = struct_from_binary(ua.RegisterServerResponse, data)
         self.logger.debug(response)
@@ -452,10 +451,9 @@ class UaClient(AbstractSession):
         # nothing to return for this service
     
     async def unregister_server(self, registered_server):
-        self.logger.debug("register_server")
+        self.logger.debug("unregister_server")
         request = ua.RegisterServerRequest()
         request.Server = registered_server
-        request.Server.IsOnline = False
         data = await self.protocol.send_request(request)
         response = struct_from_binary(ua.RegisterServerResponse, data)
         self.logger.debug(response)
@@ -464,6 +462,16 @@ class UaClient(AbstractSession):
 
     async def register_server2(self, params):
         self.logger.debug("register_server2")
+        request = ua.RegisterServer2Request()
+        request.Parameters = params
+        data = await self.protocol.send_request(request)
+        response = struct_from_binary(ua.RegisterServer2Response, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.ConfigurationResults
+
+    async def unregister_server2(self, params):
+        self.logger.debug("unregister_server2")
         request = ua.RegisterServer2Request()
         request.Parameters = params
         data = await self.protocol.send_request(request)

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -444,6 +444,18 @@ class UaClient(AbstractSession):
         self.logger.debug("register_server")
         request = ua.RegisterServerRequest()
         request.Server = registered_server
+        request.Server.IsOnline = True
+        data = await self.protocol.send_request(request)
+        response = struct_from_binary(ua.RegisterServerResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        # nothing to return for this service
+    
+    async def unregister_server(self, registered_server):
+        self.logger.debug("register_server")
+        request = ua.RegisterServerRequest()
+        request.Server = registered_server
+        request.Server.IsOnline = False
         data = await self.protocol.send_request(request)
         response = struct_from_binary(ua.RegisterServerResponse, data)
         self.logger.debug(response)

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -283,7 +283,7 @@ class Server:
         """
         stop registration thread
         """
-        # FIXME: is there really no way to deregister?
+        # FIXME: is there really no way to deregister? -> isOnline false! https://reference.opcfoundation.org/Core/Part4/v104/docs/7.27#_Ref413265664
         await self._discovery_clients[url].close_secure_channel() 
         await self._discovery_clients[url].disconnect_socket()
         del self._discovery_clients[url]

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -284,6 +284,7 @@ class Server:
         stop registration thread
         """
         # FIXME: is there really no way to deregister? -> isOnline false! https://reference.opcfoundation.org/Core/Part4/v104/docs/7.27#_Ref413265664
+        await self._discovery_clients[url].unregister_server(self)
         await self._discovery_clients[url].close_secure_channel() 
         await self._discovery_clients[url].disconnect_socket()
         del self._discovery_clients[url]

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -295,7 +295,7 @@ class Server:
     async def _renew_registration(self):
         for client in self._discovery_clients.values():
             await client.connect_sessionless()
-            await client.register_server(self)
+            await client.register_server(self)  #FIXME discovery_configuration?
             await client.disconnect_sessionless()
 
     def allow_remote_admin(self, allow):

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -268,9 +268,12 @@ class Server:
         """
         # FIXME: have a period per discovery
         if url in self._discovery_clients:
-            await self._discovery_clients[url].disconnect()
+            await self._discovery_clients[url].close_secure_channel() 
+            await self._discovery_clients[url].disconnect_socket()
         self._discovery_clients[url] = Client(url)
-        await self._discovery_clients[url].connect()
+        await self._discovery_clients[url].connect_socket()
+        await self._discovery_clients[url].send_hello()
+        await self._discovery_clients[url].open_secure_channel()
         await self._discovery_clients[url].register_server(self)
         self._discovery_period = period
         if period:
@@ -281,7 +284,8 @@ class Server:
         stop registration thread
         """
         # FIXME: is there really no way to deregister?
-        await self._discovery_clients[url].disconnect()
+        await self._discovery_clients[url].close_secure_channel() 
+        await self._discovery_clients[url].disconnect_socket()
         del self._discovery_clients[url]
         if not self._discovery_clients and self._discovery_handle:
             self._discovery_handle.cancel()

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -259,7 +259,7 @@ class Server:
         params.ServerUris = uris
         return self.iserver.find_servers(params)
 
-    async def register_to_discovery(self, url: str = "opc.tcp://localhost:4840", period: int = 60):
+    async def register_to_discovery(self, url: str = "opc.tcp://localhost:4840", period: int = 60, discovery_configuration=None):
         """
         Register to an OPC-UA Discovery server. Registering must be renewed at
         least every 10 minutes, so this method will use our asyncio thread to
@@ -268,25 +268,22 @@ class Server:
         """
         # FIXME: have a period per discovery
         if url in self._discovery_clients:
-            await self._discovery_clients[url].close_secure_channel() 
-            await self._discovery_clients[url].disconnect_socket()
+            await self._discovery_clients[url].disconnect_sessionless()
         self._discovery_clients[url] = Client(url)
-        await self._discovery_clients[url].connect_socket()
-        await self._discovery_clients[url].send_hello()
-        await self._discovery_clients[url].open_secure_channel()
-        await self._discovery_clients[url].register_server(self)
+        await self._discovery_clients[url].connect_sessionless()
+        await self._discovery_clients[url].register_server(self, discovery_configuration)
+        await self._discovery_clients[url].disconnect_sessionless()
         self._discovery_period = period
         if period:
             asyncio.get_running_loop().call_soon(self._schedule_renew_registration)
 
-    async def unregister_to_discovery(self, url: str = "opc.tcp://localhost:4840"):
+    async def unregister_from_discovery(self, url: str = "opc.tcp://localhost:4840", discovery_configuration=None):
         """
         stop registration thread
         """
-        # FIXME: is there really no way to deregister? -> isOnline false! https://reference.opcfoundation.org/Core/Part4/v104/docs/7.27#_Ref413265664
-        await self._discovery_clients[url].unregister_server(self)
-        await self._discovery_clients[url].close_secure_channel() 
-        await self._discovery_clients[url].disconnect_socket()
+        await self._discovery_clients[url].connect_sessionless()
+        await self._discovery_clients[url].unregister_server(self, discovery_configuration)
+        await self._discovery_clients[url].disconnect_sessionless()
         del self._discovery_clients[url]
         if not self._discovery_clients and self._discovery_handle:
             self._discovery_handle.cancel()
@@ -297,7 +294,9 @@ class Server:
 
     async def _renew_registration(self):
         for client in self._discovery_clients.values():
+            await client.connect_sessionless()
             await client.register_server(self)
+            await client.disconnect_sessionless()
 
     def allow_remote_admin(self, allow):
         """

--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -158,7 +158,10 @@ class UaProcessor:
                       ua.NodeId(ua.ObjectIds.CloseSessionRequest_Encoding_DefaultBinary),
                       ua.NodeId(ua.ObjectIds.ActivateSessionRequest_Encoding_DefaultBinary),
                       ua.NodeId(ua.ObjectIds.FindServersRequest_Encoding_DefaultBinary),
-                      ua.NodeId(ua.ObjectIds.GetEndpointsRequest_Encoding_DefaultBinary)]:
+                      ua.NodeId(ua.ObjectIds.GetEndpointsRequest_Encoding_DefaultBinary),
+                      ua.NodeId(ua.ObjectIds.RegisterServerRequest_Encoding_DefaultBinary),
+                      ua.NodeId(ua.ObjectIds.RegisterServer2Request_Encoding_DefaultBinary),
+                      ]:
             # The connection is first created without a user being attached, and then during activation the
             user = None
         elif self.session is None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,11 +41,11 @@ async def test_unregister_discovery(server, discovery_server):
         await server.register_to_discovery(discovery_server.endpoint.geturl(), period=0)
         await asyncio.sleep(0.1)
         # unregister, no automatic renewal to stop
-        await server.unregister_to_discovery(discovery_server.endpoint.geturl())
+        await server.unregister_from_discovery(discovery_server.endpoint.geturl())
         # reregister with automatic renewal
         await server.register_to_discovery(discovery_server.endpoint.geturl(), period=60)
         # unregister, cancel scheduled renewal
-        await server.unregister_to_discovery(discovery_server.endpoint.geturl())
+        await server.unregister_from_discovery(discovery_server.endpoint.geturl())
 
 
 async def test_find_servers2(server, discovery_server):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -25,7 +25,7 @@ async def test_discovery(server, discovery_server):
         await server.set_application_uri(new_app_uri)
         await server.register_to_discovery(discovery_server.endpoint.geturl(), 0)
         # let server register registration
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.5)
         new_servers = await client.find_servers()
         assert len(new_servers) - len(servers) == 1
         assert new_app_uri not in [s.ApplicationUri for s in servers]
@@ -39,11 +39,13 @@ async def test_unregister_discovery(server, discovery_server):
         await server.set_application_uri(new_app_uri)
         # register without automatic renewal
         await server.register_to_discovery(discovery_server.endpoint.geturl(), period=0)
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.5)
         # unregister, no automatic renewal to stop
         await server.unregister_from_discovery(discovery_server.endpoint.geturl())
+        await asyncio.sleep(0.5)
         # reregister with automatic renewal
         await server.register_to_discovery(discovery_server.endpoint.geturl(), period=60)
+        await asyncio.sleep(0.5)
         # unregister, cancel scheduled renewal
         await server.unregister_from_discovery(discovery_server.endpoint.geturl())
 


### PR DESCRIPTION
### Spec. Reference: https://reference.opcfoundation.org/Core/Part4/v104/docs/5.4.5

A [Server](https://reference.opcfoundation.org/search/17?t=Server)shall establish a [SecureChannel](https://reference.opcfoundation.org/search/17?t=SecureChannel)with the [Discovery Server](https://reference.opcfoundation.org/search/17?t=Discovery%20Server)before calling this [Service](https://reference.opcfoundation.org/search/17?t=Service). The [SecureChannel](https://reference.opcfoundation.org/search/17?t=SecureChannel)is described in [5.5](https://reference.opcfoundation.org/Core/Part4/v104/docs/?r=_Ref187648579). The [Administrator](https://reference.opcfoundation.org/search/17?t=Administrator)of the [Server](https://reference.opcfoundation.org/search/17?t=Server)shall provide the [Server](https://reference.opcfoundation.org/search/17?t=Server)with an [EndpointDescription](https://reference.opcfoundation.org/search/17?t=EndpointDescription)for the [Discovery Server ](https://reference.opcfoundation.org/search/17?t=Discovery%20Server)as part of the configuration process. [Discovery Servers](https://reference.opcfoundation.org/search/17?t=Discovery%20Servers)shall reject registrations if the [serverUri](https://reference.opcfoundation.org/search/17?t=serverUri)provided does not match the [applicationUri](https://reference.opcfoundation.org/search/17?t=applicationUri)in [Server Certificate](https://reference.opcfoundation.org/search/17?t=Server%20Certificate)used to create the [SecureChannel](https://reference.opcfoundation.org/search/17?t=SecureChannel).


the spec. does not say anything about creating a session!
we probalby need to rework ua_processor to process a register/register2 without a session!