### PR TITLE
[ua.uatypes.String] used str as base class instead off nothing

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -149,7 +149,7 @@ class Null:  # Null(NoneType) is not supported in Python
     pass
 
 
-class String:  # Passing None as arg will result in unexpected behaviour so disabling
+class String(str):
     pass
 
 


### PR DESCRIPTION
Most types in `ua.uatypes`, for example like `CharArray` and `Float`, are derived from a matching Python datatype.
But this isn't the case for `ua.uatypes.String`. In #609 the typedef is changed from `class String(str):` to `class String:`.

Not sure why this is done and if the original reason is still the case . If I change it back and run pytest no new errors are introduced. It even fix an existing issue in the test:
```
./tests/test_common.py::test_alias[client] Failed: [undefined]AttributeError: 'String' object has no attribute 'encode'
```

By having no str as baseclass makes use of the python typing system hard:
```python
my_string : ua.String = "" # due typing invalid
my_string : ua.String = ua.String()  # Quite unusable, return empty ua.String object
```
Fro more background informatio see discussion #1067 

