### PR TITLE
Correct certificate checks for application_uri and hostname

### DIFF
--- a/asyncua/crypto/uacrypto.py
+++ b/asyncua/crypto/uacrypto.py
@@ -278,7 +278,7 @@ def check_certificate(cert: x509.Certificate, application_uri: str, hostname: Op
             err = True
         if hostname is not None:
             san_dns_names = san.value.get_values_for_type(x509.DNSName)
-            if hostname is not san_dns_names:
+            if not (hostname in san_dns_names):
                 _logger.error(f'certificate does not contain the hostname in DNSNames {hostname}. Some applications will check this.')
                 err = True
     except x509.ExtensionNotFound:

--- a/asyncua/crypto/uacrypto.py
+++ b/asyncua/crypto/uacrypto.py
@@ -273,13 +273,13 @@ def check_certificate(cert: x509.Certificate, application_uri: str, hostname: Op
     try:
         san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
         san_uri = san.value.get_values_for_type(x509.UniformResourceIdentifier)
-        if application_uri is not san_uri:
-            _logger.error(f'certificate does not cotain the application uri ({application_uri}). Most applications will reject a connection without it.')
+        if not (application_uri in san_uri):
+            _logger.error(f'certificate does not contain the application uri ({application_uri}). Most applications will reject a connection without it.')
             err = True
         if hostname is not None:
             san_dns_names = san.value.get_values_for_type(x509.DNSName)
             if hostname is not san_dns_names:
-                _logger.error(f'certificate does not cotain the hostname in DNSNames {hostname}. Some applications will check this.')
+                _logger.error(f'certificate does not contain the hostname in DNSNames {hostname}. Some applications will check this.')
                 err = True
     except x509.ExtensionNotFound:
         _logger.error('certificate has no SubjectAlternativeName this is need for application verification!')


### PR DESCRIPTION
application_uri is a string, but san_uri is an array of strings. The comparison will fail therefore.
