### PR TITLE
Add type hints to struct_from_binary()

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -681,7 +681,7 @@ class Client:
     def get_server_node(self):
         return self.get_node(ua.FourByteNodeId(ua.ObjectIds.Server))
 
-    def get_node(self, nodeid: Union[Node, ua.NodeId, str, bytes, int]) -> Node:
+    def get_node(self, nodeid: Union[Node, ua.NodeId, str, int]) -> Node:
         """
         Get node using NodeId object or a string representing a NodeId.
         """

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -681,7 +681,7 @@ class Client:
     def get_server_node(self):
         return self.get_node(ua.FourByteNodeId(ua.ObjectIds.Server))
 
-    def get_node(self, nodeid: Union[ua.NodeId, str]) -> Node:
+    def get_node(self, nodeid: Union[Node, ua.NodeId, str, bytes, int]) -> Node:
         """
         Get node using NodeId object or a string representing a NodeId.
         """

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -4,7 +4,7 @@ Low level binary client
 import asyncio
 import copy
 import logging
-from typing import Awaitable, Callable, Dict, List, Optional, Union, Coroutine, Any
+from typing import Awaitable, Callable, Dict, List, Optional, Union
 
 from asyncua import ua
 from asyncua.common.session_interface import AbstractSession

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -499,7 +499,7 @@ class UaClient(AbstractSession):
 
     async def create_subscription(   # type: ignore[override]
         self, params: ua.CreateSubscriptionParameters, callback
-    ) -> Coroutine[Any, Any, ua.CreateSubscriptionResult]:
+    ) -> ua.CreateSubscriptionResult:
         self.logger.debug("create_subscription")
         request = ua.CreateSubscriptionRequest()
         request.Parameters = params
@@ -780,7 +780,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def set_monitoring_mode(self, params) -> ua.uatypes.StatusCode:
+    async def set_monitoring_mode(self, params) -> List[ua.uatypes.StatusCode]:
         """
         Update the subscription monitoring mode
         """
@@ -793,7 +793,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Parameters.Results
 
-    async def set_publishing_mode(self, params) -> ua.uatypes.StatusCode:
+    async def set_publishing_mode(self, params) -> List[ua.uatypes.StatusCode]:
         """
         Update the subscription publishing mode
         """

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -46,7 +46,7 @@ class Node:
     OPC-UA protocol. Feel free to look at the code of this class and call
     directly UA services methods to optimize your code
     """
-    def __init__(self, session: AbstractSession, nodeid: Union[ua.NodeId, str, int]):
+    def __init__(self, session: AbstractSession, nodeid: Union["Node", ua.NodeId, str, bytes, int]):
         self.session = session
         self.nodeid: ua.NodeId
         if isinstance(nodeid, Node):

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -53,7 +53,7 @@ class Node:
             self.nodeid = nodeid.nodeid
         elif isinstance(nodeid, ua.NodeId):
             self.nodeid = nodeid
-        elif type(nodeid) in (str, bytes):
+        elif isinstance(nodeid, str) or isinstance(nodeid, bytes):
             self.nodeid = ua.NodeId.from_string(nodeid)
         elif isinstance(nodeid, int):
             self.nodeid = ua.NodeId(nodeid, 0)

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -46,14 +46,14 @@ class Node:
     OPC-UA protocol. Feel free to look at the code of this class and call
     directly UA services methods to optimize your code
     """
-    def __init__(self, session: AbstractSession, nodeid: Union["Node", ua.NodeId, str, bytes, int]):
+    def __init__(self, session: AbstractSession, nodeid: Union["Node", ua.NodeId, str, int]):
         self.session = session
         self.nodeid: ua.NodeId
         if isinstance(nodeid, Node):
             self.nodeid = nodeid.nodeid
         elif isinstance(nodeid, ua.NodeId):
             self.nodeid = nodeid
-        elif isinstance(nodeid, str) or isinstance(nodeid, bytes):
+        elif isinstance(nodeid, str):
             self.nodeid = ua.NodeId.from_string(nodeid)
         elif isinstance(nodeid, int):
             self.nodeid = ua.NodeId(nodeid, 0)

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -292,7 +292,7 @@ class Client:
     def get_namespace_index(self, url):
         pass
 
-    def get_node(self, nodeid: Union["SyncNode", ua.NodeId, str, bytes, int]):
+    def get_node(self, nodeid: Union["SyncNode", ua.NodeId, str, int]):
         aio_nodeid = nodeid.aio_obj if isinstance(nodeid, SyncNode) else nodeid
         return SyncNode(self.tloop, self.aio_obj.get_node(aio_nodeid))
 

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -205,6 +205,7 @@ class _SubHandler:
     def status_change_notification(self, status: ua.StatusChangeNotification):
         self.sync_handler.status_change_notification(status)
 
+
 class Client:
     def __init__(self, url: str, timeout: int = 4, tloop=None):
         self.tloop = tloop
@@ -291,8 +292,9 @@ class Client:
     def get_namespace_index(self, url):
         pass
 
-    def get_node(self, nodeid):
-        return SyncNode(self.tloop, self.aio_obj.get_node(nodeid))
+    def get_node(self, nodeid: Union["SyncNode", ua.NodeId, str, bytes, int]):
+        aio_nodeid = nodeid.aio_obj if isinstance(nodeid, SyncNode) else nodeid
+        return SyncNode(self.tloop, self.aio_obj.get_node(aio_nodeid))
 
     def get_root_node(self):
         return SyncNode(self.tloop, self.aio_obj.get_root_node())
@@ -437,7 +439,6 @@ class Server:
         return Subscription(self.tloop, aio_sub)
 
 
-
 class EventGenerator:
     def __init__(self, tloop, aio_evgen):
         self.aio_obj = aio_evgen
@@ -459,7 +460,7 @@ def new_node(sync_node, nodeid):
 
 
 class SyncNode:
-    def __init__(self, tloop, aio_node):
+    def __init__(self, tloop: ThreadLoop, aio_node: node.Node):
         self.aio_obj = aio_node
         self.tloop = tloop
 

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -915,7 +915,7 @@ class Variant:
 
     # FIXME: typing is wrong here
     Value: Any = None
-    VariantType: VariantType = None
+    VariantType: "VariantType" = None
     Dimensions: Optional[List[Int32]] = None
     is_array: Optional[bool] = None
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -546,7 +546,7 @@ async def test_unsubscribe_two_objects_consecutively(opc):
     ]
     sub = await opc.opc.create_subscription(100, handler)
     handles = await sub.subscribe_data_change(nodes, queuesize=1)
-    assert type(handles) is list
+    assert isinstance(handles, list)
     await handler.done()
     for handle in handles:
         await sub.unsubscribe(handle)


### PR DESCRIPTION
- Add type hints to `struct_from_binary()` to leverage type inferences for the methods on `UaClient`
- Fix type hints on `Client.get_node()`