### PR TITLE
[Datatypes] allow optional arrays

### DIFF
--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -229,8 +229,9 @@ class {struct_name}{base_class}:
             uatype = 'String'
         elif sfield.ValueRank >= 1 or sfield.ArrayDimensions:
             uatype = f"List[{uatype}]"
-        elif sfield.IsOptional:
+        if sfield.IsOptional:
             uatype = f"Optional[{uatype}]"
+            default_value = 'None'
         fields.append((fname, uatype, default_value))
     if is_union:
         # Generate getter and setter to mimic opc ua union access
@@ -256,7 +257,6 @@ class {struct_name}{base_class}:
     else:
         for fname, uatype, default_value in fields:
             code += f"    {fname}: {uatype} = {default_value}\n"
-
     return code
 
 

--- a/asyncua/ua/ua_binary.py
+++ b/asyncua/ua/ua_binary.py
@@ -261,6 +261,8 @@ def field_serializer(ftype, dataclazz) -> Callable[[Any], bytes]:
         uatype = type_from_optional(uatype)
     if type_is_list(uatype):
         ft = type_from_list(uatype)
+        if is_optional:
+            return lambda val: b'' if val is None else create_list_serializer(ft, ft == dataclazz)(val)
         return create_list_serializer(ft, ft == dataclazz)
     else:
         if ftype == dataclazz:

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -59,6 +59,22 @@ def type_is_list(uatype):
 def type_allow_subclass(uatype):
     return get_origin(uatype) not in [Union, list, None]
 
+
+def types_or_list_from_union(uatype):
+    # returns the type of a union or the list of type if a list is inside the union
+    types = []
+    for subtype in get_args(uatype):
+        if hasattr(subtype, '_paramspec_tvars'):
+            # @hack how to check if a parameter is a list:
+            # check if have _paramspec_tvars
+            return True, subtype
+        if not isinstance(None, subtype):
+            types.append(subtype)
+    if not types:
+        raise ValueError(f"Union {uatype} does not seem to contain a valid type")
+    return False, types[0]
+
+
 def types_from_union(uatype, origin=None):
     if origin is None:
         origin = get_origin(uatype)
@@ -74,8 +90,14 @@ def types_from_union(uatype, origin=None):
 def type_from_list(uatype):
     return get_args(uatype)[0]
 
+
+def type_from_optional(uatype):
+    return get_args(uatype)[0]
+
+
 def type_from_allow_subtype(uatype):
     return get_args(uatype)[0]
+
 
 def type_string_from_type(uatype):
     if type_is_union(uatype):

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -66,9 +66,14 @@ def types_or_list_from_union(uatype):
     for subtype in get_args(uatype):
         if hasattr(subtype, '_paramspec_tvars'):
             # @hack how to check if a parameter is a list:
-            # check if have _paramspec_tvars
+            # check if have _paramspec_tvars works for type[X]
             return True, subtype
-        if not isinstance(None, subtype):
+        elif hasattr(subtype, '_name'):
+            # @hack how to check if parameter is union or list
+            # if _name is not List, it is Union
+            if subtype._name == 'List':
+                return True, subtype
+        elif not isinstance(None, subtype):
             types.append(subtype)
     if not types:
         raise ValueError(f"Union {uatype} does not seem to contain a valid type")

--- a/tests/substructs.xml
+++ b/tests/substructs.xml
@@ -27,6 +27,20 @@
             <ua:ModelInfo Tool="UaModeler" Hash="l1kpQd8c2aTEMZi8xJvKfA==" Version="1.6.3"/>
         </Extension>
     </Extensions>
+        <UADataType NodeId="ns=1;i=3003" BrowseName="1:MySubstruct">
+        <DisplayName>MySubstruct</DisplayName>
+        <References>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5004</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5006</Reference>
+            <Reference ReferenceType="HasEncoding">ns=1;i=5005</Reference>
+            <Reference ReferenceType="HasSubtype" IsForward="false">i=22</Reference>
+        </References>
+        <Definition Name="1:MySubstruct">
+            <Field IsOptional="true" DataType="Double" Name="titi"/>
+            <Field IsOptional="true" DataType="Double" Name="opt_array" ValueRank="1" ArrayDimensions="0"/>
+            <Field DataType="MyStruct" ValueRank="1" ArrayDimensions="0" Name="structs"/>
+        </Definition>
+    </UADataType>
     <UADataType NodeId="ns=1;i=3002" BrowseName="1:MyStruct">
         <DisplayName>MyStruct</DisplayName>
         <References>
