### PR TITLE
Add set_attribute_value_callback() to Server

### DIFF
--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -9,7 +9,7 @@ from cryptography import x509
 from datetime import timedelta, datetime
 import socket
 from urllib.parse import urlparse
-from typing import Optional, Tuple, Union
+from typing import Callable, Optional, Tuple, Union
 from pathlib import Path
 
 from asyncua import ua
@@ -818,6 +818,18 @@ class Server:
         so it is a little faster
         """
         return await self.iserver.write_attribute_value(nodeid, datavalue, attr)
+
+    def set_attribute_value_callback(
+        self,
+        nodeid: ua.NodeId,
+        callback: Callable[[ua.NodeId, ua.AttributeIds], ua.DataValue],
+        attr=ua.AttributeIds.Value
+    ) -> None:
+        """
+        Set a callback function to the Attribute that returns a value for read_attribute_value() instead of the
+        written value. Note that it does not trigger the datachange_callbacks unlike write_attribute_value().
+        """
+        self.iserver.set_attribute_value_callback(nodeid, callback, attr)
 
     def read_attribute_value(self, nodeid, attr=ua.AttributeIds.Value):
         """

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -11,8 +11,7 @@ from cryptography import x509
 from pathlib import Path
 from threading import Thread, Condition
 import logging
-from typing import Any, Dict, Iterable, List, Sequence, Set, Tuple, Type, Union, Optional, overload
-
+from typing import Any, Callable, Dict, Iterable, List, Sequence, Set, Tuple, Type, Union, Optional, overload
 
 if sys.version_info >= (3, 8):
     from typing import Literal
@@ -627,6 +626,14 @@ class Server:
     @syncmethod
     def write_attribute_value(self, nodeid, datavalue, attr=ua.AttributeIds.Value):
         pass
+
+    def set_attribute_value_callback(
+        self,
+        nodeid: ua.NodeId,
+        callback: Callable[[ua.NodeId, ua.AttributeIds], ua.DataValue],
+        attr=ua.AttributeIds.Value
+    ) -> None:
+        self.aio_obj.set_attribute_value_callback(nodeid, callback, attr)
 
     def create_subscription(self, period, handler):
         coro = self.aio_obj.create_subscription(period, _SubHandler(self.tloop, handler))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -664,6 +664,26 @@ async def test_server_read_write_attribute_value(server: Server):
     await server.delete_nodes([node])
 
 
+async def test_server_read_set_attribute_value_callback(server: Server):
+    node = await server.get_objects_node().add_variable(0, "0:TestVar", 0, varianttype=ua.VariantType.Int64)
+    dv = server.read_attribute_value(node.nodeid, attr=ua.AttributeIds.Value)
+    assert dv.Value.Value == 0
+
+    def callback(nodeid, attr):
+        return ua.DataValue(Value=ua.Variant(Value=5, VariantType=ua.VariantType.Int64))
+
+    server.set_attribute_value_callback(node.nodeid, callback, attr=ua.AttributeIds.Value)
+    dv = server.read_attribute_value(node.nodeid, attr=ua.AttributeIds.Value)
+    assert dv.Value.Value == 5
+
+    dv = ua.DataValue(Value=ua.Variant(Value=10, VariantType=ua.VariantType.Int64))
+    await server.write_attribute_value(node.nodeid, dv, attr=ua.AttributeIds.Value)
+    dv = server.read_attribute_value(node.nodeid, attr=ua.AttributeIds.Value)
+    assert dv.Value.Value == 10
+
+    await server.delete_nodes([node])
+
+
 @pytest.fixture(scope="function")
 def restore_transport_limits_server(server: Server):
     # Restore limits after test


### PR DESCRIPTION
- Add `set_attribute_value_callback()` to `Server`
- Make `value_callback()` trigger with `NodeId` and `AttributeIds` as parameters

It is a simplified version of #144 without async callback support.
