### PR TITLE
Add raise_on_partial_error parameter to write_values()

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -879,15 +879,17 @@ class Client:
         res = await self.read_attributes(nodes, attr=ua.AttributeIds.Value)
         return [r.Value.Value for r in res]
 
-    async def write_values(self, nodes, values):
+    async def write_values(self, nodes, values, raise_on_partial_error=True):
         """
         Write values to multiple nodes in one ua call
         """
         nodeids = [node.nodeid for node in nodes]
         dvs = [value_to_datavalue(val) for val in values]
         results = await self.uaclient.write_attributes(nodeids, dvs, ua.AttributeIds.Value)
-        for result in results:
-            result.check()
+        if raise_on_partial_error:
+            for result in results:
+                result.check()
+        return results
 
     get_values = read_values  # legacy compatibility
     set_values = write_values  # legacy compatibility

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -261,7 +261,7 @@ class Client:
         pass
 
     @syncmethod
-    def write_values(self, nodes, values):
+    def write_values(self, nodes, values, raise_on_partial_error=True):
         pass
 
     def __enter__(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -103,11 +103,14 @@ async def test_multiple_read_and_write_value(server, client):
 
     vals = await client.read_values([v1, v2, v3])
     assert vals == [1, 2, 3]
-    await client.write_values([v1, v2, v3], [4, 5, 6])
+    rets = await client.write_values([v1, v2, v3], [4, 5, 6])
+    assert rets == [ua.StatusCode(value=ua.StatusCodes.Good), ua.StatusCode(value=ua.StatusCodes.Good), ua.StatusCode(value=ua.StatusCodes.Good)]
     vals = await client.read_values([v1, v2, v3])
     assert vals == [4, 5, 6]
     with pytest.raises(ua.uaerrors.BadUserAccessDenied):
         await client.write_values([v1, v2, v_ro], [4, 5, 6])
+    rets = await client.write_values([v1, v2, v_ro], [4, 5, 6], raise_on_partial_error=False)
+    assert rets == [ua.StatusCode(value=ua.StatusCodes.Good), ua.StatusCode(ua.StatusCodes.Good), ua.StatusCode(ua.StatusCodes.BadUserAccessDenied)]
 
 
 async def test_read_and_write_status_check(server, client):


### PR DESCRIPTION
`write_values()` on `Client` always throws `UaStatusCodeError` even when the [service partially succeeded](https://reference.opcfoundation.org/Core/Part4/v105/docs/5.3) and hides the rest of the error codes other than the first one. This patch adds a `raise_on_partial_error` parameter to make it returns all status codes for each write operation.