### PR TITLE
fix type hints of Node methods

### DIFF
--- a/asyncua/common/manage_nodes.py
+++ b/asyncua/common/manage_nodes.py
@@ -45,7 +45,7 @@ def _parse_nodeid_qname(*args):
         )
 
 
-async def create_folder(parent: asyncua.Node, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str]) -> asyncua.Node:
+async def create_folder(parent: asyncua.Node, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str]) -> asyncua.Node:
     """
     create a child node folder
     arguments are nodeid, browsename
@@ -60,7 +60,7 @@ async def create_folder(parent: asyncua.Node, nodeid: Union[ua.NodeId, str], bna
 
 async def create_object(
     parent: asyncua.Node,
-    nodeid: Union[ua.NodeId, str],
+    nodeid: Union[ua.NodeId, str, int],
     bname: Union[ua.QualifiedName, str],
     objecttype: Optional[Union[ua.NodeId, int]] = None,
     instantiate_optional: bool = True,
@@ -86,7 +86,7 @@ async def create_object(
 
 async def create_property(
     parent: asyncua.Node,
-    nodeid: Union[ua.NodeId, str],
+    nodeid: Union[ua.NodeId, str, int],
     bname: Union[ua.QualifiedName, str],
     val: Any,
     varianttype: Optional[ua.VariantType] = None,
@@ -111,7 +111,7 @@ async def create_property(
 
 async def create_variable(
     parent: asyncua.Node,
-    nodeid: Union[ua.NodeId, str],
+    nodeid: Union[ua.NodeId, str, int],
     bname: Union[ua.QualifiedName, str],
     val: Any,
     varianttype: Optional[ua.VariantType] = None,
@@ -136,7 +136,7 @@ async def create_variable(
 
 
 async def create_variable_type(
-    parent: asyncua.Node, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str], datatype: Union[ua.NodeId, int]
+    parent: asyncua.Node, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str], datatype: Union[ua.NodeId, int]
 ) -> asyncua.Node:
     """
     Create a new variable type
@@ -156,7 +156,7 @@ async def create_variable_type(
 
 
 async def create_reference_type(
-    parent: asyncua.Node, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str], symmetric: bool = True, inversename: Optional[str] = None
+    parent: asyncua.Node, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str, int], symmetric: bool = True, inversename: Optional[str] = None
 ) -> asyncua.Node:
     """
     Create a new reference type
@@ -170,7 +170,7 @@ async def create_reference_type(
     )
 
 
-async def create_object_type(parent: asyncua.Node, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str]):
+async def create_object_type(parent: asyncua.Node, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str]):
     """
     Create a new object type to be instantiated in address space.
     arguments are nodeid, browsename
@@ -338,7 +338,7 @@ async def _create_variable_type(session, parentnodeid, nodeid, qname, datatype, 
 
 
 async def create_data_type(
-    parent: asyncua.Node, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str], description: Optional[str] = None
+    parent: asyncua.Node, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str], description: Optional[str] = None
 ) -> asyncua.Node:
     """
     Create a new data type to be used in new variables, etc ..
@@ -380,7 +380,7 @@ async def create_data_type(
     return make_node(parent.session, new_node_id)
 
 
-async def create_encoding(parent, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str]) -> asyncua.Node:
+async def create_encoding(parent, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str]) -> asyncua.Node:
     """
     Create a new encoding object to be instantiated in address space.
     arguments are nodeid, browsename

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -802,12 +802,12 @@ class Node:
             rule = ua.ObjectIds.ModellingRule_Mandatory if mandatory else ua.ObjectIds.ModellingRule_Optional
             await self.add_reference(rule, ua.ObjectIds.HasModellingRule, True, False)
 
-    async def add_folder(self, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str]) -> "Node":
+    async def add_folder(self, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str]) -> "Node":
         return await create_folder(self, nodeid, bname)
 
     async def add_object(
         self,
-        nodeid: Union[ua.NodeId, str],
+        nodeid: Union[ua.NodeId, str, int],
         bname: Union[ua.QualifiedName, str],
         objecttype: Optional[int] = None,
         instantiate_optional: bool = True,
@@ -816,7 +816,7 @@ class Node:
 
     async def add_variable(
         self,
-        nodeid: Union[ua.NodeId, str],
+        nodeid: Union[ua.NodeId, str, int],
         bname: Union[ua.QualifiedName, str],
         val: Any,
         varianttype: Optional[ua.VariantType] = None,
@@ -824,18 +824,18 @@ class Node:
     ) -> "Node":
         return await create_variable(self, nodeid, bname, val, varianttype, datatype)
 
-    async def add_object_type(self, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str]) -> "Node":
+    async def add_object_type(self, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str]) -> "Node":
         return await create_object_type(self, nodeid, bname)
 
-    async def add_variable_type(self, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str], datatype: Union[ua.NodeId, int]) -> "Node":
+    async def add_variable_type(self, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str], datatype: Union[ua.NodeId, int]) -> "Node":
         return await create_variable_type(self, nodeid, bname, datatype)
 
-    async def add_data_type(self, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str], description: Optional[str] = None) -> "Node":
+    async def add_data_type(self, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str], description: Optional[str] = None) -> "Node":
         return await create_data_type(self, nodeid, bname, description=description)
 
     async def add_property(
         self,
-        nodeid: Union[ua.NodeId, str],
+        nodeid: Union[ua.NodeId, str, int],
         bname: Union[ua.QualifiedName, str],
         val: Any,
         varianttype: Optional[ua.VariantType] = None,
@@ -847,7 +847,7 @@ class Node:
         return await create_method(self, *args)
 
     async def add_reference_type(
-        self, nodeid: Union[ua.NodeId, str], bname: Union[ua.QualifiedName, str], symmetric: bool = True, inversename: Optional[str] = None
+        self, nodeid: Union[ua.NodeId, str, int], bname: Union[ua.QualifiedName, str], symmetric: bool = True, inversename: Optional[str] = None
     ) -> "Node":
         return await create_reference_type(self, nodeid, bname, symmetric, inversename)
 

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -809,7 +809,7 @@ class Node:
         self,
         nodeid: Union[ua.NodeId, str, int],
         bname: Union[ua.QualifiedName, str],
-        objecttype: Optional[int] = None,
+        objecttype: Optional[Union[ua.NodeId, int]] = None,
         instantiate_optional: bool = True,
     ) -> "Node":
         return await create_object(self, nodeid, bname, objecttype, instantiate_optional)


### PR DESCRIPTION
Closes #1466, Closes #1491

- fix type hints of functions which call `_parse_nodeid_qname`
- fix type hint of `add_object`

for `nodeid` and `bname`, valid combinations are only `(int, str)` and `(NodeId | str, QualifiedName, str)`.
(it's possible to put two `@overload`s to reject `(int, QualifiedName)` case)
