### PR TITLE
Add `set_attribute_value_setter()` method to server

### DIFF
--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -16,7 +16,7 @@ from .user_managers import PermissiveUserManager, UserManager
 from ..common.callback import CallbackService
 from ..common.node import Node
 from .history import HistoryManager
-from .address_space import AddressSpace, AttributeService, ViewService, NodeManagementService, MethodService
+from .address_space import NodeData, AddressSpace, AttributeService, ViewService, NodeManagementService, MethodService
 from .subscription_service import SubscriptionService
 from .standard_address_space import standard_address_space
 from .users import User, UserRole
@@ -352,6 +352,20 @@ class InternalServer:
         written value. Note that it does not trigger the datachange_callbacks unlike write_attribute_value().
         """
         self.aspace.set_attribute_value_callback(nodeid, attr, callback)
+
+    def set_attribute_value_setter(
+        self,
+        nodeid: ua.NodeId,
+        setter: Callable[[NodeData, ua.AttributeIds, ua.DataValue], None],
+        attr=ua.AttributeIds.Value
+    ) -> None:
+        """
+        Set a setter function for the Attribute. This setter will be called when a new value is set using
+        write_attribute_value() instead of directly writing the value. This is useful, for example, if you want to
+        intercept writes to certain attributes to perform some kind of validation of the value to be written and return
+        appropriate status codes to the client.
+        """
+        self.aspace.set_attribute_value_setter(nodeid, attr, setter)
 
     def read_attribute_value(self, nodeid, attr=ua.AttributeIds.Value):
         """

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -13,6 +13,7 @@ from typing import Callable, Optional, Tuple, Union
 from pathlib import Path
 
 from asyncua import ua
+from .address_space import NodeData
 from .binary_server_asyncio import BinaryServer
 from .internal_server import InternalServer
 from .event_generator import EventGenerator
@@ -847,6 +848,20 @@ class Server:
         written value. Note that it does not trigger the datachange_callbacks unlike write_attribute_value().
         """
         self.iserver.set_attribute_value_callback(nodeid, callback, attr)
+
+    def set_attribute_value_setter(
+        self,
+        nodeid: ua.NodeId,
+        setter: Callable[[NodeData, ua.AttributeIds, ua.DataValue], None],
+        attr=ua.AttributeIds.Value
+    ) -> None:
+        """
+        Set a setter function for the Attribute. This setter will be called when a new value is set using
+        write_attribute_value() instead of directly writing the value. This is useful, for example, if you want to
+        intercept writes to certain attributes to perform some kind of validation of the value to be written and return
+        appropriate status codes to the client.
+        """
+        self.iserver.set_attribute_value_setter(nodeid, setter, attr)
 
     def read_attribute_value(self, nodeid, attr=ua.AttributeIds.Value):
         """


### PR DESCRIPTION
This method allows to set a custom setter function on a per-attribute basis. This setter function will then be called by `write_attribute_value()` instead of writing the attribute value directly. This allows for custom logic to be implemented by the user (such as checking if the value to be written is within a certain range) and if not, an appropriate error can be raised from that setter, preventing the write and notifying the client about the occurred error.

Also, see discussion #1563 for some more background info about the use case of this method.