### PR TITLE
Alarms & Conditions

### DIFF
--- a/asyncua/common/event_objects.py
+++ b/asyncua/common/event_objects.py
@@ -6,7 +6,7 @@ Model Uri:http://opcfoundation.org/UA/"
 Version:1.05.01"
 Publication date:2022-02-24T00:00:00Z"
 
-File creation Date:2022-09-22 16:18:40.843698"
+File creation Date:2023-07-25 09:08:45.084676"
 """
 from asyncua import ua
 from .events import Event
@@ -90,7 +90,7 @@ class AuditSessionEvent(AuditSecurityEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditSessionEventType)
-        self.add_property('SessionId', ua.NodeId(ua.ObjectIds.AuditSessionEventType), ua.VariantType.NodeId)
+        self.add_property('SessionId', None, ua.VariantType.NodeId)
 
 
 class AuditCreateSessionEvent(AuditSessionEvent):
@@ -272,7 +272,7 @@ class AuditHistoryUpdateEvent(AuditUpdateEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryUpdateEventType)
-        self.add_property('ParameterDataTypeId', ua.NodeId(ua.ObjectIds.AuditHistoryUpdateEventType), ua.VariantType.NodeId)
+        self.add_property('ParameterDataTypeId', None, ua.VariantType.NodeId)
 
 
 class AuditUpdateMethodEvent(AuditEvent):
@@ -282,7 +282,7 @@ class AuditUpdateMethodEvent(AuditEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditUpdateMethodEventType)
-        self.add_property('MethodId', ua.NodeId(ua.ObjectIds.AuditUpdateMethodEventType), ua.VariantType.NodeId)
+        self.add_property('MethodId', None, ua.VariantType.NodeId)
         self.add_property('InputArguments', None, ua.VariantType.Variant)
 
 
@@ -386,12 +386,12 @@ class Condition(BaseEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.ConditionType)
-        self.add_property('ConditionClassId', ua.NodeId(ua.ObjectIds.ConditionType), ua.VariantType.NodeId)
+        self.add_property('ConditionClassId', None, ua.VariantType.NodeId)
         self.add_property('ConditionClassName', None, ua.VariantType.LocalizedText)
-        self.add_property('ConditionSubClassId', ua.NodeId(ua.ObjectIds.ConditionType), ua.VariantType.NodeId)
+        self.add_property('ConditionSubClassId', None, ua.VariantType.NodeId)
         self.add_property('ConditionSubClassName', None, ua.VariantType.LocalizedText)
         self.add_property('ConditionName', None, ua.VariantType.String)
-        self.add_property('BranchId', ua.NodeId(ua.ObjectIds.ConditionType), ua.VariantType.NodeId)
+        self.add_property('BranchId', None, ua.VariantType.NodeId)
         self.add_property('Retain', None, ua.VariantType.Boolean)
         self.add_property('EnabledState/Id', None, ua.VariantType.Boolean)
         self.add_property('EnabledState/EffectiveDisplayName', None, ua.VariantType.LocalizedText)
@@ -524,7 +524,7 @@ class AlarmCondition(AcknowledgeableCondition):
         self.add_property('ActiveState/TrueState', None, ua.VariantType.LocalizedText)
         self.add_property('ActiveState/FalseState', None, ua.VariantType.LocalizedText)
         self.add_variable('ActiveState', None, ua.VariantType.LocalizedText)
-        self.add_property('InputNode', ua.NodeId(ua.ObjectIds.AlarmConditionType), ua.VariantType.NodeId)
+        self.add_property('InputNode', None, ua.VariantType.NodeId)
         self.add_property('SuppressedState/Id', None, ua.VariantType.Boolean)
         self.add_property('SuppressedState/TransitionTime', None, ua.NodeId(ua.ObjectIds.UtcTime))
         self.add_property('SuppressedState/TrueState', None, ua.VariantType.LocalizedText)
@@ -588,7 +588,7 @@ class AuditHistoryEventUpdateEvent(AuditHistoryUpdateEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryEventUpdateEventType)
-        self.add_property('UpdatedNode', ua.NodeId(ua.ObjectIds.AuditHistoryEventUpdateEventType), ua.VariantType.NodeId)
+        self.add_property('UpdatedNode', None, ua.VariantType.NodeId)
         self.add_property('PerformInsertReplace', None, ua.NodeId(ua.ObjectIds.PerformUpdateType))
         self.add_property('Filter', None, ua.NodeId(ua.ObjectIds.EventFilter))
         self.add_property('NewValues', None, ua.NodeId(ua.ObjectIds.HistoryEventFieldList))
@@ -602,7 +602,7 @@ class AuditHistoryValueUpdateEvent(AuditHistoryUpdateEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryValueUpdateEventType)
-        self.add_property('UpdatedNode', ua.NodeId(ua.ObjectIds.AuditHistoryValueUpdateEventType), ua.VariantType.NodeId)
+        self.add_property('UpdatedNode', None, ua.VariantType.NodeId)
         self.add_property('PerformInsertReplace', None, ua.NodeId(ua.ObjectIds.PerformUpdateType))
         self.add_property('NewValues', None, ua.NodeId(ua.ObjectIds.DataValue))
         self.add_property('OldValues', None, ua.NodeId(ua.ObjectIds.DataValue))
@@ -615,7 +615,7 @@ class AuditHistoryDeleteEvent(AuditHistoryUpdateEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditHistoryDeleteEventType)
-        self.add_property('UpdatedNode', ua.NodeId(ua.ObjectIds.AuditHistoryDeleteEventType), ua.VariantType.NodeId)
+        self.add_property('UpdatedNode', None, ua.VariantType.NodeId)
 
 
 class AuditHistoryRawModifyDeleteEvent(AuditHistoryDeleteEvent):
@@ -669,7 +669,7 @@ class ProgramTransitionAuditEvent(AuditUpdateStateEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.ProgramTransitionAuditEventType)
-        self.add_property('Transition/Id', ua.NodeId(ua.ObjectIds.ProgramTransitionAuditEventType), ua.VariantType.NodeId)
+        self.add_property('Transition/Id', None, ua.VariantType.NodeId)
         self.add_variable('Transition', None, ua.VariantType.LocalizedText)
 
 
@@ -742,8 +742,8 @@ class ExclusiveDeviationAlarm(ExclusiveLimitAlarm):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.ExclusiveDeviationAlarmType)
-        self.add_property('SetpointNode', ua.NodeId(ua.ObjectIds.ExclusiveDeviationAlarmType), ua.VariantType.NodeId)
-        self.add_property('BaseSetpointNode', ua.NodeId(ua.ObjectIds.ExclusiveDeviationAlarmType), ua.VariantType.NodeId)
+        self.add_property('SetpointNode', None, ua.VariantType.NodeId)
+        self.add_property('BaseSetpointNode', None, ua.VariantType.NodeId)
 
 
 class NonExclusiveLimitAlarm(LimitAlarm):
@@ -803,8 +803,8 @@ class NonExclusiveDeviationAlarm(NonExclusiveLimitAlarm):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.NonExclusiveDeviationAlarmType)
-        self.add_property('SetpointNode', ua.NodeId(ua.ObjectIds.NonExclusiveDeviationAlarmType), ua.VariantType.NodeId)
-        self.add_property('BaseSetpointNode', ua.NodeId(ua.ObjectIds.NonExclusiveDeviationAlarmType), ua.VariantType.NodeId)
+        self.add_property('SetpointNode', None, ua.VariantType.NodeId)
+        self.add_property('BaseSetpointNode', None, ua.VariantType.NodeId)
 
 
 class DiscreteAlarm(AlarmCondition):
@@ -823,7 +823,7 @@ class OffNormalAlarm(DiscreteAlarm):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.OffNormalAlarmType)
-        self.add_property('NormalState', ua.NodeId(ua.ObjectIds.OffNormalAlarmType), ua.VariantType.NodeId)
+        self.add_property('NormalState', None, ua.VariantType.NodeId)
 
 
 class TripAlarm(OffNormalAlarm):
@@ -901,8 +901,8 @@ class CertificateUpdatedAuditEvent(AuditUpdateMethodEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.CertificateUpdatedAuditEventType)
-        self.add_property('CertificateGroup', ua.NodeId(ua.ObjectIds.CertificateUpdatedAuditEventType), ua.VariantType.NodeId)
-        self.add_property('CertificateType', ua.NodeId(ua.ObjectIds.CertificateUpdatedAuditEventType), ua.VariantType.NodeId)
+        self.add_property('CertificateGroup', None, ua.VariantType.NodeId)
+        self.add_property('CertificateType', None, ua.VariantType.NodeId)
 
 
 class CertificateExpirationAlarm(SystemOffNormalAlarm):
@@ -914,7 +914,7 @@ class CertificateExpirationAlarm(SystemOffNormalAlarm):
         self.EventType = ua.NodeId(ua.ObjectIds.CertificateExpirationAlarmType)
         self.add_property('ExpirationDate', None, ua.VariantType.DateTime)
         self.add_property('ExpirationLimit', None, ua.NodeId(ua.ObjectIds.Duration))
-        self.add_property('CertificateType', ua.NodeId(ua.ObjectIds.CertificateExpirationAlarmType), ua.VariantType.NodeId)
+        self.add_property('CertificateType', None, ua.VariantType.NodeId)
         self.add_property('Certificate', None, ua.VariantType.ByteString)
 
 
@@ -934,8 +934,8 @@ class PubSubStatusEvent(SystemEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.PubSubStatusEventType)
-        self.add_property('ConnectionId', ua.NodeId(ua.ObjectIds.PubSubStatusEventType), ua.VariantType.NodeId)
-        self.add_property('GroupId', ua.NodeId(ua.ObjectIds.PubSubStatusEventType), ua.VariantType.NodeId)
+        self.add_property('ConnectionId', None, ua.VariantType.NodeId)
+        self.add_property('GroupId', None, ua.VariantType.NodeId)
         self.add_property('State', None, ua.NodeId(ua.ObjectIds.PubSubState))
 
 
@@ -967,7 +967,7 @@ class DiscrepancyAlarm(AlarmCondition):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.DiscrepancyAlarmType)
-        self.add_property('TargetValueNode', ua.NodeId(ua.ObjectIds.DiscrepancyAlarmType), ua.VariantType.NodeId)
+        self.add_property('TargetValueNode', None, ua.VariantType.NodeId)
         self.add_property('ExpectedTime', None, ua.NodeId(ua.ObjectIds.Duration))
         self.add_property('Tolerance', None, ua.VariantType.Double)
 
@@ -1074,7 +1074,7 @@ class TrustListOutOfDateAlarm(SystemOffNormalAlarm):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.TrustListOutOfDateAlarmType)
-        self.add_property('TrustListId', ua.NodeId(ua.ObjectIds.TrustListOutOfDateAlarmType), ua.VariantType.NodeId)
+        self.add_property('TrustListId', None, ua.VariantType.NodeId)
         self.add_property('LastUpdateTime', None, ua.NodeId(ua.ObjectIds.UtcTime))
         self.add_property('UpdateFrequency', None, ua.NodeId(ua.ObjectIds.Duration))
 
@@ -1096,8 +1096,8 @@ class AuditClientUpdateMethodResultEvent(AuditClientEvent):
     def __init__(self, sourcenode=None, message=None, severity=1):
         super().__init__(sourcenode, message, severity)
         self.EventType = ua.NodeId(ua.ObjectIds.AuditClientUpdateMethodResultEventType)
-        self.add_property('ObjectId', ua.NodeId(ua.ObjectIds.AuditClientUpdateMethodResultEventType), ua.VariantType.NodeId)
-        self.add_property('MethodId', ua.NodeId(ua.ObjectIds.AuditClientUpdateMethodResultEventType), ua.VariantType.NodeId)
+        self.add_property('ObjectId', None, ua.VariantType.NodeId)
+        self.add_property('MethodId', None, ua.VariantType.NodeId)
         self.add_property('StatusCodeId', None, ua.VariantType.StatusCode)
         self.add_property('InputArguments', None, ua.NodeId(ua.ObjectIds.Argument))
         self.add_property('OutputArguments', None, ua.NodeId(ua.ObjectIds.Argument))

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -273,17 +273,7 @@ class Subscription:
         MaxUInt32 for max queue size
         :return: Handle for changing/cancelling of the subscription
         """
