### PR TITLE
Adds a certificate validation hook to the client and server

### DIFF
--- a/asyncua/crypto/validator.py
+++ b/asyncua/crypto/validator.py
@@ -1,0 +1,133 @@
+from typing import Callable, Awaitable, Optional
+import logging
+from datetime import datetime
+from enum import Flag, auto
+from cryptography import x509
+from cryptography.x509.oid import ExtendedKeyUsageOID
+from asyncua import ua
+from asyncua.common.utils import ServiceError
+from asyncua.ua import ApplicationDescription
+from asyncua.crypto.truststore import TrustStore
+
+_logger = logging.getLogger(__name__)
+
+# Use for storing method that can validate a certificate on a create_session
+CertificateValidatorMethod = Callable[[x509.Certificate, ApplicationDescription], Awaitable[None]]
+
+class CertificateValidatorOptions(Flag):
+    """
+    Flags for which certificate validation should be performed
+
+    Three default sets of flags are provided:
+    - BASIC_VALIDATION
+    - EXT_VALIDATION
+    - TRUSTED_VALIDATION
+    """
+    TIME_RANGE = auto()
+    URI = auto()
+    KEY_USAGE = auto()
+    EXT_KEY_USAGE = auto()
+    TRUSTED = auto()
+    REVOKED = auto()
+
+    PEER_CLIENT = auto()
+    """Expect role of the peer is client (mutal exclusive with PEER_SERVER)"""
+    PEER_SERVER = auto()
+    """Expect role of the peer is server (mutal exclusive with PEER_CLIENT)"""
+
+    BASIC_VALIDATION = TIME_RANGE | URI
+    """Option set with: Only check time range and uri"""
+    EXT_VALIDATION = TIME_RANGE | URI | KEY_USAGE | EXT_KEY_USAGE
+    """Option set with: Check time, uri, key usage and extended key usage"""
+    TRUSTED_VALIDATION = TIME_RANGE | URI | KEY_USAGE | EXT_KEY_USAGE | TRUSTED | REVOKED
+    """Option set with: Check time, uri, key usage, extended key usage, is trusted (direct or by CA) and not revoked (CRL)"""
+
+
+class CertificateValidator:
+    """
+    CertificateValidator contains a basic certificate validator including trusted store with revocation list support.
+    The CertificateValidator can be used as a CertificateValidatorMethod.
+
+    Default CertificateValidatorOptions.BASIC_VALIDATION is used.
+    """
+
+    def __init__(self, options: CertificateValidatorOptions = CertificateValidatorOptions.BASIC_VALIDATION | CertificateValidatorOptions.PEER_CLIENT, trust_store: Optional[TrustStore] = None):
+        self._options = options
+        self._trust_store: Optional[TrustStore] = trust_store
+
+    def set_validate_options(self, options: CertificateValidatorOptions):
+        """ Change the use validation options at runtime"""
+
+        self._options = options
+
+    async def validate(self, cert: x509.Certificate, app_description: ua.ApplicationDescription):
+        """ Validate if a certificate is valid based on the validation options.
+        When not valid is raises a ServiceError with an UA Result Code.
+
+        Args:
+            cert (x509.Certificate): certificate to check
+            app_description (ua.ApplicationDescription): application descriptor of the client/server
+
+        Raises:
+            BadCertificateTimeInvalid: When current time is not in the time range of the certificate
+            BadCertificateUriInvalid: Uri from certificate doesn't match application descriptor uri
+            BadCertificateUseNotAllowed: KeyUsage or ExtendedKeyUsage fields mismatch
+            BadCertificateInvalid: General when part of certifcate fields can't be found
+            BadCertificateUntrusted: Not trusted by TrustStore
+            ApplicationDescription: Certifacate in CRL of the TrustStore
+        """
+
+        if CertificateValidatorOptions.TIME_RANGE in self._options:
+            now = datetime.utcnow()
+            if cert.not_valid_after < now:
+                raise ServiceError(ua.StatusCodes.BadCertificateTimeInvalid)
+            elif cert.not_valid_before > now:
+                raise ServiceError(ua.StatusCodes.BadCertificateTimeInvalid)
+        try:
+            san = cert.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+            if CertificateValidatorOptions.URI in self._options:
+                san_uri = san.value.get_values_for_type(x509.UniformResourceIdentifier)
+                if app_description.ApplicationUri not in san_uri:
+                    raise ServiceError(ua.StatusCodes.BadCertificateUriInvalid)
+            if CertificateValidatorOptions.KEY_USAGE in self._options:
+
+                key_usage = cert.extensions.get_extension_for_class(x509.KeyUsage).value
+                if key_usage.data_encipherment is False or \
+                key_usage.digital_signature is False or \
+                key_usage.content_commitment is False or \
+                key_usage.key_encipherment is False:
+                    raise ServiceError(ua.StatusCodes.BadCertificateUseNotAllowed)
+            if CertificateValidatorOptions.EXT_KEY_USAGE in self._options:
+                oid = ExtendedKeyUsageOID.SERVER_AUTH if CertificateValidatorOptions.PEER_SERVER in self._options else ExtendedKeyUsageOID.CLIENT_AUTH
+
+                if oid not in cert.extensions.get_extension_for_class(x509.ExtendedKeyUsage).value:
+                    raise ServiceError(ua.StatusCodes.BadCertificateUseNotAllowed)
+
+                if CertificateValidatorOptions.PEER_SERVER in self._options and \
+                    app_description.ApplicationType not in [ua.ApplicationType.Server, ua.ApplicationType.ClientAndServer]:
+                    _logger.warning('mismatch between application type and certificate ExtendedKeyUsage')
+                    raise ServiceError(ua.StatusCodes.BadCertificateUseNotAllowed)
+                elif CertificateValidatorOptions.PEER_CLIENT in self._options and \
+                    app_description.ApplicationType not in [ua.ApplicationType.Client, ua.ApplicationType.ClientAndServer]:
+                    _logger.warning('mismatch between application type and certificate ExtendedKeyUsage')
+                    raise ServiceError(ua.StatusCodes.BadCertificateUseNotAllowed)
+
+
+            # if hostname is not None:
+            #     san_dns_names = san.value.get_values_for_type(x509.DNSName)
+            #     if hostname not in san_dns_names:
+            #         raise ServiceError(ua.StatusCodes.BadCertificateHostNameInvalid) from exc
+        except x509.ExtensionNotFound as exc:
+            raise ServiceError(ua.StatusCodes.BadCertificateInvalid) from exc
+
+        if CertificateValidatorOptions.TRUSTED in self._options or CertificateValidatorOptions.REVOKED in self._options:
+
+            if CertificateValidatorOptions.TRUSTED in self._options:
+                if self._trust_store and not self._trust_store.is_trusted(cert):
+                    raise ServiceError(ua.StatusCodes.BadCertificateUntrusted)
+            if CertificateValidatorOptions.REVOKED in self._options:
+                if self._trust_store and self._trust_store.is_revoked(cert):
+                    raise ServiceError(ua.StatusCodes.BadCertificateRevoked)
+
+    async def __call__(self, cert: x509.Certificate, app_description: ua.ApplicationDescription):
+        return await self.validate(cert, app_description)

