### PR TITLE
Adds a truststore for certficates

### DIFF
--- a/asyncua/crypto/truststore.py
+++ b/asyncua/crypto/truststore.py
@@ -1,0 +1,184 @@
+'''
+Functionality for checking a certificate based on:
+- trusted (ca) certificates
+- crl
+
+Use of cryptography module is prefered, but  doesn't provide functionality for truststores yet, so for some we rely on using pyOpenSSL.
+
+'''
+from typing import List
+from pathlib import Path
+import re
+from datetime import datetime
+import logging
+from cryptography import x509
+from OpenSSL import crypto
+from asyncua.crypto.uacrypto import get_content, load_certificate
+
+_logger = logging.getLogger("asyncuagds.validate")
+
+
+class TrustStore:
+    '''
+    TrustStore is used to validate certificates in two ways:
+    - Based on being absent in provided certificate revocation lists
+    - The certificate or its issuer being  present in a list of trusted certificates
+
+    It doesn't check other content of extensions of the certificate
+    '''
+
+    def __init__(self, trust_locations: List[Path], crl_locations: List[Path]):
+        """Constructor of the TrustStore
+
+        Args:
+            trust_locations (list[Path]): one or multiple locations that contain trusted (ca) certificates. Type should be DER.
+            crl_locations (list[Path]): one or multiple locations that contain CRL. TYpe should be DER.
+        """
+
+        self._trust_locations: List[Path] = trust_locations
+        self._crl_locations: List[Path] = crl_locations
+
+        self._trust_store: crypto.X509Store = crypto.X509Store()
+
+        self._revoked_list: List[x509.RevokedCertificate] = []
+
+    @property
+    def trust_locations(self) -> List[Path]:
+        return self._trust_locations
+
+    @property
+    def crl_locations(self) -> List[Path]:
+        return self._crl_locations
+
+    async def load(self):
+        """(re)load both the trusted certificates and revoctions lists"""
+        await self.load_trust()
+        await self.load_crl()
+
+    async def load_trust(self):
+        """(re)load the trusted certificates"""
+        self._trust_store: crypto.X509Store = crypto.X509Store()
+        for location in self._trust_locations:
+            await self._load_trust_location(location)
+
+    async def load_crl(self):
+        """(re)load the certificate revocation lists"""
+        self._revoked_list.clear()
+        for location in self._crl_locations:
+            await self._load_crl_location(location)
+
+    def validate(self, certificate: x509.Certificate) -> bool:
+        """ Validates if a certificate is trusted, not revoked and lays in valid datarange
+
+        Args:
+            certificate (x509.Certificate): Certificate to check
+
+        Returns:
+            bool: Returns True when the certificate is valid
+        """
+
+        return self.is_trusted(certificate) and self.is_revoked(certificate) is False and self.check_date_range(certificate)
+
+    def check_date_range(self, certificate: x509.Certificate) -> bool:
+        """ Checks if the certificate not_valid_before and not_valid_after are valid.
+
+        Args:
+            certificate (x509.Certificate): Certificate to check
+
+        Returns:
+            bool: Returns True when the now lays in valid range of the certificate
+        """
+        valid: bool = True
+        now = datetime.utcnow()
+        if certificate.not_valid_after < now:
+            _logger.error('certificate is no longer valid: valid until %s', certificate.not_valid_after)
+            valid = False
+        if certificate.not_valid_before > now:
+            _logger.error('certificate is not yet vaild: valid after %s', certificate.not_valid_before)
+            valid = False
+        return valid
+
+    def is_revoked(self, certificate: x509.Certificate) -> bool:
+        """ Check if the provided certifcate is in the revocation lists
+
+        when not CRLs are present it the certificate is considere not revoked.
+
+        Args:
+            certificate (x509.Certificate): Certificate to check
+
+        Returns:
+            bool: True when it is on a revocation list. If no list is present also return False.
+        """
+        is_revoked = False
+        for revoked in self._revoked_list:
+            if revoked.serial_number == certificate.serial_number:
+                subject_cn = certificate.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)[0].value
+                _logger.warning('Found revoked serial "%s" [CN=%s]', hex(certificate.serial_number),  subject_cn)
+                is_revoked = True
+                break
+        return is_revoked
+
+    def is_trusted(self, certificate: x509.Certificate) -> bool:
+        """ Check if the provided certifcate is considered trusted
+        For a self-signed to be trusted is must be placed in the trusted location
+        Args:
+            certificate (x509.Certificate): Certificate to check
+
+        Returns:
+            bool: True when it is trusted or the trust store is empty.
+        """
+        # TODO: return True when trust store is empty
+        _certificate: crypto.X509 = crypto.X509.from_cryptography(certificate)
+        store_ctx = crypto.X509StoreContext(self._trust_store, _certificate)
+        try:
+            store_ctx.verify_certificate()
+            _logger.debug('Use trusted certificate : \'%s\'', _certificate.get_subject().CN)
+            return True
+        except crypto.X509StoreContextError as exp:
+            print(exp)
+            _logger.warning('Not trusted certificate used: "%s"', _certificate.get_subject().CN)
+        return False
+
+    async def _load_trust_location(self, location: Path):
+        """Load from a single directory location the certificates and add those to the truststore
+
+        Args:
+            location (Path): location to scan for certificates
+        """
+        files = Path(location).glob('*.*')
+        for file_name in files:
+            if re.match('.*(der|pem)', file_name.name.lower()):
+                _logger.debug('Add certificate to TrustStore : \'%s\'', file_name)
+                trusted_cert: crypto.X509 = crypto.X509.from_cryptography(await load_certificate(file_name))
+                self._trust_store.add_cert(trusted_cert)
+
+    async def _load_crl_location(self, location: Path):
+        """Load from a single directory location the CRLs and add the revoked serials to the central CRL list.
+
+        Args:
+            location (Path): location to scan for crls
+        """
+        files = Path(location).glob('*.*')
+        for file_name in files:
+            if re.match('.*(der|pem)', file_name.name.lower()):
+                _logger.debug('Add CRL to list : \'%s\'', file_name)
+                crl = await self._load_crl(file_name)
+
+                for revoked in crl:
+                    self._revoked_list.append(revoked)
+
+    @ staticmethod
+    async def _load_crl(crl_file_name: Path) -> x509.CertificateRevocationList:
+        """Load a single crl from file
+
+        Args:
+            crl_file_name (Path): file to load
+
+        Returns:
+            x509.CertificateRevocationList: Return loaded CRL
+        """
+        content = await get_content(crl_file_name)
+        if crl_file_name.suffix.lower() == '.der':
+            return x509.load_der_x509_crl(content)
+
+        return x509.load_pem_x509_crl(content)

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -5,3 +5,4 @@ pytest-cov
 pytest-mock
 asynctest
 types-aiofiles
