### PR TITLE
Typing the nodeid field on a node.

### DIFF
--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -48,7 +48,7 @@ class Node:
     """
     def __init__(self, session: AbstractSession, nodeid: Union[ua.NodeId, str, int]):
         self.session = session
-        self.nodeid = None
+        self.nodeid: ua.NodeId
         if isinstance(nodeid, Node):
             self.nodeid = nodeid.nodeid
         elif isinstance(nodeid, ua.NodeId):


### PR DESCRIPTION
A nodeid should never be none, as instantiation of a node object will fail if the nodeid cannot be set. Properly typing nodeid helps with type checkers.