### PR TITLE
Add several helpers for creating certificates

### DIFF
--- a/asyncua/crypto/cert_gen.py
+++ b/asyncua/crypto/cert_gen.py
@@ -1,0 +1,246 @@
+"""
+    crypothelper contains helper functions to isolate the lower level cryto stuff from the GDS client.
+"""
+
+import datetime
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat._oid import _OID_NAMES as OID_NAMES
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives.serialization import Encoding, PrivateFormat, NoEncryption
+from cryptography.x509.extensions import _key_identifier_from_public_key as key_identifier_from_public_key
+
+ONE_DAY = datetime.timedelta(1, 0, 0)
+""" Shorthand for delta of 1 day """
+
+OID_NAME_MAP: dict[str, x509.ObjectIdentifier] = {name: oid for oid, name in OID_NAMES.items()}
+""" Create lookup table for x509.ObjectIdentifier based on textual name, by swapping key<>value of the available mapping"""
+
+
+def _names_to_nameattributes(names: dict[str, str]) -> list[x509.NameAttribute]:
+    """Convert a dict with key/value of an x509.NameAttribute list
+
+    Args:
+        names (dict[str,str]): key is the textual name of a NameOID, value is the of the attribute
+
+    Returns:
+        list[x509.NameAttribute]: Coverted list with NameAttributes
+    """
+    return [x509.NameAttribute(OID_NAME_MAP[key], value) for key, value in names.items()]
+
+
+def generate_private_key() -> rsa.RSAPrivateKey:
+    """Generate a private key for certifacte signing and requesting
+
+    Returns:
+        rsa.RSAPrivateKey: The generated private key
+    """
+    private_key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+        backend=default_backend())
+    return private_key
+
+
+def dump_private_key_as_pem(private_key: rsa.RSAPrivateKey) -> bytes:
+    """dumps a private key in PEM format
+
+    Args:
+        private_key (rsa.RSAPrivateKey): The privatekey to dump
+
+    Returns:
+        bytes: The private as PEM/PKCS8 format
+    """
+    return private_key.private_bytes(encoding=Encoding.PEM, format=PrivateFormat.PKCS8, encryption_algorithm=NoEncryption())
+
+
+def generate_self_signed_app_certificate(private_key: rsa.RSAPrivateKey,
+                                         common_name: str,
+                                         names: dict[str, str],
+                                         subject_alt_names: list[x509.GeneralName],
+                                         extended: list[x509.ObjectIdentifier],
+                                         days: int = 365) -> x509.Certificate:
+    """Generate a self signed certificate for OPC UA client/server application that is according to OPC 10000-4 6.1 / OPC 10000-6 6.2.2
+
+    Args:
+        private_key (rsa.RSAPrivateKey): private key used to sign the certificate
+        common_name (str): common name (CN) for the subject, matches to the applications name
+        names (dict[str,str]): additional fields (like O,C,L) for the subject
+        subject_alt_names (list[x509.GeneralName]): uri,dns ip entires
+        extended (list[x509.ObjectIdentifier]): Indicates use of certificate (ExtendedKeyUsageOID.CLIENT_AUTH and/or ExtendedKeyUsageOID.SERVER_AUTH).
+                                                When empty assumes to generate a CA
+        days (int, optional): How long the certificate is valid. Defaults to 365.
+
+    Returns:
+        x509.Certificate: The generated certificate.
+    """
+    generate_ca = len(extended) == 0
+    name_attributes: list[x509.NameAttribute] = _names_to_nameattributes(names)
+    name_attributes.insert(0, x509.NameAttribute(NameOID.COMMON_NAME, common_name))
+
+    public_key = private_key.public_key()
+    serial_number: int = x509.random_serial_number()
+
+    builder = x509.CertificateBuilder()
+    builder = builder.subject_name(x509.Name(name_attributes))
+    builder = builder.issuer_name(x509.Name(name_attributes))
+    builder = builder.not_valid_before(datetime.datetime.utcnow())
+    builder = builder.not_valid_after(datetime.datetime.utcnow() + (ONE_DAY * days))
+    builder = builder.serial_number(serial_number)
+    builder = builder.public_key(public_key)
+    builder = builder.add_extension(
+        x509.SubjectKeyIdentifier.from_public_key(private_key.public_key()),
+        critical=False
+    )
+    builder = builder.add_extension(
+        x509.AuthorityKeyIdentifier(key_identifier_from_public_key(private_key.public_key()),
+                                    [x509.DirectoryName(x509.Name(name_attributes))],
+                                    serial_number),
+        critical=False
+    )
+    builder = builder.add_extension(
+        x509.SubjectAlternativeName(subject_alt_names),
+        critical=False
+    )
+    builder = builder.add_extension(
+        x509.BasicConstraints(ca=True, path_length=0),
+        critical=False
+    )
+    builder = builder.add_extension(
+        x509.KeyUsage(
+            digital_signature=True,
+            content_commitment=True,
+            key_encipherment=True,
+            data_encipherment=not (generate_ca),
+            key_agreement=False,
+            key_cert_sign=True,
+            crl_sign=generate_ca,
+            encipher_only=False,
+            decipher_only=False),
+        critical=False
+    )
+    if not generate_ca:
+        builder = builder.add_extension(
+            x509.ExtendedKeyUsage(extended),
+            critical=False
+        )
+
+    certificate = builder.sign(
+        private_key=private_key, algorithm=hashes.SHA256(),
+    )
+
+    return certificate
+
+
+def generate_app_certificate_signing_request(private_key: rsa.RSAPrivateKey,
+                                             common_name: str,
+                                             names: dict[str, str],
+                                             subject_alt_names: list[x509.GeneralName],
+                                             extended: list[x509.ObjectIdentifier]
+                                             ) -> x509.CertificateSigningRequest:
+    """Generate a certificate signing request for a OPC UA client/server application that is according to OPC 10000-4 6.1 / OPC 10000-6 6.2.2
+
+    Args:
+        private_key (rsa.RSAPrivateKey): private key used to sign the certificate
+        common_name (str): common name (CN) for the subject, matches to the applications name
+        names (dict[str,str]): additional fields (like O,C,L) for the subject
+        subject_alt_names (list[x509.GeneralName]): uri,dns ip entires
+        extended (list[x509.ObjectIdentifier]): Indicates use of certificate (ExtendedKeyUsageOID.CLIENT_AUTH and/or ExtendedKeyUsageOID.SERVER_AUTH)
+
+    Returns:
+        x509.CertificateSigningRequest: The generated certificate signing request
+    """
+
+    name_attributes: list[x509.NameAttribute] = _names_to_nameattributes(names)
+    name_attributes.insert(0, x509.NameAttribute(NameOID.COMMON_NAME, common_name))
+
+    builder = x509.CertificateSigningRequestBuilder()
+    builder = builder.subject_name(x509.Name(name_attributes))
+    builder = builder.add_extension(
+        x509.SubjectAlternativeName(subject_alt_names),
+        critical=False
+    )
+    builder = builder.add_extension(
+        x509.KeyUsage(
+            digital_signature=True,
+            content_commitment=True,
+            key_encipherment=True,
+            data_encipherment=True,
+            key_agreement=False,
+            key_cert_sign=False,
+            crl_sign=False,
+            encipher_only=False,
+            decipher_only=False),
+        critical=False
+    )
+
+    builder = builder.add_extension(
+        x509.ExtendedKeyUsage(extended),
+        critical=False
+    )
+    csr = builder.sign(
+        private_key=private_key, algorithm=hashes.SHA256(),
+    )
+
+    return csr
+
+
+def sign_certificate_request(csr: x509.CertificateSigningRequest,
+                             issuer: x509.Certificate,
+                             private_key: rsa.RSAPrivateKey, days=365) -> x509.Certificate:
+    """Create certficate based on certificate signing request and ca
+
+    Args:
+        csr (x509.CertificateSigningRequest): certificate signing request
+        issuer (x509.Certificate): certificate used a CA
+        private_key (rsa.RSAPrivateKey): private key of the issuer
+        days (int, optional): Days valid. Defaults to 365.
+
+    Returns:
+        x509.Certificate: Signed certificate
+    """
+    public_key = csr.public_key()
+    serial_number: int = x509.random_serial_number()
+
+    builder = x509.CertificateBuilder()
+    builder = builder.subject_name(csr.subject)
+    builder = builder.issuer_name(issuer.subject)
+    builder = builder.not_valid_before(datetime.datetime.utcnow())
+    builder = builder.not_valid_after(datetime.datetime.utcnow() + (ONE_DAY * days))
+    builder = builder.serial_number(serial_number)
+    builder = builder.public_key(public_key)
+    builder = builder.add_extension(
+        x509.SubjectKeyIdentifier.from_public_key(csr.public_key()),
+        critical=False
+    )
+    builder = builder.add_extension(
+        x509.AuthorityKeyIdentifier(key_identifier_from_public_key(issuer.public_key()),
+                                    [x509.DirectoryName(issuer.subject)],
+                                    issuer.serial_number),
+        critical=False
+    )
+    builder = builder.add_extension(
+        csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).value,
+        critical=False
+    )
+    builder = builder.add_extension(
+        x509.BasicConstraints(ca=False, path_length=None),
+        critical=False
+    )
+    builder = builder.add_extension(
+        csr.extensions.get_extension_for_class(x509.KeyUsage).value,
+        critical=False
+    )
+    builder = builder.add_extension(
+        csr.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value,
+        critical=False
+    )
+
+    certificate: x509.Certificate = builder.sign(
+        private_key=private_key, algorithm=hashes.SHA256(),
+    )
+
+    return certificate

