### PR TITLE
Automatically print error text when an ua.ErrorMessage is received.

### DIFF
--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -96,6 +96,10 @@ class UASocketProtocol(asyncio.Protocol):
                     return
                 # Buffer still has bytes left, try to process again
                 data = bytes(buf)
+            except ua.UaStatusCodeError as e:
+                self.logger.error('Got error status from server: {}'.format(e))
+                self.disconnect_socket()
+                return
             except Exception:
                 self.logger.exception('Exception raised while parsing message from server')
                 self.disconnect_socket()
@@ -111,6 +115,9 @@ class UASocketProtocol(asyncio.Protocol):
         elif isinstance(msg, ua.ErrorMessage):
             self.logger.fatal("Received an error: %r", msg)
             self.disconnect_socket()
+            if msg.Error is not None:
+                # Automatically print human-readable error text.
+                msg.Error.check()
         else:
             raise ua.UaError(f"Unsupported message type: {msg}")
 


### PR DESCRIPTION
This PR improves the (for example SSL secure_open) error reporting from

```
Received an error: ErrorMessage(Error=StatusCode(value=2148728832), Reason=None)
Received an error: ErrorMessage(Error=StatusCode(value=2148728832), Reason=None)
```

to

```
Received an error: ErrorMessage(Error=StatusCode(value=2148728832), Reason=None)
Received an error: ErrorMessage(Error=StatusCode(value=2148728832), Reason=None)
Got error status from server: "An error occurred verifying security."(BadSecurityChecksFailed)
```

