### PR TITLE
Fix missing SecurityLevel of the EndpointDescription

### DIFF
--- a/tests/test_crypto_connect.py
+++ b/tests/test_crypto_connect.py
@@ -452,3 +452,27 @@ async def test_anonymous_rejection():
     with pytest.raises(ua.uaerrors.BadIdentityTokenRejected):
         await clt.connect()
     await srv.stop()
+
+async def test_security_level_all():
+    assert Server.determine_security_level(ua.SecurityPolicy.URI, ua.MessageSecurityMode.None_) == Server.lookup_security_level_for_policy_type(ua.SecurityPolicyType.NoSecurity)
+
+    assert Server.determine_security_level(security_policies.SecurityPolicyBasic256Sha256.URI, ua.MessageSecurityMode.Sign) == Server.lookup_security_level_for_policy_type(ua.SecurityPolicyType.Basic256Sha256_Sign)
+    assert Server.determine_security_level(security_policies.SecurityPolicyBasic256Sha256.URI, ua.MessageSecurityMode.SignAndEncrypt) == Server.lookup_security_level_for_policy_type(ua.SecurityPolicyType.Basic256Sha256_SignAndEncrypt)
+
+    assert Server.determine_security_level(security_policies.SecurityPolicyAes128Sha256RsaOaep.URI, ua.MessageSecurityMode.Sign) == Server.lookup_security_level_for_policy_type(ua.SecurityPolicyType.Aes128Sha256RsaOaep_Sign)
+    assert Server.determine_security_level(security_policies.SecurityPolicyAes128Sha256RsaOaep.URI, ua.MessageSecurityMode.SignAndEncrypt) == Server.lookup_security_level_for_policy_type(ua.SecurityPolicyType.Aes128Sha256RsaOaep_SignAndEncrypt)
+
+    # For the sake of completeness also the old, not recommended, protocols Basic128Rsa15 and Basic256
+    assert Server.determine_security_level(security_policies.SecurityPolicyBasic128Rsa15.URI, ua.MessageSecurityMode.Sign) == Server.lookup_security_level_for_policy_type(ua.SecurityPolicyType.Basic128Rsa15_Sign)
+    assert Server.determine_security_level(security_policies.SecurityPolicyBasic128Rsa15.URI, ua.MessageSecurityMode.SignAndEncrypt) == Server.lookup_security_level_for_policy_type(ua.SecurityPolicyType.Basic128Rsa15_SignAndEncrypt)
+
+    assert Server.determine_security_level(security_policies.SecurityPolicyBasic256.URI, ua.MessageSecurityMode.Sign) == Server.lookup_security_level_for_policy_type(ua.SecurityPolicyType.Basic256_Sign)
+    assert Server.determine_security_level(security_policies.SecurityPolicyBasic256.URI, ua.MessageSecurityMode.SignAndEncrypt) == Server.lookup_security_level_for_policy_type(ua.SecurityPolicyType.Basic256_SignAndEncrypt)
+
+async def test_security_level_endpoints(srv_crypto_all_certs):
+    srv = srv_crypto_all_certs[0]
+
+    end_points: list[ua.EndpointDescription] = await srv.get_endpoints()
+
+    for end_point in end_points:
+        assert end_point.SecurityLevel == Server.determine_security_level(end_point.SecurityPolicyUri, end_point.SecurityMode)


### PR DESCRIPTION
According to Part 4 - 7.10 this should be an a number that indicates how secure the EndPoint is. The current implementation used a level of 0 for every EndPoint.
The number is Server implementation specific, how higher the number how safer the security is.
See https://reference.opcfoundation.org/Core/Part4/v104/docs/7.10

Case:
Hit this issue when implementing a server which supports a GDS push application/certificate with the Ua GDS Server. Ua GDS server ignores endpoints with a security level of 0.