--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -2,7 +2,7 @@
 Internal server implementing opcu-ua interface.
 Can be used on server side or to implement binary/https opc-ua servers
 """
-
+from typing import Optional
 import asyncio
 from datetime import datetime, timedelta
 from copy import copy
@@ -23,6 +23,7 @@ from .standard_address_space import standard_address_space
 from .users import User, UserRole
 from .internal_session import InternalSession
 from .event_generator import EventGenerator
+from ..crypto.validator import CertificateValidatorMethod
 
 try:
     from asyncua.crypto import uacrypto
@@ -67,6 +68,8 @@ class InternalServer:
             _logger.info("No user manager specified. Using default permissive manager instead.")
             user_manager = PermissiveUserManager()
         self.user_manager = user_manager
+        self.certificate_validator: Optional[CertificateValidatorMethod]= None
+        """hook to validate a certificate, raises a ServiceError when not valid"""
         # create a session to use on server side
         self.isession = InternalSession(
             self, self.aspace, self.subscription_service, "Internal", user=User(role=UserRole.Admin)

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -28,7 +28,7 @@ from ..common.structures104 import load_data_type_definitions
 from ..common.ua_utils import get_nodes_of_namespace
 from ..common.connection import TransportLimits
 
-from ..crypto import security_policies, uacrypto
+from ..crypto import security_policies, uacrypto, validator
 
 _logger = logging.getLogger(__name__)
 
@@ -825,3 +825,17 @@ class Server:
         directly read datavalue of the Attribute
         """
         return self.iserver.read_attribute_value(nodeid, attr)
