### PR TITLE
Dont die on missing MinimumSamplingInterval Fixes #1312

### DIFF
--- a/asyncua/common/xmlexporter.py
+++ b/asyncua/common/xmlexporter.py
@@ -262,7 +262,7 @@ class XmlExporter:
         if useraccesslevel not in (0, ua.AccessLevel.CurrentRead.mask):
             var_el.attrib["UserAccessLevel"] = str(useraccesslevel)
 
-        var = await node.read_attribute(ua.AttributeIds.MinimumSamplingInterval)
+        var = await node.read_attribute(ua.AttributeIds.MinimumSamplingInterval, raise_on_bad_status=False)
         if var.Value.Value:
             var_el.attrib["MinimumSamplingInterval"] = str(var.Value.Value)
         var = await node.read_attribute(ua.AttributeIds.Historizing)


### PR DESCRIPTION
Ignore the missing MinimumSamplingInterval for xml exports
Siemens S7 automatically puts some icon nodes without this attribute causing the export to crash.
See #1312 