### PR TITLE
Support the nested list result in sync functions

### DIFF
--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -77,8 +77,11 @@ def _to_async(args, kwargs):
 def _to_sync(tloop, result):
     if isinstance(result, node.Node):
         return SyncNode(tloop, result)
-    if isinstance(result, (list, tuple)) and len(result) > 0 and isinstance(result[0], node.Node):
-        return [SyncNode(tloop, i) for i in result]
+    if isinstance(result, (list, tuple)) and len(result) > 0:
+        if isinstance(result[0], node.Node):
+            return [SyncNode(tloop, i) for i in result]
+        elif isinstance(result[0], (list, tuple)):
+            return [_to_sync(tloop, item) for item in result]
     if isinstance(result, server.event_generator.EventGenerator):
         return EventGenerator(tloop, result)
     if isinstance(result, subscription.Subscription):

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -93,7 +93,7 @@ def test_sync_async_client_method(client, idx):
     assert results[0].Value.Value == 6.7
 
 
-def test_sync_client_get_node(client):
+def test_sync_client_get_node(client, idx):
     node = client.get_node(85)
     assert node == client.nodes.objects
     nodes = node.get_children()
@@ -101,14 +101,26 @@ def test_sync_client_get_node(client):
     assert nodes[0] == client.nodes.server
     assert isinstance(nodes[0], SyncNode)
 
+    results = node.get_children_by_path([[f"{idx}:MyObject", f"{idx}:MyVariable"]])
+    assert len(results) == 1
+    vars = results[0]
+    assert len(vars) == 1
+    assert vars[0].read_value() == 6.7
 
-def test_sync_server_get_node(server):
+
+def test_sync_server_get_node(server, idx):
     node = server.get_node(85)
     assert node == server.nodes.objects
     nodes = node.get_children()
     assert len(nodes) > 2
     assert nodes[0] == server.nodes.server
     assert isinstance(nodes[0], SyncNode)
+
+    results = node.get_children_by_path([[f"{idx}:MyObject", f"{idx}:MyVariable"]])
+    assert len(results) == 1
+    vars = results[0]
+    assert len(vars) == 1
+    assert vars[0].read_value() == 6.7
 
 
 class MySubHandler:


### PR DESCRIPTION
Make `_to_sync()` function support the nested list result from some methods like `sync.Client.get_children_by_path()`.