### PR TITLE
Add type hints to Client and its missing sync methods

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -3,7 +3,7 @@ import logging
 import socket
 from cryptography import x509
 from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
-from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple, Type, Union, cast
 from urllib.parse import urlparse, unquote
 from pathlib import Path
 
@@ -100,7 +100,7 @@ class Client:
     __repr__ = __str__
 
     @staticmethod
-    def find_endpoint(endpoints: List[ua.EndpointDescription], security_mode: ua.MessageSecurityMode, policy_uri: str) -> ua.EndpointDescription:
+    def find_endpoint(endpoints: Iterable[ua.EndpointDescription], security_mode: ua.MessageSecurityMode, policy_uri: str) -> ua.EndpointDescription:
         """
         Find endpoint with required security mode and policy URI
         """
@@ -126,7 +126,7 @@ class Client:
             raise TypeError(f"Password must be a string, got {pwd} of type {type(pwd)}")
         self._password = pwd
 
-    def set_locale(self, locale: List[str]) -> None:
+    def set_locale(self, locale: Sequence[str]) -> None:
         """
         Sets the preferred locales of the client, the server chooses which locale he can provide.
         Normally the first matching locale in the list will be chosen, by the server.
@@ -230,7 +230,7 @@ class Client:
         """
         self.user_private_key = await uacrypto.load_private_key(path, password, extension)
 
-    async def connect_and_get_server_endpoints(self) -> List[ua.EndpointDescription]:
+    async def connect_and_get_server_endpoints(self) -> Sequence[ua.EndpointDescription]:
         """
         Connect, ask server for endpoints, and disconnect
         """
@@ -246,7 +246,7 @@ class Client:
             self.disconnect_socket()
         return endpoints
 
-    async def connect_and_find_servers(self) -> List[ua.ApplicationDescription]:
+    async def connect_and_find_servers(self) -> Sequence[ua.ApplicationDescription]:
         """
         Connect, ask server for a list of known servers, and disconnect
         """
@@ -262,7 +262,7 @@ class Client:
             self.disconnect_socket()
         return servers
 
-    async def connect_and_find_servers_on_network(self) -> List[ua.FindServersOnNetworkResult]:
+    async def connect_and_find_servers_on_network(self) -> Sequence[ua.FindServersOnNetworkResult]:
         """
         Connect, ask server for a list of known servers on network, and disconnect
         """
@@ -382,7 +382,7 @@ class Client:
     async def close_secure_channel(self):
         return await self.uaclient.close_secure_channel()
 
-    async def get_endpoints(self) -> List[ua.EndpointDescription]:
+    async def get_endpoints(self) -> Sequence[ua.EndpointDescription]:
         """Get a list of OPC-UA endpoints."""
 
         params = ua.GetEndpointsParameters()
@@ -427,7 +427,7 @@ class Client:
             return await self.uaclient.unregister_server2(params)
         return await self.uaclient.unregister_server(serv)
 
-    async def find_servers(self, uris: Optional[List[str]] = None) -> List[ua.ApplicationDescription]:
+    async def find_servers(self, uris: Optional[Iterable[str]] = None) -> Sequence[ua.ApplicationDescription]:
         """
         send a FindServer request to the server. The answer should be a list of
         servers the server knows about
@@ -437,10 +437,10 @@ class Client:
             uris = []
         params = ua.FindServersParameters()
         params.EndpointUrl = self.server_url.geturl()
-        params.ServerUris = uris
+        params.ServerUris = list(uris)
         return await self.uaclient.find_servers(params)
 
-    async def find_servers_on_network(self) -> List[ua.FindServersOnNetworkResult]:
+    async def find_servers_on_network(self) -> Sequence[ua.FindServersOnNetworkResult]:
         params = ua.FindServersOnNetworkParameters()
         return await self.uaclient.find_servers_on_network(params)
 
@@ -757,7 +757,7 @@ class Client:
             modified_params.RequestedLifetimeCount = results.RevisedLifetimeCount
             return modified_params
 
-    async def delete_subscriptions(self, subscription_ids: List[int]) -> List[ua.StatusCode]:
+    async def delete_subscriptions(self, subscription_ids: Iterable[int]) -> Sequence[ua.StatusCode]:
         """
         Deletes the provided list of subscription_ids
         """
@@ -776,7 +776,7 @@ class Client:
         period = period or 1000
         return int((self.session_timeout / period) * 0.75)
 
-    async def get_namespace_array(self) -> List[str]:
+    async def get_namespace_array(self) -> Sequence[str]:
         ns_node = self.get_node(ua.NodeId(ua.ObjectIds.Server_NamespaceArray))
         return await ns_node.read_value()
 
@@ -785,10 +785,10 @@ class Client:
         _logger.info("get_namespace_index %s %r", type(uries), uries)
         return uries.index(uri)
 
-    async def delete_nodes(self, nodes: List[Node], recursive=False) -> Tuple[List[Node], List[ua.StatusCode]]:
+    async def delete_nodes(self, nodes: Iterable[Node], recursive=False) -> Tuple[Sequence[Node], Sequence[ua.StatusCode]]:
         return await delete_nodes(self.uaclient, nodes, recursive)
 
-    async def import_xml(self, path=None, xmlstring=None, strict_mode=True) -> List[ua.NodeId]:
+    async def import_xml(self, path=None, xmlstring=None, strict_mode=True) -> Sequence[ua.NodeId]:
         """
         Import nodes defined in xml
         """
@@ -843,7 +843,7 @@ class Client:
         _logger.warning("Deprecated since spec 1.04, call load_data_type_definitions")
         return await load_enums(self)
 
-    async def register_nodes(self, nodes: List[Node]) -> List[Node]:
+    async def register_nodes(self, nodes: Iterable[Node]) -> Sequence[Node]:
         """
         Register nodes for faster read and write access (if supported by server)
         Rmw: This call modifies the nodeid of the nodes, the original nodeid is
