### PR TITLE
Make Sync Client and Server reusable

### DIFF
--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -249,9 +249,12 @@ class Client:
     def application_uri(self, value):
         self.aio_obj.application_uri = value
 
-    @syncmethod
     def connect(self) -> None:
-        pass
+        if not self.tloop.is_alive():
+            self.tloop = ThreadLoop()
+            self.tloop.start()
+            self.close_tloop = True
+        self.tloop.post(self.aio_obj.connect())
 
     def disconnect(self) -> None:
         try:
@@ -592,9 +595,12 @@ class Server:
     def get_namespace_array(self):
         pass
 
-    @syncmethod
     def start(self):
-        pass
+        if not self.tloop.is_alive():
+            self.tloop = ThreadLoop()
+            self.tloop.start()
+            self.close_tloop = True
+        self.tloop.post(self.aio_obj.start())
 
     def stop(self):
         self.tloop.post(self.aio_obj.stop())


### PR DESCRIPTION
As the issue #1364 suggests, OpcUa `Client` (and `Server`) are not reusable, since disconnecting the client or stopping the server, stops the Sync Wrapper's `ThreadLoop` respectively and therefore lead to `ThreadLoopNotRunnning` exceptions on any call that depends on the ThreadLoop.

As in the discussion of #1364 the Sync Wrapper should start the ThreadLoop on connection (or server.start) if ThreadLoop is not alive anymore. 
This proposed behaviour has been implemented in this PR.