### PR TITLE
load_enums: skip bad enum definitions with error message

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1255,6 +1255,11 @@ async def test_custom_enum_with_bad_dtd(opc, caplog):
     # Set some garbage as type definition
     await dtype.write_data_type_definition(ua.StructureField())
 
+    # If leftover from previous test, it would be skipped, clear out
+    try:
+        del ua.MyEnum
+    except AttributeError:
+        pass
     # Does not raise
     await opc.opc.load_data_type_definitions()
     # Check that error was logged

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1247,6 +1247,25 @@ async def test_custom_enum_x(opc):
     assert val == 1
 
 
+async def test_custom_enum_with_bad_dtd(opc, caplog):
+    """Enum with invalid type definition is skipped and an error is logged"""
+    caplog.set_level("ERROR")
+    idx = 4
+    dtype = await opc.opc.nodes.enum_data_type.add_data_type(idx, "MyEnum")
+    # Set some garbage as type definition
+    await dtype.write_data_type_definition(ua.StructureField())
+
+    # Does not raise
+    await opc.opc.load_data_type_definitions()
+    # Check that error was logged
+    logs = [t for t in caplog.record_tuples if t[0].endswith(".structures104")]
+    assert len(logs) == 1
+    message = logs[0][2]
+    assert "MyEnum" in message
+    assert "Failed to generate class from UA datatype" in message
+
+
+
 async def test_custom_option_set(opc):
     idx = 4
     await new_enum(opc.opc, idx, "MyOptionSet", ["tata", "titi", "toto", "None"], True)


### PR DESCRIPTION
See Issue #1381 :

Looking beyond the problem at hand, it might always be that a server has unexpected or corrupt data for one or more type definitions. ``load_type_definitions`` should skip such definitions with an error message and continue on. This PR provides this behavior for Enum + OptionSet types.

For regular structure types, this should already happen with the code as before (since there are up to 10 retries); however I didn't verify this.

The idea of raising all Exceptions together as `ExceptionGroup` was discarded for two reasons:
1. `load_type_definitions` returns the created objects as list, which is not possible if an Exception is raised;
2. `ExceptionGroup` was introduced in Py 3.11, requiring some hack or backport to support earlier versions.