### PR TITLE
Allow ByteString Variant to be None

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -957,6 +957,7 @@ class Variant:
                     VariantType.String,
                     VariantType.DateTime,
                     VariantType.ExtensionObject,
+                    VariantType.ByteString,
             ):
                 raise UaError(
                     f"Non array Variant of type {self.VariantType} cannot have value None"


### PR DESCRIPTION
Hello,
while working with an open62541 based server, I encountered an empty/null `ByteString`. The `ua_binary` implementation of ByteString (`_Bytes`) already handles this case as per the standard ([Part 6 5.2.2.7](https://reference.opcfoundation.org/Core/Part6/v105/docs/5.2.2.7)) and sets the value to `None`, but the implementation of `Variant` currently throws an `UaError` when a `ByteString` with value `None` is encountered. This PR adds `ByteString` to the allowed `VariantType`s that can be `None`.