@@ -854,9 +854,9 @@ class Client:
         for node, nodeid in zip(nodes, nodeids):
             node.basenodeid = node.nodeid
             node.nodeid = nodeid
-        return nodes
+        return list(nodes)
 
-    async def unregister_nodes(self, nodes: List[Node]) -> None:
+    async def unregister_nodes(self, nodes: Iterable[Node]) -> None:
         """
         Unregister nodes
         """
@@ -868,21 +868,21 @@ class Client:
             node.nodeid = node.basenodeid
             node.basenodeid = None
 
-    async def read_attributes(self, nodes: List[Node], attr: ua.AttributeIds = ua.AttributeIds.Value) -> List[ua.DataValue]:
+    async def read_attributes(self, nodes: Iterable[Node], attr: ua.AttributeIds = ua.AttributeIds.Value) -> Sequence[ua.DataValue]:
         """
         Read the attributes of multiple nodes.
         """
         nodeids = [node.nodeid for node in nodes]
         return await self.uaclient.read_attributes(nodeids, attr)
 
-    async def read_values(self, nodes: List[Node]) -> List[Any]:
+    async def read_values(self, nodes: Iterable[Node]) -> Sequence[Any]:
         """
         Read the value of multiple nodes in one ua call.
         """
         res = await self.read_attributes(nodes, attr=ua.AttributeIds.Value)
         return [r.Value.Value if r.Value else None for r in res]
 
-    async def write_values(self, nodes: List[Node], values: List[Any], raise_on_partial_error: bool = True) -> List[ua.StatusCode]:
+    async def write_values(self, nodes: Iterable[Node], values: Iterable[Any], raise_on_partial_error: bool = True) -> Sequence[ua.StatusCode]:
         """
         Write values to multiple nodes in one ua call
         """
@@ -897,7 +897,7 @@ class Client:
     get_values = read_values  # legacy compatibility
     set_values = write_values  # legacy compatibility
 
-    async def browse_nodes(self, nodes: List[Node]) -> List[Tuple[Node, ua.BrowseResult]]:
+    async def browse_nodes(self, nodes: Iterable[Node]) -> Sequence[Tuple[Node, ua.BrowseResult]]:
         """
         Browses multiple nodes in one ua call
         returns a List of Tuples(Node, BrowseResult)
@@ -915,7 +915,7 @@ class Client:
         results = await self.uaclient.browse(parameters)
         return list(zip(nodes, results))
 
-    async def translate_browsepaths(self, starting_node: ua.NodeId, relative_paths: List[Union[ua.RelativePath, str]]) -> List[ua.BrowsePathResult]:
+    async def translate_browsepaths(self, starting_node: ua.NodeId, relative_paths: Iterable[Union[ua.RelativePath, str]]) -> Sequence[ua.BrowsePathResult]:
         bpaths = []
         for p in relative_paths:
             try:

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -1,17 +1,20 @@
 import asyncio
 import logging
 import socket
-from typing import List, Tuple, Union, Coroutine, Optional, Type
+from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric.types import PrivateKeyTypes
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, cast
 from urllib.parse import urlparse, unquote
 from pathlib import Path
 
+import asyncua
 from asyncua import ua
 from .ua_client import UaClient
 from ..common.xmlimporter import XmlImporter
 from ..common.xmlexporter import XmlExporter
 from ..common.node import Node
 from ..common.manage_nodes import delete_nodes
-from ..common.subscription import Subscription
+from ..common.subscription import SubHandler, Subscription
 from ..common.shortcuts import Shortcuts
 from ..common.structures import load_type_definitions, load_enums
 from ..common.structures104 import load_data_type_definitions
@@ -68,14 +71,14 @@ class Client:
         self.secure_channel_id = None
         self.secure_channel_timeout = 3600000  # 1 hour
         self.session_timeout = 3600000  # 1 hour
-        self._policy_ids = []
+        self._policy_ids: List[ua.UserTokenPolicy] = []
         self.uaclient: UaClient = UaClient(timeout)
         self.uaclient.pre_request_hook = self.check_connection
-        self.user_certificate = None
-        self.user_private_key = None
+        self.user_certificate: Optional[x509.Certificate] = None
+        self.user_private_key: Optional[PrivateKeyTypes] = None
         self._server_nonce = None
         self._session_counter = 1
-        self.nodes = Shortcuts(self.uaclient)
+        self.nodes: Shortcuts = Shortcuts(self.uaclient)
         self.max_messagesize = 0  # No limits
         self.max_chunkcount = 0  # No limits
         self._renew_channel_task = None
@@ -97,7 +100,7 @@ class Client:
     __repr__ = __str__
 
     @staticmethod
-    def find_endpoint(endpoints, security_mode, policy_uri):
+    def find_endpoint(endpoints: List[ua.EndpointDescription], security_mode: ua.MessageSecurityMode, policy_uri: str) -> ua.EndpointDescription:
         """
         Find endpoint with required security mode and policy URI
         """
@@ -107,14 +110,14 @@ class Client:
                 return ep
         raise ua.UaError(f"No matching endpoints: {security_mode}, {policy_uri}")
 
-    def set_user(self, username: str):
+    def set_user(self, username: str) -> None:
         """
         Set user name for the connection.
         initial user from the URL will be overwritten
         """
         self._username = username
 
-    def set_password(self, pwd: str):
+    def set_password(self, pwd: str) -> None:
         """
         Set user password for the connection.
         initial password from the URL will be overwritten
@@ -131,7 +134,7 @@ class Client:
         """
         self._locale = locale
 
-    async def set_security_string(self, string: str):
+    async def set_security_string(self, string: str) -> None:
         """
         Set SecureConnection mode.
         :param string: Mode format ``Policy,Mode,certificate,private_key[,server_private_key]``
