### PR TITLE
Add support for coroutine functions as attribute value setters

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -792,7 +792,10 @@ class AddressSpace:
             return ua.StatusCode(ua.StatusCodes.BadTypeMismatch)
 
         if attval.value_setter is not None:
-            attval.value_setter(node, attr, value)
+            if asyncio.iscoroutinefunction(attval.value_setter):
+                await attval.value_setter(node, attr, value)
+            else:
+                attval.value_setter(node, attr, value)
         else:
             attval.value = value
         attval.value_callback = None


### PR DESCRIPTION
The previous implementation only allowed sync functions to be registered as an attribute value setter. This limits the setter function in a way such that it cannot read from other nodes using `Node.read_value()`, for example. Allowing coroutine functions to be set as attribute value setters enables these functions to also use coroutine functions themselves.