### PR TITLE
Fix/trailing bracket missing

### DIFF
--- a/asyncua/common/ua_utils.py
+++ b/asyncua/common/ua_utils.py
@@ -83,7 +83,7 @@ def string_to_val(string, vtype):
     Note: no error checking is done here, supplying null strings could raise exceptions (datetime and guid)
     """
     string = string.strip()
-    if string.startswith("["):
+    if string.startswith("[") and string.endswith("]"):
         string = string[1:-1]
         var = []
         for s in string.split(","):

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -231,6 +231,11 @@ def test_string_to_variant_datetime_string():
     assert arr_datetime == string_to_val(s_arr_datetime, ua.VariantType.DateTime)
 
 
+def test_string_not_an_array():
+    s_not_an_array = "[this] is not an array"
+    assert s_not_an_array == string_to_val(s_not_an_array, ua.VariantType.String)
+
+
 def test_string_to_variant_nodeid():
     s_arr_nodeid = "[ns=2;i=56, i=45]"
     arr_nodeid = [ua.NodeId.from_string("ns=2;i=56"), ua.NodeId.from_string("i=45")]


### PR DESCRIPTION
When a string start with an opening squared bracket, it is blindly assumed to end with a closing one as well.
Both characters get (also blindly) stripped from it and the remains are interpreted as an array of strings.

I propose to check for the last character as well, in order to cheaply avoid false positives, where something other than a closing bracket gets removed and a regular string gets interpreted as array of strings wrongly.