+
+    def set_certificate_validator(self, validator: validator.CertificateValidatorMethod):
+        """
+        Assign a method to be called when certificate needs to be validated.
+
+        Function is called with certificate and application description and should raise the correct status code
+        when invalid.
+
+            async def example_validation_method(certificate: x509.Certificate, app_description: ua.ApplicationDescription):
+                ...
+                if not_valid_condition:
+                    raise ServiceError(ua.StatusCodes.BadCertificateInvalid)
+        """
+        self.iserver.certificate_validator = validator

--- a/tests/test_crypto_connect.py
+++ b/tests/test_crypto_connect.py
@@ -11,6 +11,7 @@ from asyncua import Server
 from asyncua import ua
 from asyncua.server.user_managers import CertificateUserManager
 from asyncua.crypto.security_policies import Verifier, Decryptor
+from asyncua.crypto.validator import CertificateValidator, CertificateValidatorOptions
 
 try:
     from asyncua.crypto import uacrypto
@@ -502,3 +503,36 @@ async def test_security_level_endpoints(srv_crypto_all_certs):
 
     for end_point in end_points:
         assert end_point.SecurityLevel == Server.determine_security_level(end_point.SecurityPolicyUri, end_point.SecurityMode)
+
+async def test_certificate_validator(srv_crypto_one_cert):
+    # the used certificate is not compliant with a valid OPC UA certificate so only unhappy flow can be tested!
+
+    srv, cert = srv_crypto_one_cert
+
+    validator = CertificateValidator(options=CertificateValidatorOptions.BASIC_VALIDATION | CertificateValidatorOptions.PEER_CLIENT)
+    srv.set_certificate_validator(validator)
+
+    clt = Client(uri_crypto_cert)
+    await clt.set_security(
+        security_policies.SecurityPolicyBasic256Sha256,
+        peer_creds['certificate'],
+        peer_creds['private_key'],
+        None,
+        cert,
+        mode=ua.MessageSecurityMode.SignAndEncrypt
+    )
+
+    validator.set_validate_options(options=CertificateValidatorOptions.URI | CertificateValidatorOptions.PEER_CLIENT)
+    with pytest.raises(ua.uaerrors.BadCertificateInvalid):
+        async with clt:
+            assert await clt.get_objects_node().get_children()
+
+    validator.set_validate_options(options=CertificateValidatorOptions.TIME_RANGE | CertificateValidatorOptions.PEER_CLIENT)
+    with pytest.raises(ua.uaerrors.BadCertificateTimeInvalid):
+        async with clt:
+            assert await clt.get_objects_node().get_children()
+
+    validator.set_validate_options(options=CertificateValidatorOptions.KEY_USAGE | CertificateValidatorOptions.EXT_KEY_USAGE | CertificateValidatorOptions.PEER_CLIENT)
+    with pytest.raises(ua.uaerrors.BadCertificateInvalid):
+        async with clt:
+            assert await clt.get_objects_node().get_children()


### PR DESCRIPTION
With the hook you can register callback method with the following type `CertificateValidatorMethod`:
```
Callable[[x509.Certificate, ApplicationDescription], Awaitable[None]]
```

The method must raise an `ServiceError` exception when the certificate is invalid. The makes it possible to provide your own logic for validation.

An default implementation of such certificate validation hook is also provided by `ucrypto.validator.CertificateValidator`.

`CertificateValidator` supports checking:
- Uri
- Timerange
- Key Usage
- Extended Key Usage
- Trust
- Revoked

For the last two checks a instance of a `TrustStore` needs to be provided to `CertificateValidator`.

Which checks must be performed can be configured with `CertificateValidatorOptions`. Those are provide to the constructor of `CertificateValidator` and can be changed later with `CertificateValidator.set_validate_options`.

Examples of client and server with encryption are changed to demonstrate the use of the validator.

Basic testing of the validator is present.