### PR TITLE
Add and demonstrate convenient helper for self-signed certificates

### DIFF
--- a/examples/client-with-encryption.py
+++ b/examples/client-with-encryption.py
@@ -1,25 +1,46 @@
 import asyncio
 import logging
 import sys
+import socket
+from pathlib import Path
 sys.path.insert(0, "..")
 from asyncua import Client
 from asyncua.crypto.security_policies import SecurityPolicyBasic256Sha256
+from asyncua.crypto.cert_gen import setup_self_signed_certificate
+from cryptography.x509.oid import ExtendedKeyUsageOID
+
 
 logging.basicConfig(level=logging.INFO)
 _logger = logging.getLogger("asyncua")
 
-cert_idx = 1
-cert = f"certificates/peer-certificate-example-{cert_idx}.der"
-private_key = f"certificates/peer-private-key-example-{cert_idx}.pem"
 
+cert_idx = 4
+cert_base = Path(__file__).parent
+cert = Path(cert_base / f"certificates/peer-certificate-example-{cert_idx}.der")
+private_key = Path(cert_base / f"certificates/peer-private-key-example-{cert_idx}.pem")
 
 async def task(loop):
+    host_name = socket.gethostname()
+    client_app_uri = f"urn:{host_name}:foobar:myselfsignedclient"
     url = "opc.tcp://127.0.0.1:4840/freeopcua/server/"
+
+    await setup_self_signed_certificate(private_key,
+                                        cert,
+                                        client_app_uri,
+                                        host_name,
+                                        [ExtendedKeyUsageOID.CLIENT_AUTH],
+                                        {
+                                            'countryName': 'CN',
+                                            'stateOrProvinceName': 'AState',
+                                            'localityName': 'Foo',
+                                            'organizationName': "Bar Ltd",
+                                        })
     client = Client(url=url)
+    client.application_uri = client_app_uri
     await client.set_security(
         SecurityPolicyBasic256Sha256,
-        certificate=cert,
-        private_key=private_key,
+        certificate=str(cert),
+        private_key=str(private_key),
         server_certificate="certificate-example.der"
     )
     async with client:


### PR DESCRIPTION
With PR #1368 some functions are added to create and request certificates. Based on those functions a new helper method `setup_self_signed_certificate` is created. This should make it easy to add basic support to clients and servers for generating automatically certificates.

If can generated a private key and self-signed certificate when not already present. When the data range of the certificate is no longer valid it generates a new certificate.

Both the examples for client and server use with encryption are updated to demonstrate the use.