+types-pyOpenSSL

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     provides=["asyncua"],
     license="GNU Lesser General Public License v3 or later",
-    install_requires=["aiofiles", "aiosqlite", "python-dateutil", "pytz", "cryptography", "sortedcontainers", "importlib-metadata;python_version<'3.8'"],
+    install_requires=["aiofiles", "aiosqlite", "python-dateutil", "pytz", "cryptography", "sortedcontainers", "importlib-metadata;python_version<'3.8'", "pyOpenSSL"],
     classifiers=[
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tests/test_truststore.py
+++ b/tests/test_truststore.py
@@ -1,0 +1,186 @@
+""" test certificate truststore"""
+import datetime
+import shutil
+from pathlib import Path
+import socket
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives.serialization import Encoding
+from cryptography.hazmat.primitives import hashes
+from cryptography.x509.oid import NameOID, ExtendedKeyUsageOID
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from asyncua.crypto.uacrypto import load_certificate
+from asyncua.crypto.truststore import TrustStore
+from asyncua.crypto.cert_gen import generate_private_key, generate_self_signed_app_certificate, dump_private_key_as_pem, \
+    generate_app_certificate_signing_request, sign_certificate_request
+
+# pylint: disable=redefined-outer-name,missing-function-docstring, missing-module-docstring, missing-class-docstring
+
+CA_CERT_FILE = 'ca_cert.der'
+SERVER_CERT_FILE = 'myserver_cert.der'
+SERVER_CERT_SELF_SIGNED_FILE = 'myserver_cert_selfsigned.der'
+
+
+@pytest.fixture(scope="session")
+def cert_files(tmp_path_factory) -> Path:
+    ''' session based fixure to generate certifcates to test'''
+    tmp_path_factory.mktemp("data")
+
+    store_base: Path = tmp_path_factory.mktemp("pkistore")
+    trusted_cert: Path = store_base / 'trusted' / 'certs'
+    trusted_crl: Path = store_base / 'trusted' / 'crl'
+
+    own_certs: Path = store_base / 'own' / 'certs'
+    own_private: Path = store_base / 'own' / 'private'
+
+    trusted_cert.mkdir(parents=True, exist_ok=True)
+    trusted_crl.mkdir(parents=True, exist_ok=True)
+    own_certs.mkdir(parents=True, exist_ok=True)
+    own_private.mkdir(parents=True, exist_ok=True)
+
+    hostname: str = socket.gethostname()
+
+    names = {
+        'countryName': 'NL',
+        'stateOrProvinceName': 'ZH',
+        'localityName': 'Foo',
+        'organizationName': "Bar Ltd",
+    }
+    subject_alt_names: list[x509.GeneralName] = [x509.UniformResourceIdentifier(f"urn:{hostname}:foobar:myserver"),
+                                                 x509.DNSName(f"{hostname}")]
+
+    extended = [ExtendedKeyUsageOID.CLIENT_AUTH,
+                ExtendedKeyUsageOID.SERVER_AUTH]
+
+    # gen CA
+    key_ca: RSAPrivateKey = generate_private_key()
+    issuer: x509.Certificate = generate_self_signed_app_certificate(key_ca,
+                                                                    "Application CA",
+                                                                    names,
+                                                                    subject_alt_names,
+                                                                    extended=[],  # keep this one empty when generating an application CA
+                                                                    days=365)
+
+    # gen server private key
+    server_key: RSAPrivateKey = generate_private_key()
+
+    # gen server self signed cert
+    cert_self_signed: x509.Certificate = generate_self_signed_app_certificate(server_key,
+                                                                              f"myserver@{hostname}",
+                                                                              names,
+                                                                              subject_alt_names,
+                                                                              extended=[],  # keep this one empty when generating an application CA
+                                                                              days=365)
+
+    # gen server CSR
+    csr: x509.CertificateSigningRequest = generate_app_certificate_signing_request(server_key,
+                                                                                   f"myserver@{hostname}",
+                                                                                   names,
+                                                                                   subject_alt_names,
+                                                                                   extended=extended)
+
+    # sign CSR
+    cert: x509.Certificate = sign_certificate_request(csr, issuer, key_ca, days=30)
+
+    (own_private / 'ca_key.pem').write_bytes(dump_private_key_as_pem(key_ca))
+    (own_certs / CA_CERT_FILE).write_bytes(issuer.public_bytes(encoding=Encoding.DER))
+
+    (own_private / 'myserver_key.pem').write_bytes(dump_private_key_as_pem(server_key))
+    (own_certs / SERVER_CERT_FILE).write_bytes(cert.public_bytes(encoding=Encoding.DER))
+    (own_certs / SERVER_CERT_SELF_SIGNED_FILE).write_bytes(cert_self_signed.public_bytes(encoding=Encoding.DER))
+
+    one_day = datetime.timedelta(1, 0, 0)
+
+    builder = x509.CertificateRevocationListBuilder()
+    builder = builder.issuer_name(x509.Name([
+        x509.NameAttribute(NameOID.COMMON_NAME, 'Application CA'),
+    ]))
+    builder = builder.last_update(datetime.datetime.today())
+    builder = builder.next_update(datetime.datetime.today() + one_day)
+
+    crl_empty = builder.sign(
+        private_key=key_ca, algorithm=hashes.SHA256(),
+    )
+
+    (own_certs / 'ca_empty_crl.der').write_bytes(crl_empty.public_bytes(encoding=Encoding.DER))
+
+    revoked_cert = x509.RevokedCertificateBuilder().serial_number(
+        cert.serial_number
+    ).revocation_date(
+        datetime.datetime.today()
+    ).build()
+    builder = builder.add_revoked_certificate(revoked_cert)
+    crl = builder.sign(
+        private_key=key_ca, algorithm=hashes.SHA256(),
+    )
+    (own_certs / 'ca_crl.der').write_bytes(crl.public_bytes(encoding=Encoding.DER))
+
+    return own_certs
+
+
+@ pytest.fixture
+def trust_store(tmp_path) -> TrustStore:
+    """ fixture to generate clean trust store per test"""
+    base_trust_store: Path = tmp_path / 'truststore'
+    trusted_certs: Path = base_trust_store / 'certs'
+    trusted_crls: Path = base_trust_store / 'crl'
+
+    trusted_certs.mkdir(parents=True, exist_ok=True)
+    trusted_crls.mkdir(parents=True, exist_ok=True)
+
+    _trust_store = TrustStore([trusted_certs], [trusted_crls])
+    return _trust_store
+
+
+async def test_selfsigned_not_in_trust_store(cert_files, trust_store):
+    cert_self_signed: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_SELF_SIGNED_FILE)
+    assert trust_store.is_trusted(cert_self_signed) is False
+
+
+async def test_selfsigned_in_trust_store(cert_files, trust_store):
+    shutil.copyfile(cert_files / SERVER_CERT_SELF_SIGNED_FILE, trust_store.trust_locations[0] / SERVER_CERT_SELF_SIGNED_FILE)
+    await trust_store.load()
+
+    cert_self_signed: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_SELF_SIGNED_FILE)
+    assert trust_store.is_trusted(cert_self_signed) is True
+
+
+async def test_ca_not_in_trust_store(cert_files, trust_store):
+    cert_self_signed: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_SELF_SIGNED_FILE)
+    assert trust_store.is_trusted(cert_self_signed) is False
+
+
+async def test_ca_in_trust_store(cert_files, trust_store):
+    shutil.copyfile(cert_files / CA_CERT_FILE, trust_store.trust_locations[0] / CA_CERT_FILE)
+    await trust_store.load()
+
+    cert_server: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_FILE)
+    assert trust_store.is_trusted(cert_server) is True
+
+
+async def test_empty_crl(cert_files, trust_store):
+    shutil.copyfile(cert_files / CA_CERT_FILE, trust_store.trust_locations[0] / CA_CERT_FILE)
+    shutil.copyfile(cert_files / 'ca_empty_crl.der', trust_store.crl_locations[0] / 'ca_empty_crl.der')
+    await trust_store.load()
+
+    cert_server: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_FILE)
+
+    assert trust_store.is_trusted(cert_server) is True
+    assert trust_store.is_revoked(cert_server) is False
+    assert trust_store.check_date_range(cert_server) is True
+
+    assert trust_store.validate(cert_server) is True
+
+
+async def test_cert_in_crl(cert_files, trust_store):
+    shutil.copyfile(cert_files / CA_CERT_FILE, trust_store.trust_locations[0] / CA_CERT_FILE)
+    shutil.copyfile(cert_files / 'ca_crl.der', trust_store.crl_locations[0] / 'ca_crl.der')
+    await trust_store.load()
+
+    cert_server: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_FILE)
+
+    assert trust_store.is_trusted(cert_server) is True
+    assert trust_store.is_revoked(cert_server) is True
+    assert trust_store.check_date_range(cert_server) is True
+
+    assert trust_store.validate(cert_server) is False


### PR DESCRIPTION
This PR introduces a new class ` asyncua.crypto.truststore.TrustStore`.
With this `TrustStore` certificates can be validated against trusted certificates, trusted ca certificates and certificate revocation lists.
The TrustStore can handle multiple locations to collect trusted certificates and CRLs.

Test is included.

A subsequent PR is required to integrate `TrustStore` with `Client` and `Server` code.