@@ -166,7 +169,7 @@ class Client:
         private_key_password: Optional[Union[str, bytes]] = None,
         server_certificate: Optional[Union[str, uacrypto.CertProperties, bytes]] = None,
         mode: ua.MessageSecurityMode = ua.MessageSecurityMode.SignAndEncrypt,
-    ):
+    ) -> None:
         """
         Set SecureConnection mode.
         Call this before connect()
@@ -201,7 +204,7 @@ class Client:
         private_key: uacrypto.CertProperties,
         server_cert: uacrypto.CertProperties,
         mode: ua.MessageSecurityMode = ua.MessageSecurityMode.SignAndEncrypt,
-    ):
+    ) -> None:
 
         if isinstance(server_cert, uacrypto.CertProperties):
             server_cert = await uacrypto.load_certificate(server_cert.path_or_content, server_cert.extension)
@@ -215,19 +218,19 @@ class Client:
         self.security_policy = policy(server_cert, cert, pk, mode)  # type: ignore
         self.uaclient.set_security(self.security_policy)
 
-    async def load_client_certificate(self, path: str, extension: Optional[str] = None):
+    async def load_client_certificate(self, path: str, extension: Optional[str] = None) -> None:
         """
         load our certificate from file, either pem or der
         """
         self.user_certificate = await uacrypto.load_certificate(path, extension)
 
-    async def load_private_key(self, path: Path, password: Optional[Union[str, bytes]] = None, extension: Optional[str] = None):
+    async def load_private_key(self, path: Path, password: Optional[Union[str, bytes]] = None, extension: Optional[str] = None) -> None:
         """
         Load user private key. This is used for authenticating using certificate
         """
         self.user_private_key = await uacrypto.load_private_key(path, password, extension)
 
-    async def connect_and_get_server_endpoints(self):
+    async def connect_and_get_server_endpoints(self) -> List[ua.EndpointDescription]:
         """
         Connect, ask server for endpoints, and disconnect
         """
@@ -243,7 +246,7 @@ class Client:
             self.disconnect_socket()
         return endpoints
 
-    async def connect_and_find_servers(self):
+    async def connect_and_find_servers(self) -> List[ua.ApplicationDescription]:
         """
         Connect, ask server for a list of known servers, and disconnect
         """
@@ -259,7 +262,7 @@ class Client:
             self.disconnect_socket()
         return servers
 
-    async def connect_and_find_servers_on_network(self):
+    async def connect_and_find_servers_on_network(self) -> List[ua.FindServersOnNetworkResult]:
         """
         Connect, ask server for a list of known servers on network, and disconnect
         """
@@ -275,7 +278,7 @@ class Client:
             self.disconnect_socket()
         return servers
 
-    async def connect(self):
+    async def connect(self) -> None:
         """
         High level method
         Connect, create and activate session
@@ -302,7 +305,7 @@ class Client:
             self.disconnect_socket()
             raise
 
-    async def connect_sessionless(self):
+    async def connect_sessionless(self) -> None:
         """
         High level method
         Connect without a session
@@ -317,7 +320,7 @@ class Client:
             self.disconnect_socket()
             raise
 
-    async def disconnect(self):
+    async def disconnect(self) -> None:
         """
         High level method
         Close session, secure channel and socket
@@ -329,7 +332,7 @@ class Client:
         finally:
             self.disconnect_socket()
 
-    async def disconnect_sessionless(self):
+    async def disconnect_sessionless(self) -> None:
         """
         High level method
         Close secure channel and socket
@@ -340,17 +343,17 @@ class Client:
         finally:
             self.disconnect_socket()
 
-    async def connect_socket(self):
+    async def connect_socket(self) -> None:
         """
         connect to socket defined in url
         """
         await self.uaclient.connect_socket(self.server_url.hostname, self.server_url.port)
 
-    def disconnect_socket(self):
+    def disconnect_socket(self) -> None:
         if self.uaclient:
             self.uaclient.disconnect_socket()
 
-    async def send_hello(self):
+    async def send_hello(self) -> None:
         """
         Send OPC-UA hello to server
         """
@@ -358,7 +361,7 @@ class Client:
         if isinstance(ack, ua.UaStatusCodeError):
             raise ack
 
-    async def open_secure_channel(self, renew=False):
+    async def open_secure_channel(self, renew: bool = False) -> None:
         """
         Open secure channel, if renew is True, renew channel
         """
@@ -379,14 +382,14 @@ class Client:
     async def close_secure_channel(self):
         return await self.uaclient.close_secure_channel()
 
-    async def get_endpoints(self) -> list:
+    async def get_endpoints(self) -> List[ua.EndpointDescription]:
         """Get a list of OPC-UA endpoints."""
 
         params = ua.GetEndpointsParameters()
         params.EndpointUrl = self.server_url.geturl()
         return await self.uaclient.get_endpoints(params)
 
-    async def register_server(self, server, discovery_configuration=None):
+    async def register_server(self, server: "asyncua.server.Server", discovery_configuration: Optional[ua.DiscoveryConfiguration] = None) -> None:
         """
         register a server to discovery server
         if discovery_configuration is provided, the newer register_server2 service call is used
@@ -394,7 +397,7 @@ class Client:
         serv = ua.RegisteredServer()
         serv.ServerUri = server.get_application_uri()
         serv.ProductUri = server.product_uri
-        serv.DiscoveryUrls = [server.endpoint.geturl()]
+        serv.DiscoveryUrls = [cast(ua.String, server.endpoint.geturl())]
         serv.ServerType = server.application_type
         serv.ServerNames = [ua.LocalizedText(server.name)]
         serv.IsOnline = True
@@ -405,7 +408,7 @@ class Client:
             return await self.uaclient.register_server2(params)
         return await self.uaclient.register_server(serv)
 
