### PR TITLE
Update dev_requirements.txt

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -4,4 +4,4 @@ coverage
 pytest-cov
 pytest-mock
 asynctest
-types_aiofiles
+types-aiofiles


### PR DESCRIPTION
I think types_aiofiles was a typo. I can only install types-aiofiles module.