### PR TITLE
Fix/server stop fails when bind fails

### DIFF
--- a/asyncua/server/binary_server_asyncio.py
+++ b/asyncua/server/binary_server_asyncio.py
@@ -154,11 +154,13 @@ class BinaryServer:
             transport.close()
 
         # stop cleanup process and run it a last time
-        self.cleanup_task.cancel()
-        try:
-            await self.cleanup_task
-        except asyncio.CancelledError:
-            pass
+        if self.cleanup_task is not None:
+            self.cleanup_task.cancel()
+            try:
+                await self.cleanup_task
+            except asyncio.CancelledError:
+                pass
+            
         await self._close_tasks()
 
         if self._server:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -753,23 +753,6 @@ class TestServerCaching(unittest.TestCase):
 
         os.remove(path)
 
-class TestServerStartError(unittest.TestCase):
-
-    def test_port_in_use(self):
-
-        server1 = Server()
-        server1.set_endpoint('opc.tcp://127.0.0.1:{0:d}'.format(port_num + 1))
-        server1.start()
-
-        server2 = Server()
-        server2.set_endpoint('opc.tcp://127.0.0.1:{0:d}'.format(port_num + 1))
-        try:
-            server2.start()
-        except Exception:
-            pass
-
-        server1.stop()
-        server2.stop()
 """
 
 async def test_null_auth(server):
@@ -787,3 +770,14 @@ async def test_null_auth(server):
     # Attempt to connect, this should be accepted without error
     async with client:
         pass
+
+
+async def test_start_server_when_port_is_in_use(server: str):
+    server2 = Server()
+    await server2.init()
+    url = server.endpoint.geturl()
+    server2.set_endpoint(url) # try to bind on the same endpoint as an already running server
+    with pytest.raises(OSError):
+        await server2.start()
+    # now it should still be possible to stop the server with exceptions
+    await server2.stop()


### PR DESCRIPTION
Fixes #1209 
`server.stop()` does currently cause an exception (`AttributeError: 'NoneType' object has no attribute 'cancel`')  in `BinaryServer.stop()`, when `server.start()` failed, because `BinaryServer.cleanup_task` is None in this case. 
See linked issue for details. 

With this PR, the `cleanup_task.cancel()` is only called, when `cleanup_task` is actually valid (not None). 
It might be reasonable to move the creation of the cleanup task further up in `BinaryServer.start()` but I don`t have enough insight for that. 

This PR also adds a testcase that tests correct behavior, when the port can not be bound because it is already in use. 
There was also an old (commented out)  testcase for exactly this, which I removed. 