### PR TITLE
Adding historical data reading methods to SyncNode wrapper

### DIFF
--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -543,7 +543,7 @@ class Node:
         details.ReturnBounds = return_bounds
         history = []
         continuation_point = None
-        while True:
+        while len(history) < numvalues:
             result = await self.history_read(details, continuation_point)
             result.StatusCode.check()
             continuation_point = result.ContinuationPoint

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -507,6 +507,22 @@ class SyncNode:
         pass
 
     @syncmethod
+    def read_raw_history(self, starttime=None, endtime=None, numvalues=0, return_bounds=True):
+        pass
+
+    @syncmethod
+    def history_read(self, details, continuation_point=None):
+        pass
+
+    @syncmethod
+    def read_event_history(self, starttime=None, endtime=None, numvalues=0, evtypes=ua.ObjectIds.BaseEventType):
+        pass
+
+    @syncmethod
+    def history_read_events(self, details):
+        pass
+
+    @syncmethod
     def set_modelling_rule(self, mandatory: bool):
         pass
 


### PR DESCRIPTION
This pull request enables historical data reading by synchronous client wrapper.
The pull request was created as a continuation of this [discussion](https://github.com/FreeOpcUa/opcua-asyncio/discussions/1345).