### PR TITLE
Respect EndpointUrl request parameter in GetEndpoints, FindServers and CreateSession

### DIFF
--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -64,7 +64,10 @@ class InternalSession(AbstractSession):
         result.MaxRequestMessageSize = 65536
         self.nonce = create_nonce(32)
         result.ServerNonce = self.nonce
-        result.ServerEndpoints = await self.get_endpoints(sockname=sockname)
+
+        ep_params = ua.GetEndpointsParameters()
+        ep_params.EndpointUrl = params.EndpointUrl
+        result.ServerEndpoints = await self.get_endpoints(params=ep_params, sockname=sockname)
 
         return result
 

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -128,6 +128,15 @@ class Server:
 
         await self.set_build_info(self.product_uri, self.manufacturer_name, self.name, "1.0pre", "0", datetime.now())
 
+    def set_match_discovery_endpoint_url(self, match_discovery_endpoint_url: bool):
+        """
+        Enables or disables the matching of the EndpointUrl request parameter during discovery.
+
+        When True (default), the host/port of endpoints sent during the discovery is modified to the host/port
+        which is specified in the EndpointUrl request parameter.
+        """
+        self.iserver.match_discovery_endpoint_url = match_discovery_endpoint_url
+
     def set_match_discovery_client_ip(self, match_discovery_client_ip: bool):
         """
         Enables or disables the matching of an endpoint IP to a client IP during discovery.

--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -233,7 +233,7 @@ class UaProcessor:
         elif typeid == ua.NodeId(ua.ObjectIds.FindServersRequest_Encoding_DefaultBinary):
             _logger.info("find servers request (%s)", user)
             params = struct_from_binary(ua.FindServersParameters, body)
-            servers = self.iserver.find_servers(params)
+            servers = self.iserver.find_servers(params, sockname=self.sockname)
             response = ua.FindServersResponse()
             response.Servers = servers
             # _logger.info("sending find servers response")


### PR DESCRIPTION
This is especially handy when the server runs behind NAT or inside docker container, but a static EndpointUrl cannot be used because the host is multihomed.

If no EndpointUrl is specified in the request, the server first tries to use the socket address and then falls back to the statically configured EndpointUrl.