### PR TITLE
Fix handling of `UaStatusCodeError`s in `UaProcessor.process_message`

### DIFF
--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -135,7 +135,7 @@ class UaProcessor:
         _logger.debug('process_message %r %r', typeid, requesthdr)
         try:
             return await self._process_message(typeid, requesthdr, seqhdr, body)
-        except ServiceError as e:
+        except (ServiceError, ua.uaerrors.UaStatusCodeError) as e:
             status = ua.StatusCode(e.code)
             response = ua.ServiceFault()
             response.ResponseHeader.ServiceResult = status


### PR DESCRIPTION
I noticed that raising a `BadOutOfRangeError` in a server callback set through `Server.subscribe_server_callback` resulted in a *BadInternalError* on the client side (tested with UaExpert) rather than the expected *BadOutOfRange*. But raising a
`ServiceError(ua.StatusCodes.BadOutOfRange)` instead would show the the expected *BadOutOfRange* error in the client.
The reason for this idiosyncrasy was that `UaStatusCodeError`s were not explicitly caught. Therefore the "default" `except Exception` handler would be used which resulted in a
`ua.StatusCode(ua.StatusCodes.BadInternalError)` to be sent to the client instead of the actual status code of the error that occurred.

This commit changes the behavior such that the status code of `UaStatusCodeError`s is respected the same way as it's already done for `ServiceError`s so that the client correctly receives the status code of the `raise`d error.

See also https://github.com/FreeOpcUa/opcua-asyncio/discussions/1563#discussioncomment-8382555