### PR TITLE
Add `read_attributes` method to `Client`

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -865,14 +865,12 @@ class Client:
             node.nodeid = node.basenodeid
             node.basenodeid = None
 
-    async def read_attributes(self, nodes, attr=ua.AttributeIds.Value):
+    async def read_attributes(self, nodes: List[Node], attr=ua.AttributeIds.Value):
         """
         Read the attributes of multiple nodes.
         """
         nodeids = [node.nodeid for node in nodes]
-        return await self.uaclient.read_attributes(
-            nodeids, ua.AttributeIds.Value
-        )
+        return await self.uaclient.read_attributes(nodeids, attr)
 
     async def read_values(self, nodes):
         """

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -865,13 +865,24 @@ class Client:
             node.nodeid = node.basenodeid
             node.basenodeid = None
 
-    async def read_values(self, nodes):
+    async def read_values(self, nodes, depth=2):
         """
         Read the value of multiple nodes in one ua call.
+
+        The 'depth' parameter defines how deep in the 'Value' attributes we
+        should extract
         """
+        if 0 > depth > 2:
+            raise ValueError("'depth' must be between 0 and 2")
         nodeids = [node.nodeid for node in nodes]
         results = await self.uaclient.read_attributes(nodeids, ua.AttributeIds.Value)
-        return [result.Value.Value for result in results]
+        vals = []
+        for r in results:
+            v = r
+            for _ in range(depth):
+                v = v.Value
+            vals.append(v)
+        return vals
 
     async def write_values(self, nodes, values):
         """

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -878,7 +878,7 @@ class Client:
         """
         Read the value of multiple nodes in one ua call.
         """
-        res = self.read_attributes(nodes, attr=ua.AttributeIds.Value)
+        res = await self.read_attributes(nodes, attr=ua.AttributeIds.Value)
         return [r.Value.Value for r in res]
 
     async def write_values(self, nodes, values):

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -865,7 +865,7 @@ class Client:
             node.nodeid = node.basenodeid
             node.basenodeid = None
 
-    async def read_attributes(self, nodes: List[Node], attr=ua.AttributeIds.Value):
+    async def read_attributes(self, nodes: List[Node], attr: ua.AttributeIds = ua.AttributeIds.Value):
         """
         Read the attributes of multiple nodes.
         """

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -865,24 +865,21 @@ class Client:
             node.nodeid = node.basenodeid
             node.basenodeid = None
 
-    async def read_values(self, nodes, depth=2):
+    async def read_attributes(self, nodes, attr=ua.AttributeIds.Value):
+        """
+        Read the attributes of multiple nodes.
+        """
+        nodeids = [node.nodeid for node in nodes]
+        return await self.uaclient.read_attributes(
+            nodeids, ua.AttributeIds.Value
+        )
+
+    async def read_values(self, nodes):
         """
         Read the value of multiple nodes in one ua call.
-
-        The 'depth' parameter defines how deep in the 'Value' attributes we
-        should extract
         """
-        if 0 > depth > 2:
-            raise ValueError("'depth' must be between 0 and 2")
-        nodeids = [node.nodeid for node in nodes]
-        results = await self.uaclient.read_attributes(nodeids, ua.AttributeIds.Value)
-        vals = []
-        for r in results:
-            v = r
-            for _ in range(depth):
-                v = v.Value
-            vals.append(v)
-        return vals
+        res = self.read_attributes(nodes, attr=ua.AttributeIds.Value)
+        return [r.Value.Value for r in res]
 
     async def write_values(self, nodes, values):
         """

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -253,7 +253,11 @@ class Client:
         pass
 
     @syncmethod
-    def read_values(self, nodes, depth=2):
+    def read_attributes(self, nodes, attr=ua.AttributeIds.Value):
+        pass
+
+    @syncmethod
+    def read_values(self, nodes):
         pass
 
     @syncmethod

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -152,7 +152,7 @@ class _SubHandler:
 
     def event_notification(self, event):
         self.sync_handler.event_notification(event)
-        
+
     def status_change_notification(self, status: ua.StatusChangeNotification):
         self.sync_handler.status_change_notification(status)
 
@@ -253,7 +253,7 @@ class Client:
         pass
 
     @syncmethod
-    def read_values(self, nodes):
+    def read_values(self, nodes, depth=2):
         pass
 
     @syncmethod
@@ -704,7 +704,7 @@ def new_enum(  # type: ignore[empty-body]
     name: Union[int, ua.QualifiedName],
     values: List[str],
     optional: bool = False
-) -> SyncNode:   
+) -> SyncNode:
     pass
 
 


### PR DESCRIPTION
`read_values` is a nice and fast way to get a bunch of values in one request, but I wanted access to the `SourceTimestamp` in addition to the `Value`, which wasn't possible with this method, so I added it. If there's another way to read the values and timestamps from hundreds of nodes in one request, this isn't necessary.