### PR TITLE
Make possible to not strip credentials in Client.server_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Add `strip_url_credentials` parameter to `Client`, with a default to True.
+  Setting it to False is significantly less secure but may be necessary with some servers
+  [#1429](https://github.com/FreeOpcUa/opcua-asyncio/pull/1429)
+
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
-- Add `strip_url_credentials` parameter to `Client`, with a default to True.
+- Add `strip_url_credentials` attribute to `Client`, with a default to True.
   Setting it to False is significantly less secure but may be necessary with some servers
   [#1429](https://github.com/FreeOpcUa/opcua-asyncio/pull/1429)
 

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -108,7 +108,7 @@ class Client:
     @property
     def server_url(self):
         """Return the server URL with stripped credentials
-        
+
         if self.strip_url_credentials is True
         """
         url = self._server_url
@@ -367,7 +367,7 @@ class Client:
         """
         connect to socket defined in url
         """
-        
+
         await self.uaclient.connect_socket(self.server_url.hostname, self.server_url.port)
 
     def disconnect_socket(self):

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -34,14 +34,9 @@ class Client:
 
     _username = None
     _password = None
+    strip_url_credentials = True
 
-    def __init__(
-        self,
-        url: str,
-        timeout: float = 4,
-        watchdog_intervall: float = 1.0,
-        strip_url_credentials: bool = True
-    ):
+    def __init__(self, url: str, timeout: float = 4, watchdog_intervall: float = 1.0):
         """
         :param url: url of the server.
             if you are unsure of url, write at least hostname
@@ -87,7 +82,6 @@ class Client:
         self._monitor_server_task = None
         self._locale = ["en"]
         self._watchdog_intervall = watchdog_intervall
-        self.strip_url_credentials = strip_url_credentials
         self._closing: bool = False
 
     async def __aenter__(self):

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -35,7 +35,13 @@ class Client:
     _username = None
     _password = None
 
-    def __init__(self, url: str, timeout: float = 4, watchdog_intervall: float = 1.0):
+    def __init__(
+        self,
+        url: str,
+        timeout: float = 4,
+        watchdog_intervall: float = 1.0,
+        strip_url_credentials: bool = True
+    ):
         """
         :param url: url of the server.
             if you are unsure of url, write at least hostname
@@ -45,6 +51,10 @@ class Client:
             time. The timeout is specified in seconds.
         :param watchdog_intervall:
             The time between checking if the server is still alive. The timeout is specified in seconds.
+        :param strip_url_credentials:
+            If True, strip credentials from the url before connecting, preventing them from
+            being sent unencrypted. Disabling this is not recommended for security reasons.
+
         Some other client parameters can be changed by setting
         attributes on the constructed object:
         See the source code for the exhaustive list.
@@ -58,7 +68,8 @@ class Client:
             if have_password:
                 self._password = unquote(password)
             # remove credentials from url, preventing them to be sent unencrypted in e.g. send_hello
-            self.server_url = self.server_url.__class__(self.server_url[0], hostinfo, *self.server_url[2:])
+            if strip_url_credentials:
+                self.server_url = self.server_url.__class__(self.server_url[0], hostinfo, *self.server_url[2:])
 
         self.name = "Pure Python Async. Client"
         self.description = self.name
@@ -82,6 +93,7 @@ class Client:
         self._monitor_server_task = None
         self._locale = ["en"]
         self._watchdog_intervall = watchdog_intervall
+        self.strip_url_credentials = strip_url_credentials
         self._closing: bool = False
 
     async def __aenter__(self):

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -51,9 +51,6 @@ class Client:
             time. The timeout is specified in seconds.
         :param watchdog_intervall:
             The time between checking if the server is still alive. The timeout is specified in seconds.
-        :param strip_url_credentials:
-            If True, strip credentials from the url before connecting, preventing them from
-            being sent unencrypted. Disabling this is not recommended for security reasons.
 
         Some other client parameters can be changed by setting
         attributes on the constructed object:
@@ -109,7 +106,8 @@ class Client:
     def server_url(self):
         """Return the server URL with stripped credentials
 
-        if self.strip_url_credentials is True
+        if self.strip_url_credentials is True.  Disabling this
+        is not recommended for security reasons.
         """
         url = self._server_url
         userinfo, have_info, hostinfo = url.netloc.rpartition('@')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -190,5 +190,6 @@ async def test_strip_credentials_in_url():
     client = Client('opc.tcp://user:password@dummy_address:10000')
     assert client.server_url.netloc == 'dummy_address:10000'
 
-    client = Client('opc.tcp://user:password@dummy_address:10000', strip_url_credentials=False)
+    client = Client('opc.tcp://user:password@dummy_address:10000')
+    client.strip_url_credentials = False
     assert client.server_url.netloc == 'user:password@dummy_address:10000'

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -182,3 +182,13 @@ async def test_translate_browsepaths(server, client: Client):
 
     with pytest.raises(ua.UaStringParsingError):
         await client.translate_browsepaths(server_node.nodeid, ["/1:<Boiler"])
+
+
+async def test_strip_credentials_in_url():
+    """Check that the credentials are correctly stripped in the server url"""
+
+    client = Client('opc.tcp://user:password@dummy_address:10000')
+    assert client.server_url.netloc == 'dummy_address:10000'
+
+    client = Client('opc.tcp://user:password@dummy_address:10000', strip_url_credentials=False)
+    assert client.server_url.netloc == 'user:password@dummy_address:10000'


### PR DESCRIPTION
Closes https://github.com/FreeOpcUa/opcua-asyncio/issues/1281

This adds `strip_url_credentials` parameter to `Client`, with a default to True.
Setting it to False is significantly less secure but may be necessary with some servers (in particular the Ignition server in my case)