-    async def unregister_server(self, server, discovery_configuration=None):
+    async def unregister_server(self, server: "asyncua.server.Server", discovery_configuration: Optional[ua.DiscoveryConfiguration] = None) -> None:
         """
         register a server to discovery server
         if discovery_configuration is provided, the newer register_server2 service call is used
@@ -413,7 +416,7 @@ class Client:
         serv = ua.RegisteredServer()
         serv.ServerUri = server.get_application_uri()
         serv.ProductUri = server.product_uri
-        serv.DiscoveryUrls = [server.endpoint.geturl()]
+        serv.DiscoveryUrls = [cast(ua.String, server.endpoint.geturl())]
         serv.ServerType = server.application_type
         serv.ServerNames = [ua.LocalizedText(server.name)]
         serv.IsOnline = False
@@ -424,7 +427,7 @@ class Client:
             return await self.uaclient.unregister_server2(params)
         return await self.uaclient.unregister_server(serv)
 
-    async def find_servers(self, uris=None):
+    async def find_servers(self, uris: Optional[List[str]] = None) -> List[ua.ApplicationDescription]:
         """
         send a FindServer request to the server. The answer should be a list of
         servers the server knows about
@@ -437,11 +440,11 @@ class Client:
         params.ServerUris = uris
         return await self.uaclient.find_servers(params)
 
-    async def find_servers_on_network(self):
+    async def find_servers_on_network(self) -> List[ua.FindServersOnNetworkResult]:
         params = ua.FindServersOnNetworkParameters()
         return await self.uaclient.find_servers_on_network(params)
 
-    async def create_session(self):
+    async def create_session(self) -> ua.CreateSessionResult:
         """
         send a CreateSessionRequest to server with reasonable parameters.
         If you want to modify settings look at code of these methods
@@ -495,7 +498,7 @@ class Client:
         self._monitor_server_task = asyncio.create_task(self._monitor_server_loop())
         return response
 
-    async def check_connection(self):
+    async def check_connection(self) -> None:
         # can be used to check if the client is still connected
         # if not it throws the underlying exception
         if self._renew_channel_task is not None:
@@ -550,7 +553,7 @@ class Client:
             _logger.exception("Error while renewing session")
             raise
 
-    def server_policy_id(self, token_type, default):
+    def server_policy_id(self, token_type: ua.UserTokenType, default: str) -> str:
         """
         Find PolicyId of server's UserTokenPolicy by token_type.
         Return default if there's no matching UserTokenPolicy.
@@ -560,7 +563,7 @@ class Client:
                 return policy.PolicyId
         return default
 
-    def server_policy_uri(self, token_type):
+    def server_policy_uri(self, token_type: ua.UserTokenType) -> str:
         """
         Find SecurityPolicyUri of server's UserTokenPolicy by token_type.
         If SecurityPolicyUri is empty, use default SecurityPolicyUri
@@ -574,7 +577,7 @@ class Client:
                 return self.security_policy.URI
         return self.security_policy.URI
 
-    async def activate_session(self, username: str = None, password: str = None, certificate=None):
+    async def activate_session(self, username: Optional[str] = None, password: Optional[str] = None, certificate: Optional[x509.Certificate] = None) -> ua.ActivateSessionResult:
         """
         Activate session using either username and password or private_key
         """
@@ -650,7 +653,7 @@ class Client:
         data, uri = security_policies.encrypt_asymmetric(pubkey, etoken, policy_uri)
         return data, uri
 
-    async def close_session(self):
+    async def close_session(self) -> None:
         """
         Close session
         """
@@ -671,14 +674,14 @@ class Client:
                 pass
         return await self.uaclient.close_session(True)
 
-    def get_root_node(self):
+    def get_root_node(self) -> Node:
         return self.get_node(ua.TwoByteNodeId(ua.ObjectIds.RootFolder))
 
-    def get_objects_node(self):
+    def get_objects_node(self) -> Node:
         _logger.info("get_objects_node")
         return self.get_node(ua.TwoByteNodeId(ua.ObjectIds.ObjectsFolder))
 
-    def get_server_node(self):
+    def get_server_node(self) -> Node:
         return self.get_node(ua.FourByteNodeId(ua.ObjectIds.Server))
 
     def get_node(self, nodeid: Union[Node, ua.NodeId, str, int]) -> Node:
@@ -688,7 +691,7 @@ class Client:
         return Node(self.uaclient, nodeid)
 
     async def create_subscription(
-        self, period, handler, publishing=True
+        self, period: Union[ua.CreateSubscriptionParameters, float], handler: SubHandler, publishing: bool = True
     ) -> Subscription:
         """
         Create a subscription.
@@ -754,13 +757,13 @@ class Client:
             modified_params.RequestedLifetimeCount = results.RevisedLifetimeCount
             return modified_params
 
-    async def delete_subscriptions(self, subscription_ids):
+    async def delete_subscriptions(self, subscription_ids: List[int]) -> List[ua.StatusCode]:
         """
         Deletes the provided list of subscription_ids
         """
-        await self.uaclient.delete_subscriptions(subscription_ids)
+        return await self.uaclient.delete_subscriptions(subscription_ids)
 
-    def get_keepalive_count(self, period) -> int:
+    def get_keepalive_count(self, period: float) -> int:
         """
         We request the server to send a Keepalive notification when
         no notification has been received for 75% of the session lifetime.
@@ -773,26 +776,26 @@ class Client:
         period = period or 1000
         return int((self.session_timeout / period) * 0.75)
 
-    async def get_namespace_array(self):
+    async def get_namespace_array(self) -> List[str]:
         ns_node = self.get_node(ua.NodeId(ua.ObjectIds.Server_NamespaceArray))
         return await ns_node.read_value()
 
-    async def get_namespace_index(self, uri):
+    async def get_namespace_index(self, uri: str) -> int:
         uries = await self.get_namespace_array()
         _logger.info("get_namespace_index %s %r", type(uries), uries)
         return uries.index(uri)
 
-    async def delete_nodes(self, nodes, recursive=False) -> Coroutine:
+    async def delete_nodes(self, nodes: List[Node], recursive=False) -> Tuple[List[Node], List[ua.StatusCode]]:
         return await delete_nodes(self.uaclient, nodes, recursive)
 
-    async def import_xml(self, path=None, xmlstring=None, strict_mode=True) -> Coroutine:
+    async def import_xml(self, path=None, xmlstring=None, strict_mode=True) -> List[ua.NodeId]:
         """
         Import nodes defined in xml
         """
         importer = XmlImporter(self, strict_mode=strict_mode)
         return await importer.import_xml(path, xmlstring)
 
-    async def export_xml(self, nodes, path, export_values: bool = False):
+    async def export_xml(self, nodes, path, export_values: bool = False) -> None:
         """
         Export defined nodes to xml
         :param export_values: exports values from variants
