### PR TITLE
fix server history save event; init list before use

### DIFF
--- a/asyncua/server/history.py
+++ b/asyncua/server/history.py
@@ -163,6 +163,9 @@ class HistoryDict(HistoryStorageInterface):
         self._events_periods[source_id] = period, count
 
     async def save_event(self, event):
+        if event.emitting_node not in self._events:
+            self._events[event.emitting_node] = []
+        evts = self._events[event.emitting_node]
         evts = self._events[event.emitting_node]
         evts.append(event)
         period, count = self._events_periods[event.emitting_node]


### PR DESCRIPTION
When event is saved it is added to `self._events[event.emitting_node]`, only that list is never initialized.
Append on line 170 will fail in that case.