### PR TITLE
Fix for numvalues parameter in Node.read_raw_history()

### DIFF
--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -543,7 +543,7 @@ class Node:
         details.ReturnBounds = return_bounds
         history = []
         continuation_point = None
-        while True:
+        while len(history) < numvalues:
             result = await self.history_read(details, continuation_point)
             result.StatusCode.check()
             continuation_point = result.ContinuationPoint

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -543,7 +543,7 @@ class Node:
         details.ReturnBounds = return_bounds
         history = []
         continuation_point = None
-        while len(history) < numvalues:
+        while True:
             result = await self.history_read(details, continuation_point)
             result.StatusCode.check()
             continuation_point = result.ContinuationPoint
@@ -551,7 +551,9 @@ class Node:
             # No more data available
             if continuation_point is None:
                 break
-
+            # No more data needed
+            if numvalues > 0:
+                break
         return history
 
     async def history_read(self, details, continuation_point=None):


### PR DESCRIPTION
The description of the function FreeOpcUa / opcua-asyncio / asyncua / common / node.py / read_raw_history() declares that non-zero `numvalues` parameter should truncate the amount of historical data to receive from a server:
> Read raw history of a node
> result code from server is checked and an exception is raised in case of error
> If numvalues is > 0 and number of events in period is > numvalues
> then result will be truncated

Actually, `numvalues` parameter is practically useless and has no effect on the function behavior. The function always reads and returns full set of historical information as defined by the other parameters regardless of `numvalues` value.
This pull request eliminates the inconsistence between the function declaration and actual behavior. If the pull request applied, the function asks for the limited amount of historical data from a server (as requested by non-zero `numvalues` parameter). It makes it possible to effectively control RAM usage of client side without guessing right period of time for historical data to request.
Please, note:
- This pull request may cause ContinuationPoint to leak on server side. But server stability should not rely on client behavior anyway. The client may crash at anytime, and ContinuationPoint may leak as well. So, possible ContinuationPoint leaks must be managed on server side (possible, through expiration) anyway.
- This pull request does not violate the [standard](https://reference.opcfoundation.org/v104/Core/docs/Part11/6.4.3/#6.4.3.1):
> When a continuationPoint is returned, a Client wanting the next numValuesPerNode values shall call ReadRaw again with the continuationPoint set.

So, the client is free to decide if it wants to request the rest of historical data from ContinuationPoint or not.
The pull request was created as a continuation of this [issue](https://github.com/FreeOpcUa/opcua-asyncio/issues/1323). Tested against 3rd party OPC UA server.