@@ -801,7 +804,7 @@ class Client:
         await exp.build_etree(nodes)
         await exp.write_xml(path)
 
-    async def register_namespace(self, uri):
+    async def register_namespace(self, uri: str) -> int:
         """
         Register a new namespace. Nodes should in custom namespace, not 0.
         This method is mainly implemented for symmetry with server
@@ -824,7 +827,7 @@ class Client:
         _logger.warning("Deprecated since spec 1.04, call load_data_type_definitions")
         return await load_type_definitions(self, nodes)
 
-    async def load_data_type_definitions(self, node=None, overwrite_existing=False):
+    async def load_data_type_definitions(self, node: Optional[Node] = None, overwrite_existing: bool = False) -> Dict[str, Type]:
         """
         Load custom types (custom structures/extension objects) definition from server
         Generate Python classes for custom structures/extension objects defined in server
@@ -832,7 +835,7 @@ class Client:
         """
         return await load_data_type_definitions(self, node, overwrite_existing=overwrite_existing)
 
-    async def load_enums(self):
+    async def load_enums(self) -> Dict[str, Type]:
         """
         generate Python enums for custom enums on server.
         This enums will be available in ua module
@@ -840,7 +843,7 @@ class Client:
         _logger.warning("Deprecated since spec 1.04, call load_data_type_definitions")
         return await load_enums(self)
 
