### PR TITLE
Add get_children_by_path()

### DIFF
--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -507,6 +507,10 @@ class SyncNode:
         pass
 
     @syncmethod
+    def get_children_by_path(self, paths, raise_on_partial_error=True):
+        pass
+
+    @syncmethod
     def read_raw_history(self, starttime=None, endtime=None, numvalues=0, return_bounds=True):
         pass
 

--- a/asyncua/ua/__init__.py
+++ b/asyncua/ua/__init__.py
@@ -6,3 +6,4 @@ from .status_codes import StatusCodes
 from .uaprotocol_auto import *
 from .uaprotocol_hand import *
 from .uatypes import *  # TODO: This should be renamed to uatypes_hand
+from .uaerrors import UaStatusCodeErrors

--- a/asyncua/ua/uaerrors/_base.py
+++ b/asyncua/ua/uaerrors/_base.py
@@ -66,6 +66,36 @@ class UaStatusCodeError(UaError):
         return self.args[0]
 
 
+class UaStatusCodeErrors(UaStatusCodeError):
+    def __new__(cls, *args):
+        # use the default implementation
+        self = UaError.__new__(cls, *args)
+        return self
+
+    def __init__(self, codes):
+        """
+        :param codes: The codes of the results.
+        """
+        self.codes = codes
+
+    def __str__(self):
+        # import here to avoid circular import problems
+        import asyncua.ua.status_codes as status_codes
+
+        return "[{0}]".format(", ".join(["{1}({0})".format(*status_codes.get_name_and_doc(code)) for code in self.codes]))
+
+    @property
+    def code(self):
+        """
+        The code of the status error.
+        """
+        # import here to avoid circular import problems
+        from asyncua.ua.uatypes import StatusCode
+
+        error_codes = [code for code in self.codes if not StatusCode(code).is_good()]
+        return error_codes[0] if len(error_codes) > 0 else None
+
+
 class UaStringParsingError(UaError):
     pass
 


### PR DESCRIPTION
Add a batch version of `get_child()` method in `Node` and `UaStatusCodeErrors` for batch operations.

(Actually it seems this is a good example of the use case of `Result` type implemented by [dry-python/returns](https://github.com/dry-python/returns) and [rustedpy/result](https://github.com/rustedpy/result) instead of using exceptions)