--- a/asyncua/crypto/uacrypto.py
+++ b/asyncua/crypto/uacrypto.py
@@ -8,7 +8,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import hmac
-from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher
 from cryptography.hazmat.primitives.ciphers import algorithms
 from cryptography.hazmat.primitives.ciphers import modes
@@ -85,6 +85,16 @@ def der_from_x509(certificate):
         return b""
     return certificate.public_bytes(serialization.Encoding.DER)
 
+def pem_from_key(private_key: rsa.RSAPrivateKey) -> bytes:
+    """dumps a private key in PEM format
+
+    Args:
+        private_key (rsa.RSAPrivateKey): The privatekey to dump
+
+    Returns:
+        bytes: The private as PEM/PKCS8 format
+    """
+    return private_key.private_bytes(encoding=serialization.Encoding.PEM, format=serialization.PrivateFormat.PKCS8, encryption_algorithm=serialization.NoEncryption())
 
 def sign_sha1(private_key, data):
     return private_key.sign(

--- a/examples/generate_certificates.py
+++ b/examples/generate_certificates.py
@@ -1,0 +1,128 @@
+""" Example of several certficate creation helpers"""
+import asyncio
+from pathlib import Path
+import socket
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import Encoding  # , load_pem_private_key
+from cryptography.x509.oid import ExtendedKeyUsageOID
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from asyncua.crypto.uacrypto import load_certificate,  load_private_key
+
+from asyncua.crypto.cert_gen import generate_private_key, generate_self_signed_app_certificate, dump_private_key_as_pem, generate_app_certificate_signing_request, sign_certificate_request
+
+
+HOSTNAME: str = socket.gethostname()
+
+# used for subject common part
+NAMES: dict[str, str] = {
+    'countryName': 'NL',
+    'stateOrProvinceName': 'ZH',
+    'localityName': 'Foo',
+    'organizationName': "Bar Ltd",
+}
+
+CLIENT_SERVER_USE = [ExtendedKeyUsageOID.CLIENT_AUTH, ExtendedKeyUsageOID.SERVER_AUTH]
+
+# setup the paths for the certs, keys and csr
+base = Path('certs-example')
+base_csr: Path = base / 'csr'
+base_private: Path = base / 'private'
+base_certs: Path = base / 'certs'
+base_csr.mkdir(parents=True, exist_ok=True)
+base_private.mkdir(parents=True, exist_ok=True)
+base_certs.mkdir(parents=True, exist_ok=True)
+
+
+def generate_private_key_for_myserver():
+    key: RSAPrivateKey = generate_private_key()
+    key_file = base_private / "myserver.pem"
+    key_file.write_bytes(dump_private_key_as_pem(key))
+
+
+async def generate_self_signed_certificate():
+    subject_alt_names: list[x509.GeneralName] = [x509.UniformResourceIdentifier(f"urn:{HOSTNAME}:foobar:myselfsignedserver"),
+                                                 x509.DNSName(f"{HOSTNAME}")]
+
+    # key: RSAPrivateKey = generate_private_key()
+    key = await load_private_key(base_private / "myserver.pem")
+
+    cert: x509.Certificate = generate_self_signed_app_certificate(key,
+                                                                  f"myselfsignedserver@{HOSTNAME}",
+                                                                  NAMES,
+                                                                  subject_alt_names,
+                                                                  extended=CLIENT_SERVER_USE)
+
+    cert_file = base_certs / "myserver-selfsigned.der"
+    cert_file.write_bytes(cert.public_bytes(encoding=Encoding.DER))
+
+
+def generate_applicationgroup_ca():
+    subject_alt_names: list[x509.GeneralName] = [x509.UniformResourceIdentifier(f"urn:{HOSTNAME}:foobar:myserver"),
+                                                 x509.DNSName(f"{HOSTNAME}")]
+
+    key: RSAPrivateKey = generate_private_key()
+    cert: x509.Certificate = generate_self_signed_app_certificate(key,
+                                                                  "Application CA",
+                                                                  NAMES,
+                                                                  subject_alt_names,
+                                                                  extended=[])
+
+    key_file = base_private / 'ca_application.pem'
+    cert_file = base_certs / 'ca_application.der'
+
+    key_file.write_bytes(dump_private_key_as_pem(key))
+    cert_file.write_bytes(cert.public_bytes(encoding=Encoding.DER))
+
+
+async def generate_csr():
+    subject_alt_names: list[x509.GeneralName] = [x509.UniformResourceIdentifier(f"urn:{HOSTNAME}:foobar:myserver"),
+                                                 x509.DNSName(f"{HOSTNAME}")]
+
+    key: RSAPrivateKey = generate_private_key()
+    key = await load_private_key(base_private / 'myserver.pem')
+    csr: x509.CertificateSigningRequest = generate_app_certificate_signing_request(key,
+                                                                                   f"myserver@{HOSTNAME}",
+                                                                                   NAMES,
+                                                                                   subject_alt_names,
+                                                                                   extended=CLIENT_SERVER_USE)
+
+    # key_file = base_private / 'myserver.pem'
+    csr_file = base_csr / 'myserver.csr'
+
+    # key_file.write_bytes(dump_private_key_as_pem(key))
+    csr_file.write_bytes(csr.public_bytes(encoding=Encoding.PEM))
+
+
+async def sign_csr():
+
+    # setup some common data (normally this differs for the CA and the CSR)
+
+    subject_alt_names: list[x509.GeneralName] = [x509.UniformResourceIdentifier(f"urn:{HOSTNAME}:foobar:myserver"),
+                                                 x509.DNSName(f"{HOSTNAME}")]
+
+    issuer = await load_certificate(base_certs / 'ca_application.der')
+    key_ca = await load_private_key(base_private / 'ca_application.pem')
+    csr_file: Path = base_csr / 'myserver.csr'
+    csr = x509.load_pem_x509_csr(csr_file.read_bytes())
+
+    cert: x509.Certificate = sign_certificate_request(csr, issuer, key_ca, days=30)
+    (base_certs / 'myserver.der').write_bytes(cert.public_bytes(encoding=Encoding.DER))
+
+
+async def main():
+    # create key and reuse it for self_signed and generate_csr
+    generate_private_key_for_myserver()
+
+    # generate self signed certificate for myserver-selfsigned
+    await generate_self_signed_certificate()
+
+    # generate certificate signing request and sign it with the ca for myserver
+    generate_applicationgroup_ca()
+    await generate_csr()
+    await sign_csr()
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except Exception as exp:
+        print(exp)

--- a/tests/test_gen_certificates.py
+++ b/tests/test_gen_certificates.py
@@ -1,0 +1,197 @@
+""" Several tests for certificate /signing request generation"""
+import pytest
+
+from datetime import datetime, timedelta
+import socket
+from cryptography import x509
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.x509.extensions import _key_identifier_from_public_key as key_identifier_from_public_key
+from asyncua.crypto.cert_gen import generate_private_key, generate_app_certificate_signing_request, generate_self_signed_app_certificate, sign_certificate_request
+
+
+async def test_create_self_signed_app_certificate():
+    """ Checks if the self signed certificate complies to OPC 10000-6 6.2.2"""
+
+    hostname = socket.gethostname()
+
+    names = {
+        'countryName': 'NL',
+        'stateOrProvinceName': 'ZH',
+        'localityName': 'Foo',
+        'organizationName': "Bar Ltd",
+    }
+    subject_alt_names: list[x509.GeneralName] = [x509.UniformResourceIdentifier(f"urn:{hostname}:foobar:myserver"),
+                                                 x509.DNSName(f"{hostname}")]
+
+    extended = [ExtendedKeyUsageOID.CLIENT_AUTH,
+                ExtendedKeyUsageOID.SERVER_AUTH]
+
+    days_valid = 100
+
+    key: RSAPrivateKey = generate_private_key()
+    dt_before_generation = datetime.utcnow()
+    dt_before_generation -= timedelta(microseconds=dt_before_generation.microsecond)
+    cert: x509.Certificate = generate_self_signed_app_certificate(key,
+                                                                  f"myserver@{hostname}",
+                                                                  names,
+                                                                  subject_alt_names,
+                                                                  extended=extended,
+                                                                  days=days_valid)
+    dt_after_generation = datetime.utcnow()
+    dt_after_generation -= timedelta(microseconds=dt_after_generation.microsecond)
+
+    # check if it is version 3
+    assert cert.version.name == "v3"
+
+    # check subject
+    assert cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == f"myserver@{hostname}"
+    assert cert.subject.get_attributes_for_oid(NameOID.COUNTRY_NAME)[0].value == "NL"
+    assert cert.subject.get_attributes_for_oid(NameOID.STATE_OR_PROVINCE_NAME)[0].value == "ZH"
+    assert cert.subject.get_attributes_for_oid(NameOID.LOCALITY_NAME)[0].value == "Foo"
+    assert cert.subject.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)[0].value == "Bar Ltd"
+
+    # check valid time range
+    assert dt_before_generation <= cert.not_valid_before <= dt_after_generation
+    assert (dt_before_generation+timedelta(days_valid)) <= cert.not_valid_after <= (dt_after_generation+timedelta(days_valid))
+
+    # check issuer
+    assert cert.issuer.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == f"myserver@{hostname}"
+
+    # check Subject Key Indentifier
+    assert cert.extensions.get_extension_for_class(x509.SubjectKeyIdentifier).value.digest == key_identifier_from_public_key(key.public_key())
+
+    # check Authority Key Identifier
+    auth_key_identifier: x509.AuthorityKeyIdentifier = cert.extensions.get_extension_for_class(x509.AuthorityKeyIdentifier).value
+    assert auth_key_identifier
+    issuer: x509.Name = auth_key_identifier.authority_cert_issuer[0].value
+    assert issuer.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == f"myserver@{hostname}"
+    assert auth_key_identifier.authority_cert_serial_number == cert.serial_number
+    assert auth_key_identifier.key_identifier == key_identifier_from_public_key(key.public_key())
+
+    # check subject alternative name
+    assert cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value.get_values_for_type(x509.DNSName)[0] == hostname
+    assert cert.extensions.get_extension_for_class(x509.SubjectAlternativeName).value.get_values_for_type(
+        x509.UniformResourceIdentifier)[0] == f"urn:{hostname}:foobar:myserver"
+
+    assert cert.extensions.get_extension_for_class(x509.BasicConstraints).value.ca is True
+
+    assert cert.extensions.get_extension_for_class(x509.KeyUsage).value == x509.KeyUsage(
+        digital_signature=True,
+        content_commitment=True,
+        key_encipherment=True,
+        data_encipherment=True,
+        key_agreement=False,
+        key_cert_sign=True,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False)
+
+    assert cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value == x509.ExtendedKeyUsage(extended)
+
+
+async def test_app_create_certificate_signing_request():
+    """ Checks if the self signed certificate complies to OPC 10000-6 6.2.2"""
+
+    hostname = socket.gethostname()
+
+    names = {
+        'countryName': 'NL',
+        'stateOrProvinceName': 'ZH',
+        'localityName': 'Foo',
+        'organizationName': "Bar Ltd",
+    }
+    subject_alt_names: list[x509.GeneralName] = [x509.UniformResourceIdentifier(f"urn:{hostname}:foobar:myserver"),
+                                                 x509.DNSName(f"{hostname}")]
+
+    extended = [ExtendedKeyUsageOID.CLIENT_AUTH,
+                ExtendedKeyUsageOID.SERVER_AUTH]
+
+    key: RSAPrivateKey = generate_private_key()
+    csr: x509.CertificateSigningRequest = generate_app_certificate_signing_request(key,
+                                                                                   f"myserver@{hostname}",
+                                                                                   names,
+                                                                                   subject_alt_names,
+                                                                                   extended=extended)
+
+    # check subject
+    assert csr.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value == f"myserver@{hostname}"
+    assert csr.subject.get_attributes_for_oid(NameOID.COUNTRY_NAME)[0].value == "NL"
+    assert csr.subject.get_attributes_for_oid(NameOID.STATE_OR_PROVINCE_NAME)[0].value == "ZH"
+    assert csr.subject.get_attributes_for_oid(NameOID.LOCALITY_NAME)[0].value == "Foo"
+    assert csr.subject.get_attributes_for_oid(NameOID.ORGANIZATION_NAME)[0].value == "Bar Ltd"
+
+    # check subject alternative name
+    assert csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).value.get_values_for_type(x509.DNSName)[0] == hostname
+    assert csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).value.get_values_for_type(
+        x509.UniformResourceIdentifier)[0] == f"urn:{hostname}:foobar:myserver"
+
+    assert csr.extensions.get_extension_for_class(x509.KeyUsage).value == x509.KeyUsage(
+        digital_signature=True,
+        content_commitment=True,
+        key_encipherment=True,
+        data_encipherment=True,
+        key_agreement=False,
+        key_cert_sign=False,
+        crl_sign=False,
+        encipher_only=False,
+        decipher_only=False)
+
+    assert csr.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value == x509.ExtendedKeyUsage(extended)
+
+
+async def test_app_sign_certificate_request():
+    """Check the correct signing of certificate signing request"""
+    hostname = socket.gethostname()
+
+    names = {
+        'countryName': 'NL',
+        'stateOrProvinceName': 'ZH',
+        'localityName': 'Foo',
+        'organizationName': "Bar Ltd",
+    }
+    subject_alt_names: list[x509.GeneralName] = [x509.UniformResourceIdentifier(f"urn:{hostname}:foobar:myserver"),
+                                                 x509.DNSName(f"{hostname}")]
+
+    extended = [ExtendedKeyUsageOID.CLIENT_AUTH,
+                ExtendedKeyUsageOID.SERVER_AUTH]
+
+    key_ca: RSAPrivateKey = generate_private_key()
+    issuer: x509.Certificate = generate_self_signed_app_certificate(key_ca,
+                                                                    "Application CA",
+                                                                    names,
+                                                                    subject_alt_names,
+                                                                    extended=[],  # keep this one empty when generating an application CA
+                                                                    days=365)
+
+    key_server: RSAPrivateKey = generate_private_key()
+    csr: x509.CertificateSigningRequest = generate_app_certificate_signing_request(key_server,
+                                                                                   f"myserver@{hostname}",
+                                                                                   names,
+                                                                                   subject_alt_names,
+                                                                                   extended=extended)
+
+    cert: x509.Certificate = sign_certificate_request(csr, issuer, key_ca, days=30)
+
+    assert cert.subject == csr.subject
+
+    # check subject key identifier
+    assert cert.extensions.get_extension_for_class(x509.SubjectKeyIdentifier).value.digest == key_identifier_from_public_key(key_server.public_key())
+
+    # check authority Key Identifier
+    auth_key_identifier: x509.AuthorityKeyIdentifier = cert.extensions.get_extension_for_class(x509.AuthorityKeyIdentifier).value
+    assert auth_key_identifier
+    assert auth_key_identifier.authority_cert_issuer[0].value == issuer.subject
+    assert auth_key_identifier.authority_cert_serial_number == issuer.serial_number
+    assert auth_key_identifier.key_identifier == key_identifier_from_public_key(key_ca.public_key())
+
+    assert cert.extensions.get_extension_for_class(x509.BasicConstraints).value.ca is False
+
+    assert cert.extensions.get_extension_for_class(
+        x509.SubjectAlternativeName).value == csr.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+
+    assert cert.extensions.get_extension_for_class(
+        x509.KeyUsage).value == csr.extensions.get_extension_for_class(x509.KeyUsage).value
+
+    assert cert.extensions.get_extension_for_class(
+        x509.ExtendedKeyUsage).value == csr.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value


### PR DESCRIPTION
To encourage the use of certifactes, it should be easy to create certificates from within your opc-asyncio applications.

The PR adds several helpers for creating certificates, that follow the guidelines from OPC 10000-4 6.1 / OPC 10000-6 6.2.2 for ApplicationInstanceCertificate, for the following tasks:
* create private keys
* create self signed certficates
* create certifcate signing requests
* create ca for signing csr


The helpers are:
* generate_private_key
* generate_app_certificate_signing_request
* generate_self_signed_app_certificate
* sign_certificate_request

Test and example are included.