-    async def register_nodes(self, nodes):
+    async def register_nodes(self, nodes: List[Node]) -> List[Node]:
         """
         Register nodes for faster read and write access (if supported by server)
         Rmw: This call modifies the nodeid of the nodes, the original nodeid is
@@ -853,7 +856,7 @@ class Client:
             node.nodeid = nodeid
         return nodes
 
-    async def unregister_nodes(self, nodes):
+    async def unregister_nodes(self, nodes: List[Node]) -> None:
         """
         Unregister nodes
         """
@@ -865,21 +868,21 @@ class Client:
             node.nodeid = node.basenodeid
             node.basenodeid = None
 
-    async def read_attributes(self, nodes: List[Node], attr: ua.AttributeIds = ua.AttributeIds.Value):
+    async def read_attributes(self, nodes: List[Node], attr: ua.AttributeIds = ua.AttributeIds.Value) -> List[ua.DataValue]:
         """
         Read the attributes of multiple nodes.
         """
         nodeids = [node.nodeid for node in nodes]
         return await self.uaclient.read_attributes(nodeids, attr)
 
-    async def read_values(self, nodes):
+    async def read_values(self, nodes: List[Node]) -> List[Any]:
         """
         Read the value of multiple nodes in one ua call.
         """
         res = await self.read_attributes(nodes, attr=ua.AttributeIds.Value)
-        return [r.Value.Value for r in res]
+        return [r.Value.Value if r.Value else None for r in res]
 
-    async def write_values(self, nodes, values, raise_on_partial_error=True):
+    async def write_values(self, nodes: List[Node], values: List[Any], raise_on_partial_error: bool = True) -> List[ua.StatusCode]:
         """
         Write values to multiple nodes in one ua call
         """

--- a/asyncua/common/shortcuts.py
+++ b/asyncua/common/shortcuts.py
@@ -6,6 +6,35 @@ class Shortcuts:
     """
     This object contains Node objects to some commonly used nodes
     """
+
+    root: Node
+    objects: Node
+    server: Node
+    base_object_type: Node
+    base_data_type: Node
+    base_event_type: Node
+    base_variable_type: Node
+    folder_type: Node
+    enum_data_type: Node
+    option_set_type: Node
+    types: Node
+    data_types: Node
+    event_types: Node
+    reference_types: Node
+    variable_types: Node
+    object_types: Node
+    namespace_array: Node
+    namespaces: Node
+    opc_binary: Node
+    base_structure_type: Node
+    base_union_type: Node
+    server_state: Node
+    service_level: Node
+    HasComponent: Node
+    HasProperty: Node
+    Organizes: Node
+    HasEncoding: Node
+
     def __init__(self, server):
         self.root = Node(server, ObjectIds.RootFolder)
         self.objects = Node(server, ObjectIds.ObjectsFolder)

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -5,6 +5,7 @@ High level interface to pure python OPC-UA server
 import asyncio
 import logging
 import math
+from cryptography import x509
 from datetime import timedelta, datetime
 import socket
 from urllib.parse import urlparse
@@ -90,14 +91,14 @@ class Server:
         self.manufacturer_name = "FreeOpcUa"
         self.application_type = ua.ApplicationType.ClientAndServer
         self.default_timeout: int = 60 * 60 * 1000
-        self.iserver = iserver if iserver else InternalServer(user_manager=user_manager)
+        self.iserver: InternalServer = iserver if iserver else InternalServer(user_manager=user_manager)
         self.bserver: Optional[BinaryServer] = None
         self.socket_address: Optional[Tuple[str, int]] = None
         self._discovery_clients = {}
         self._discovery_period = 60
         self._discovery_handle = None
         self._policies = []
-        self.nodes = Shortcuts(self.iserver.isession)
+        self.nodes: Shortcuts = Shortcuts(self.iserver.isession)
         # enable all endpoints by default
         self._security_policy = [
             ua.SecurityPolicyType.NoSecurity, ua.SecurityPolicyType.Basic256Sha256_SignAndEncrypt,
@@ -107,11 +108,11 @@ class Server:
         # allow all certificates by default
         self._permission_ruleset = None
         self._policyIDs = ["Anonymous", "Basic256Sha256", "Username", "Aes128Sha256RsaOaep"]
-        self.certificate = None
+        self.certificate: Optional[x509.Certificate] = None
         # Use acceptable limits
         buffer_sz = 65535
         max_msg_sz = 100 * 1024 * 1024  # 100mb
-        self.limits = TransportLimits(
+        self.limits: TransportLimits = TransportLimits(
             max_recv_buffer=buffer_sz,
             max_send_buffer=buffer_sz,
             max_chunk_count=math.ceil(max_msg_sz / buffer_sz),  # Round up to allow max msg size

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -7,7 +7,7 @@ from cryptography import x509
 from pathlib import Path
 from threading import Thread, Condition
 import logging
-from typing import Any, Dict, List, Tuple, Type, Union, Optional
+from typing import Any, Dict, Iterable, List, Sequence, Tuple, Type, Union, Optional
 
 from asyncua import ua
 from asyncua import client
@@ -269,7 +269,7 @@ class Client:
     def set_password(self, pwd: str) -> None:
         self.aio_obj.set_password(pwd)
 
-    def set_locale(self, locale: List[str]) -> None:
+    def set_locale(self, locale: Sequence[str]) -> None:
         self.aio_obj.set_locale(locale)
 
     @syncmethod
@@ -289,7 +289,7 @@ class Client:
         pass
 
     @syncmethod
-    def get_namespace_array(self) -> List[str]:  # type: ignore[empty-body]
+    def get_namespace_array(self) -> Sequence[str]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
@@ -313,7 +313,7 @@ class Client:
         return self.aio_obj.get_subscription_revised_params(params, results)
 
     @syncmethod
-    def delete_subscriptions(self, subscription_ids: List[int]) -> List[ua.StatusCode]:  # type: ignore[empty-body]
+    def delete_subscriptions(self, subscription_ids: Iterable[int]) -> Sequence[ua.StatusCode]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
@@ -334,15 +334,15 @@ class Client:
         return SyncNode(self.tloop, self.aio_obj.get_server_node())
 
     @syncmethod
-    def connect_and_get_server_endpoints(self) -> List[ua.EndpointDescription]:  # type: ignore[empty-body]
+    def connect_and_get_server_endpoints(self) -> Sequence[ua.EndpointDescription]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def connect_and_find_servers(self) -> List[ua.ApplicationDescription]:  # type: ignore[empty-body]
+    def connect_and_find_servers(self) -> Sequence[ua.ApplicationDescription]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def connect_and_find_servers_on_network(self) -> List[ua.FindServersOnNetworkResult]:  # type: ignore[empty-body]
+    def connect_and_find_servers_on_network(self) -> Sequence[ua.FindServersOnNetworkResult]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
@@ -358,7 +358,7 @@ class Client:
         pass
 
     @syncmethod
-    def get_endpoints(self) -> List[ua.EndpointDescription]:  # type: ignore[empty-body]
+    def get_endpoints(self) -> Sequence[ua.EndpointDescription]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
@@ -378,11 +378,11 @@ class Client:
         pass
 
     @syncmethod
-    def find_servers(self, uris: Optional[List[str]] = None) -> List[ua.ApplicationDescription]:  # type: ignore[empty-body]
+    def find_servers(self, uris: Optional[Iterable[str]] = None) -> Sequence[ua.ApplicationDescription]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def find_servers_on_network(self) -> List[ua.FindServersOnNetworkResult]:  # type: ignore[empty-body]
+    def find_servers_on_network(self) -> Sequence[ua.FindServersOnNetworkResult]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
@@ -416,11 +416,11 @@ class Client:
         return self.aio_obj.get_keepalive_count(period)
 
     @syncmethod
-    def delete_nodes(self, nodes: List["SyncNode"], recursive=False) -> Tuple[List["SyncNode"], List[ua.StatusCode]]:  # type: ignore[empty-body]
+    def delete_nodes(self, nodes: Iterable["SyncNode"], recursive=False) -> Tuple[Sequence["SyncNode"], Sequence[ua.StatusCode]]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def import_xml(self, path=None, xmlstring=None, strict_mode=True) -> List[ua.NodeId]:  # type: ignore[empty-body]
+    def import_xml(self, path=None, xmlstring=None, strict_mode=True) -> Sequence[ua.NodeId]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
@@ -432,35 +432,35 @@ class Client:
         pass
 
     @syncmethod
-    def register_nodes(self, nodes: List["SyncNode"]) -> List["SyncNode"]:  # type: ignore[empty-body]
+    def register_nodes(self, nodes: Iterable["SyncNode"]) -> Sequence["SyncNode"]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def unregister_nodes(self, nodes: List["SyncNode"]):  # type: ignore[empty-body]
+    def unregister_nodes(self, nodes: Iterable["SyncNode"]):  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def read_attributes(self, nodes: List["SyncNode"], attr: ua.AttributeIds = ua.AttributeIds.Value) -> List[ua.DataValue]:  # type: ignore[empty-body]
+    def read_attributes(self, nodes: Iterable["SyncNode"], attr: ua.AttributeIds = ua.AttributeIds.Value) -> Sequence[ua.DataValue]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def read_values(self, nodes: List["SyncNode"]) -> List[Any]:  # type: ignore[empty-body]
+    def read_values(self, nodes: Iterable["SyncNode"]) -> Sequence[Any]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def write_values(self, nodes: List["SyncNode"], values: List[Any], raise_on_partial_error: bool = True) -> List[ua.StatusCode]:  # type: ignore[empty-body]
+    def write_values(self, nodes: Iterable["SyncNode"], values: Iterable[Any], raise_on_partial_error: bool = True) -> Sequence[ua.StatusCode]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def browse_nodes(self, nodes: List["SyncNode"]) -> List[Tuple["SyncNode", ua.BrowseResult]]:  # type: ignore[empty-body]
+    def browse_nodes(self, nodes: Iterable["SyncNode"]) -> Sequence[Tuple["SyncNode", ua.BrowseResult]]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
     def translate_browsepaths(  # type: ignore[empty-body]
         self,
         starting_node: ua.NodeId,
-        relative_paths: List[Union[ua.RelativePath, str]]
-    ) -> List[ua.BrowsePathResult]:
+        relative_paths: Iterable[Union[ua.RelativePath, str]]
+    ) -> Sequence[ua.BrowsePathResult]:
         pass
 
     def __enter__(self):

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -3,10 +3,11 @@ sync API of asyncua
 """
 import asyncio
 import functools
