### PR TITLE
Configure ThreadLoop to be daemon

### DIFF
--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -34,7 +34,7 @@ class ThreadLoopNotRunning(Exception):
 
 class ThreadLoop(Thread):
     def __init__(self, timeout: Optional[float] = 120) -> None:
-        Thread.__init__(self)
+        Thread.__init__(self, daemon=True)
         self.loop = None
         self._cond = Condition()
         self.timeout = timeout


### PR DESCRIPTION
Configuring a sync Client object and connecting it to an OPC-UA host will cause the calling script to hang on exit if disconnect() is not called. By setting the ThreadLoop to be a daemon resolves this issue.