### PR TITLE
[xmlexporter] fix extensionobjects typeid indentifier missing namespace mapping to idx_in_exported_file

### DIFF
--- a/asyncua/common/xmlexporter.py
+++ b/asyncua/common/xmlexporter.py
@@ -397,6 +397,8 @@ class XmlExporter:
     async def _val_to_etree(self, el, dtype, val):
         if dtype == ua.NodeId(ua.ObjectIds.NodeId) or dtype == ua.NodeId(ua.ObjectIds.ExpandedNodeId):
             id_el = Et.SubElement(el, "uax:Identifier")
+            if val.NamespaceIndex in self._addr_idx_to_xml_idx:
+                val = ua.NodeId(val.Identifier, NamespaceIndex=self._addr_idx_to_xml_idx[val.NamespaceIndex])
             id_el.text = val.to_string()
         elif dtype == ua.NodeId(ua.ObjectIds.Guid):
             id_el = Et.SubElement(el, "uax:String")


### PR DESCRIPTION
Other nodeids namespace are corrected to ``dx_in_exported_file`, only  the extensionobject typeid identifier isn't. Resulting in bad export.

Example:
```
<uax:ListOfExtensionObject>
        <uax:ExtensionObject>
          <uax:TypeId>
            <uax:Identifier>i=296</uax:Identifier>
          </uax:TypeId>
          <uax:Body>
            <uax:Argument>
              <uax:Name>MyFiled</uax:Name>
              <uax:DataType>
                <uax:Identifier>ns=3;i=3003</uax:Identifier>
              </uax:DataType>
```
In the case above `<uax:Identifier>ns=3;i=3003</uax:Identifier>` isn't corrected. This can be easly fixed in `XmlExporter._val_to_etree` by using the lookup table `self._addr_idx_to_xml_idx`.