-        sourcenode = Node(self.server, sourcenode)
-        if evfilter is None:
-            evfilter = await self._create_eventfilter(evtypes)
-        # Add SimpleAttribute for NodeId if missing.
-        matches = [a for a in evfilter.SelectClauses if a.AttributeId == ua.AttributeIds.NodeId]
-        if not matches:
-            conditionIdOperand = ua.SimpleAttributeOperand()
-            conditionIdOperand.TypeDefinitionId = ua.NodeId(ua.ObjectIds.ConditionType)
-            conditionIdOperand.AttributeId = ua.AttributeIds.NodeId
-            evfilter.SelectClauses.append(conditionIdOperand)
-        return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)  # type: ignore
+        return await self.subscribe_events(sourcenode, evtypes, evfilter, queuesize)
 
     async def _subscribe(
         self,

--- a/asyncua/common/ua_utils.py
+++ b/asyncua/common/ua_utils.py
@@ -211,6 +211,17 @@ async def get_node_supertype(node):
     return None
 
 
+async def is_subtype(node, supertype):
+    """
+    return if a node is a subtype of a specified nodeid
+    """
+    while node:
+        if node.nodeid == supertype:
+            return True
+        node = await get_node_supertype(node)
+    return False
+
+
 async def is_child_present(node, browsename):
     """
     return if a browsename is present a child from the provide node

--- a/asyncua/server/event_generator.py
+++ b/asyncua/server/event_generator.py
@@ -39,6 +39,9 @@ class EventGenerator:
 
         if node:
             self.event = await events.get_event_obj_from_type_node(node)
+            if isinstance(self.event, event_objects.Condition):
+                # Add ConditionId, which is not modelled as a component of the ConditionType
+                self.event.add_property('NodeId', None, ua.VariantType.NodeId)
 
         if isinstance(emitting_node, Node):
             pass

--- a/asyncua/server/monitored_item_service.py
+++ b/asyncua/server/monitored_item_service.py
@@ -235,14 +235,18 @@ class MonitoredItemService:
             return True
         return False
 
-    async def trigger_event(self, event):
+    async def trigger_event(self, event, mid=None):
         if event.emitting_node not in self._monitored_events:
             self.logger.debug("%s has NO subscription for events %s from node: %s", self, event, event.emitting_node)
             return False
+
         self.logger.debug("%s has subscription for events %s from node: %s", self, event, event.emitting_node)
-        mids = self._monitored_events[event.emitting_node]
-        for mid in mids:
+        if mid is not None:
             await self._trigger_event(event, mid)
+        else:
+            mids = self._monitored_events[event.emitting_node]
+            for mid in mids:
+                await self._trigger_event(event, mid)
         return True
 
     async def _trigger_event(self, event, mid: int):

--- a/schemas/generate_event_objects.py
+++ b/schemas/generate_event_objects.py
@@ -80,7 +80,7 @@ from .events import Event
             return "ua.LocalizedText(message)"
         elif reference.refBrowseName == "LocalTime":
             return "ua.uaprotocol_auto.TimeZoneDataType()"
-        elif reference.refDataType == "NodeId":
+        elif reference.refBrowseName == "EventType":
             return "ua.NodeId(ua.ObjectIds.{0})".format(
                 str(ob_ids.ObjectIdNames[int(str(reference.refId).split("=")[1])]).split("_")[0])
         else:


### PR DESCRIPTION
This is a continuation on https://github.com/FreeOpcUa/opcua-asyncio/pull/365.

Respective event classes and support for variables in event classes have already been added to master.

### ConditionRefresh
Events with Retain field are now stored in SubscriptionService (global) instead of MonitoredItemService (per Subscription). trigger_event methods have been extended to limit notifications to specific subscriptions or monitored items. RefreshStartEvent / RefreshEndEvent is also only sent on the subscription where ConditionRefresh got called.

### ConditionId / NodeId property
For easier handling, NodeId gets automatically added in SelectClauses, when the EventType is a ConditionType. This also works well with the history subsystem, which only calls subscribe_events and not subscribe_alarms_and_conditions.

### Defaults for properties of type ua.VariantType.NodeId
Change default to None instead of using the respective EventType, which is almost always not what is wanted.

Missing:
- Support for notifiers other than server object (HasNotifier references)
- Examples
