### PR TITLE
Add translate_browsepaths() to Client

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -911,3 +911,17 @@ class Client:
         parameters.NodesToBrowse = nodestobrowse
         results = await self.uaclient.browse(parameters)
         return list(zip(nodes, results))
+
+    async def translate_browsepaths(self, starting_node: ua.NodeId, relative_paths: List[Union[ua.RelativePath, str]]) -> List[ua.BrowsePathResult]:
+        bpaths = []
+        for p in relative_paths:
+            try:
+                rpath = ua.RelativePath.from_string(p) if isinstance(p, str) else p
+            except ValueError as e:
+                raise ua.UaStringParsingError(f"Failed to parse one of RelativePath: {p}") from e
+            bpath = ua.BrowsePath()
+            bpath.StartingNode = starting_node
+            bpath.RelativePath = rpath
+            bpaths.append(bpath)
+
+        return await self.uaclient.translate_browsepaths_to_nodeids(bpaths)

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -314,7 +314,11 @@ class Client:
         pass
 
     @syncmethod
-    def translate_browsepaths(self, starting_node: ua.NodeId, relative_paths: List[Union[ua.RelativePath, str]]) -> List[ua.BrowsePathResult]:
+    def translate_browsepaths(  # type: ignore[empty-body]
+        self,
+        starting_node: ua.NodeId,
+        relative_paths: List[Union[ua.RelativePath, str]]
+    ) -> List[ua.BrowsePathResult]:
         pass
 
     def __enter__(self):

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -313,6 +313,10 @@ class Client:
     def write_values(self, nodes, values, raise_on_partial_error=True):
         pass
 
+    @syncmethod
+    def translate_browsepaths(self, starting_node: ua.NodeId, relative_paths: List[Union[ua.RelativePath, str]]) -> List[ua.BrowsePathResult]:
+        pass
+
     def __enter__(self):
         try:
             self.connect()

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -546,7 +546,7 @@ async def test_unsubscribe_two_objects_consecutively(opc):
     ]
     sub = await opc.opc.create_subscription(100, handler)
     handles = await sub.subscribe_data_change(nodes, queuesize=1)
-    assert type(handles) is list
+    assert isinstance(handles, list)
     await handler.done()
     for handle in handles:
         await sub.unsubscribe(handle)


### PR DESCRIPTION
Add `translate_browsepaths()` to `Client`, a convenient method to translate the specified relative paths into `NodeId`. It supports [RelativePath text format](https://reference.opcfoundation.org/Core/Part4/v105/docs/A.2) introduced in #1382.