### PR TITLE
allow non unicode bytestring nodeid

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -520,7 +520,10 @@ class NodeId:
                 identifier = uuid.UUID(f"urn:uuid:{v}")
             elif k == "b":
                 ntype = NodeIdType.ByteString
-                identifier = bytes(v, 'utf-8')
+                if v[0:2] == '0x':
+                    identifier = bytes.fromhex(v[2:])
+                else:
+                    identifier = v.encode()
             elif k == "srv":
                 srv = int(v)
             elif k == "nsu":
@@ -549,7 +552,7 @@ class NodeId:
             ntype = "g"
         elif self.NodeIdType == NodeIdType.ByteString:
             ntype = "b"
-            identifier = identifier.decode()
+            identifier = '0x' + identifier.hex()
         string.append(f"{ntype}={identifier}")
         return ";".join(string)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -149,8 +149,10 @@ async def test_delete_nodes(opc):
 
 async def test_node_bytestring(opc):
     obj = opc.opc.nodes.objects
-    var = await obj.add_variable(ua.ByteStringNodeId(b"VarByteString", 2), ua.QualifiedName("toto", 2), ua.UInt16(9))
-    node = opc.opc.get_node("ns=2;b=VarByteString")
+    var = await obj.add_variable(ua.ByteStringNodeId(b'VarByteString', 2), ua.QualifiedName("toto", 2), ua.UInt16(9))
+    node = opc.opc.get_node(f"ns=2;b=VarByteString")
+    assert node == var
+    node = opc.opc.get_node(f"ns=2;b=0x{b'VarByteString'.hex()}")
     assert node == var
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -390,6 +390,14 @@ def test_nodeid_bytestring():
     s2 = n2.to_string()
     assert n == n2
     assert s == s2
+    n = ua.ByteStringNodeId(Identifier=b'\x01\x00\x05\x55')
+    s = n.to_string()
+    n2 = ua.NodeId.from_string(s)
+    s2 = n2.to_string()
+    assert n == n2
+    assert s == s2
+    n = ua.NodeId.from_string('b=0xaabbccdd')
+    assert n.Identifier == b'\xaa\xbb\xcc\xdd'
 
 
 def test__nodeid():


### PR DESCRIPTION
Allow bytestring nodeids with non unicode bytestring. Like 0x000F0A.

Fixes #1203, #1207