### PR TITLE
Fix new ruff E721 issues

### DIFF
--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -91,7 +91,7 @@ class InternalServer:
             evgen = EventGenerator(self.isession)
             await evgen.init(etype, add_generates_event=False)
             # don't use isinstance(int), it also matches bool
-            if type(self.bind_condition_methods) is int:
+            if isinstance(self.bind_condition_methods, int):
                 evgen.event.Severity = self.bind_condition_methods
             self.subscription_service.standard_events[etype] = evgen
 
@@ -386,7 +386,7 @@ class InternalServer:
             except Exception:
                 self.logger.exception("Unable to decrypt password")
                 return False
-        elif type(password) == bytes:  # TODO check
+        elif isinstance(password, bytes):  # TODO check
             password = password.decode('utf-8')
 
         return user_name, password

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1160,7 +1160,7 @@ async def test_guid_node_id():
     """
     node = Node(None, "ns=4;g=35d5f86f-2777-4550-9d48-b098f5ee285c")
     binary_node_id = ua.ua_binary.nodeid_to_binary(node.nodeid)
-    assert type(binary_node_id) is bytes
+    assert isinstance(binary_node_id, bytes)
 
 
 async def test_import_xml_data_type_definition(opc):

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -476,7 +476,7 @@ async def test_subscribe_server_time(opc):
     server_time_node = opc.opc.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
     sub = await opc.opc.create_subscription(200, myhandler)
     handle = await sub.subscribe_data_change(server_time_node)
-    assert type(handle) is int
+    assert isinstance(handle, int)
     node, val, data = await myhandler.result()
     assert server_time_node == node
     delta = datetime.utcnow() - val

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -642,7 +642,7 @@ def test_datavalue():
 def test_variant():
     dv = ua.Variant(True, ua.VariantType.Boolean)
     assert dv.Value is True
-    assert type(dv.Value) == bool
+    assert isinstance(dv.Value, bool)
     now = datetime.utcnow()
     v = ua.Variant(now)
     assert v.Value == now


### PR DESCRIPTION
Those issues were not detected previously since they are linked to the recent update of ruff to version 0.0.283, which fixed an issue in the detection of this lint error.