### PR TITLE
Fix StatusCode in watchdog loop

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -520,11 +520,11 @@ class Client:
                 _ = await self.nodes.server_state.read_value()
         except ConnectionError as e:
             _logger.info("connection error in watchdog loop %s", e, exc_info=True)
-            await self.uaclient.inform_subscriptions(ua.StatusCodes.BadShutdown)
+            await self.uaclient.inform_subscriptions(ua.StatusCode(ua.StatusCodes.BadShutdown))
             raise
         except Exception:
             _logger.exception("Error in watchdog loop")
-            await self.uaclient.inform_subscriptions(ua.StatusCodes.BadShutdown)
+            await self.uaclient.inform_subscriptions(ua.StatusCode(ua.StatusCodes.BadShutdown))
             raise
 
     async def _renew_channel_loop(self):

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -70,7 +70,7 @@ async def test_client_connection_lost():
             # check if connection is alive
             await cl.check_connection()
         # check if the status_change_notification was triggered
-        assert myhandler.status == ua.StatusCodes.BadShutdown
+        assert myhandler.status.value == ua.StatusCodes.BadShutdown
         # check if exception is correct rethrown on second call
         with pytest.raises(ConnectionError):
             await cl.check_connection()


### PR DESCRIPTION
Follow-up on https://github.com/FreeOpcUa/opcua-asyncio/pull/1258.

inform_subscriptions expects ua.StatusCode, not ua.StatusCodes.