@@ -39,20 +53,7 @@
             <Field DataType="Double" Name="toto"/>
         </Definition>
     </UADataType>
-    <UADataType NodeId="ns=1;i=3003" BrowseName="1:MySubstruct">
-        <DisplayName>MySubstruct</DisplayName>
-        <References>
-            <Reference ReferenceType="HasEncoding">ns=1;i=5004</Reference>
-            <Reference ReferenceType="HasEncoding">ns=1;i=5006</Reference>
-            <Reference ReferenceType="HasEncoding">ns=1;i=5005</Reference>
-            <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=3002</Reference>
-        </References>
-        <Definition Name="1:MySubstruct">
-            <Field IsOptional="true" DataType="Double" Name="titi"/>
-            <Field IsOptional="true" DataType="Double" Name="opt_array" ValueRank="1" ArrayDimensions="0"/>
-            <Field DataType="MyStruct" ValueRank="1" ArrayDimensions="0" Name="structs"/>
-        </Definition>
-    </UADataType>
+
     <UAObject SymbolicName="http___yourorganisation_org_testsubstruct_" NodeId="ns=1;i=5007" BrowseName="1:http://yourorganisation.org/testsubstruct/">
         <DisplayName>http://yourorganisation.org/testsubstruct/</DisplayName>
         <References>

--- a/tests/substructs.xml
+++ b/tests/substructs.xml
@@ -49,6 +49,7 @@
         </References>
         <Definition Name="1:MySubstruct">
             <Field IsOptional="true" DataType="Double" Name="titi"/>
+            <Field IsOptional="true" DataType="Double" Name="opt_array" ValueRank="1" ArrayDimensions="0"/>
             <Field DataType="MyStruct" ValueRank="1" ArrayDimensions="0" Name="structs"/>
         </Definition>
     </UADataType>

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1146,11 +1146,13 @@ async def test_import_xml_data_type_definition(opc):
     sdef = await datatype.read_data_type_definition()
     assert isinstance(sdef, ua.StructureDefinition)
     s = ua.MyStruct()
+
     s.toto = 0.1
     ss = ua.MySubstruct()
-    assert ss.titi == None
+    assert ss.titi is None
+    assert ss.opt_array is None
     assert isinstance(ss.structs, list)
-
+    ss.opt_array = []
     ss.titi = 1
     ss.structs.append(s)
     ss.structs.append(s)
@@ -1159,6 +1161,8 @@ async def test_import_xml_data_type_definition(opc):
 
     s2 = await var.read_value()
     assert s2.structs[1].toto == ss.structs[1].toto == 0.1
+    assert s2.opt_array == []
+
     await opc.opc.delete_nodes([datatype, var])
     n = []
     [n.append(opc.opc.get_node(node)) for node in nodes]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1152,8 +1152,7 @@ async def test_import_xml_data_type_definition(opc):
     assert ss.titi is None
     assert ss.opt_array is None
     assert isinstance(ss.structs, list)
-    ss.opt_array = []
-    ss.titi = 1
+    ss.titi = 1.0
     ss.structs.append(s)
     ss.structs.append(s)
 
@@ -1161,8 +1160,11 @@ async def test_import_xml_data_type_definition(opc):
 
     s2 = await var.read_value()
     assert s2.structs[1].toto == ss.structs[1].toto == 0.1
-    assert s2.opt_array == []
-
+    assert s2.opt_array is None
+    s2.opt_array = [1]
+    await var.write_value(s2)
+    s2 = await var.read_value()
+    assert s2.opt_array == [1]
     await opc.opc.delete_nodes([datatype, var])
     n = []
     [n.append(opc.opc.get_node(node)) for node in nodes]


### PR DESCRIPTION
See end of #839. Allow Datatypes with something like this:

```Python
class X: 
      x: Optional[list[int]]
```