+from cryptography import x509
 from pathlib import Path
 from threading import Thread, Condition
 import logging
-from typing import List, Tuple, Union, Optional
+from typing import Any, Dict, List, Tuple, Type, Union, Optional
 
 from asyncua import ua
 from asyncua import client
@@ -83,6 +84,8 @@ def _to_sync(tloop, result):
         return EventGenerator(tloop, result)
     if isinstance(result, subscription.Subscription):
         return Subscription(tloop, result)
+    if isinstance(result, server.Server):
+        return Server(tloop, result)
     return result
 
 
@@ -228,28 +231,53 @@ class Client:
         self.aio_obj.application_uri = value
 
     @syncmethod
-    def connect(self):
+    def connect(self) -> None:
         pass
 
-    def disconnect(self):
+    def disconnect(self) -> None:
         try:
             self.tloop.post(self.aio_obj.disconnect())
         finally:
             if self.close_tloop:
                 self.tloop.stop()
 
-    def set_user(self, username: str):
-        self.aio_obj.set_user(username)
+    @syncmethod
+    def connect_sessionless(self) -> None:
+        pass
 
-    def set_password(self, pwd: str):
-        self.aio_obj.set_password(pwd)
+    def disconnect_sessionless(self) -> None:
+        try:
+            self.tloop.post(self.aio_obj.disconnect_sessionless())
+        finally:
+            if self.close_tloop:
+                self.tloop.stop()
 
     @syncmethod
-    async def load_private_key(self, path: str, password: Optional[Union[str, bytes]] = None, extension: Optional[str] = None):
+    def connect_socket(self) -> None:
+        pass
+
+    def disconnect_socket(self) -> None:
+        try:
+            self.aio_obj.disconnect_socket()
+        finally:
+            if self.close_tloop:
+                self.tloop.stop()
+
+    def set_user(self, username: str) -> None:
+        self.aio_obj.set_user(username)
+
+    def set_password(self, pwd: str) -> None:
+        self.aio_obj.set_password(pwd)
+
+    def set_locale(self, locale: List[str]) -> None:
+        self.aio_obj.set_locale(locale)
+
+    @syncmethod
+    def load_private_key(self, path: str, password: Optional[Union[str, bytes]] = None, extension: Optional[str] = None) -> None:
         pass
 
     @syncmethod
-    async def load_client_certificate(self, path: str, extension: Optional[str] = None):
+    def load_client_certificate(self, path: str, extension: Optional[str] = None) -> None:
         pass
 
     @syncmethod
@@ -257,59 +285,170 @@ class Client:
         pass
 
     @syncmethod
-    def load_data_type_definitions(self, node=None):
+    def load_data_type_definitions(self, node: Optional["SyncNode"] = None, overwrite_existing: bool = False) -> Dict[str, Type]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def get_namespace_array(self):
+    def get_namespace_array(self) -> List[str]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def set_security(self):
+    def set_security(self) -> None:
         pass
 
     @syncmethod
-    def set_security_string(self, string):
+    def set_security_string(self, string: str) -> None:
         pass
 
     @syncmethod
-    def load_enums(self):
+    def load_enums(self) -> Dict[str, Type]:  # type: ignore[empty-body]
         pass
 
-    def create_subscription(self, period, handler):
-        coro = self.aio_obj.create_subscription(period, _SubHandler(self.tloop, handler))
+    def create_subscription(self, period: Union[ua.CreateSubscriptionParameters, float], handler: subscription.SubHandler, publishing: bool = True) -> "Subscription":
+        coro = self.aio_obj.create_subscription(period, _SubHandler(self.tloop, handler), publishing)
         aio_sub = self.tloop.post(coro)
         return Subscription(self.tloop, aio_sub)
 
+    def get_subscription_revised_params(self, params: ua.CreateSubscriptionParameters, results: ua.CreateSubscriptionResult) -> Optional[ua.ModifySubscriptionParameters]:  # type: ignore
+        return self.aio_obj.get_subscription_revised_params(params, results)
+
     @syncmethod
-    def delete_subscriptions(self, subscription_ids):
+    def delete_subscriptions(self, subscription_ids: List[int]) -> List[ua.StatusCode]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def get_namespace_index(self, url):
+    def get_namespace_index(self, uri: str) -> int:  # type: ignore[empty-body]
         pass
 
-    def get_node(self, nodeid: Union["SyncNode", ua.NodeId, str, int]):
+    def get_node(self, nodeid: Union["SyncNode", ua.NodeId, str, int]) -> "SyncNode":
         aio_nodeid = nodeid.aio_obj if isinstance(nodeid, SyncNode) else nodeid
         return SyncNode(self.tloop, self.aio_obj.get_node(aio_nodeid))
 
-    def get_root_node(self):
+    def get_root_node(self) -> "SyncNode":
         return SyncNode(self.tloop, self.aio_obj.get_root_node())
 
