### PR TITLE
Update handling of empty server uri params

### DIFF
--- a/asyncua/crypto/uacrypto.py
+++ b/asyncua/crypto/uacrypto.py
@@ -17,6 +17,10 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
+class InvalidSignature(Exception):
+    pass
+
+
 @dataclass
 class CertProperties:
     path_or_content: Union[bytes, Path, str]

--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -231,7 +231,7 @@ class InternalServer:
 
     def find_servers(self, params, sockname=None):
         servers = []
-        params_server_uris = [uri.split(':') for uri in params.ServerUris]
+        params_server_uris = [uri.split(':') for uri in params.ServerUris] if params.ServerUris else []
         our_application_uris = [edp.Server.ApplicationUri for edp in self.endpoints]
         for desc in self._known_servers.values():
             if params_server_uris:


### PR DESCRIPTION
When sending FindServerRequest with empty serverUris parameter ServerUris can't be looped over.

When length of the list for serverUris is -1, _create_uatype_array_deserializer will return None.
This can't be looped over.

I suggest to set params_server_uris to empty list if this happens.