+    def get_objects_node(self) -> "SyncNode":
+        return SyncNode(self.tloop, self.aio_obj.get_objects_node())
+
+    def get_server_node(self) -> "SyncNode":
+        return SyncNode(self.tloop, self.aio_obj.get_server_node())
+
     @syncmethod
-    def connect_and_get_server_endpoints(self):
+    def connect_and_get_server_endpoints(self) -> List[ua.EndpointDescription]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def read_attributes(self, nodes, attr=ua.AttributeIds.Value):
+    def connect_and_find_servers(self) -> List[ua.ApplicationDescription]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def read_values(self, nodes):
+    def connect_and_find_servers_on_network(self) -> List[ua.FindServersOnNetworkResult]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
-    def write_values(self, nodes, values, raise_on_partial_error=True):
+    def send_hello(self) -> None:
+        pass
+
+    @syncmethod
+    def open_secure_channel(self, renew=False) -> None:
+        pass
+
+    @syncmethod
+    def close_secure_channel(self) -> None:
+        pass
+
+    @syncmethod
+    def get_endpoints(self) -> List[ua.EndpointDescription]:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def register_server(
+        self,
+        server: "Server",
+        discovery_configuration: Optional[ua.DiscoveryConfiguration] = None,
+    ) -> None:
+        pass
+
+    @syncmethod
+    def unregister_server(
+        self,
+        server: "Server",
+        discovery_configuration: Optional[ua.DiscoveryConfiguration] = None,
+    ) -> None:
+        pass
+
+    @syncmethod
+    def find_servers(self, uris: Optional[List[str]] = None) -> List[ua.ApplicationDescription]:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def find_servers_on_network(self) -> List[ua.FindServersOnNetworkResult]:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def create_session(self) -> ua.CreateSessionResult:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def check_connection(self) -> None:
+        pass
+
+    def server_policy_id(self, token_type: ua.UserTokenType, default: str) -> str:
+        return self.aio_obj.server_policy_id(token_type, default)
+
+    def server_policy_uri(self, token_type: ua.UserTokenType) -> str:
+        return self.aio_obj.server_policy_uri(token_type)
+
+    @syncmethod
+    def activate_session(  # type: ignore[empty-body]
+        self,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        certificate: Optional[x509.Certificate] = None,
+    ) -> ua.ActivateSessionResult:
+        pass
+
+    @syncmethod
+    def close_session(self) -> None:
+        pass
+
+    def get_keepalive_count(self, period: float) -> int:
+        return self.aio_obj.get_keepalive_count(period)
+
+    @syncmethod
+    def delete_nodes(self, nodes: List["SyncNode"], recursive=False) -> Tuple[List["SyncNode"], List[ua.StatusCode]]:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def import_xml(self, path=None, xmlstring=None, strict_mode=True) -> List[ua.NodeId]:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def export_xml(self, nodes, path, export_values: bool = False) -> None:
+        pass
+
+    @syncmethod
+    def register_namespace(self, uri: str) -> int:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def register_nodes(self, nodes: List["SyncNode"]) -> List["SyncNode"]:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def unregister_nodes(self, nodes: List["SyncNode"]):  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def read_attributes(self, nodes: List["SyncNode"], attr: ua.AttributeIds = ua.AttributeIds.Value) -> List[ua.DataValue]:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def read_values(self, nodes: List["SyncNode"]) -> List[Any]:  # type: ignore[empty-body]
+        pass
+
+    @syncmethod
+    def write_values(self, nodes: List["SyncNode"], values: List[Any], raise_on_partial_error: bool = True) -> List[ua.StatusCode]:  # type: ignore[empty-body]
         pass
 
     @syncmethod
@@ -337,6 +476,34 @@ class Client:
 
 
 class Shortcuts:
+    root: "SyncNode"
+    objects: "SyncNode"
+    server: "SyncNode"
+    base_object_type: "SyncNode"
+    base_data_type: "SyncNode"
+    base_event_type: "SyncNode"
+    base_variable_type: "SyncNode"
+    folder_type: "SyncNode"
+    enum_data_type: "SyncNode"
+    option_set_type: "SyncNode"
+    types: "SyncNode"
+    data_types: "SyncNode"
+    event_types: "SyncNode"
+    reference_types: "SyncNode"
+    variable_types: "SyncNode"
+    object_types: "SyncNode"
+    namespace_array: "SyncNode"
+    namespaces: "SyncNode"
+    opc_binary: "SyncNode"
+    base_structure_type: "SyncNode"
+    base_union_type: "SyncNode"
+    server_state: "SyncNode"
+    service_level: "SyncNode"
+    HasComponent: "SyncNode"
+    HasProperty: "SyncNode"
+    Organizes: "SyncNode"
+    HasEncoding: "SyncNode"
+
     def __init__(self, tloop, aio_server):
         self.tloop = tloop
         self.aio_obj = shortcuts.Shortcuts(aio_server)


### PR DESCRIPTION
- Add type hints to `Client`, `Server` and `Shortcuts`
- Add type hints to `sync.Client` and `sync.Shortcuts`
- Add the following missing methods to `sync.Client`:
  - `connect_sessionless()`
  - `disconnect_sessionless()`
  - `connect_socket()`
  - `disconnect_socket()`
  - `set_locale()`
  - `get_subscription_revised_params()`
  - `get_objects_node()`
  - `get_server_node()`
  - `connect_and_find_servers()`
  - `connect_and_find_servers_on_network()`
  - `send_hello()`
  - `open_secure_channel()`
  - `close_secure_channel()`
  - `get_endpoints()`
  - `register_server()`
  - `unregister_server()`
  - `find_servers()`
  - `find_servers_on_network()`
  - `create_session()`
  - `check_connection()`
  - `server_policy_id()`
  - `server_policy_uri()`
  - `activate_session()`
  - `close_session()`
  - `get_keepalive_count()`
  - `delete_nodes()`
  - `import_xml()`
  - `export_xml()`
  - `register_namespace()`
  - `register_nodes()`
  - `unregister_nodes()`
