### PR TITLE
Fix NodeId parsing for nodes containing semicolons in string identifiers

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -531,7 +531,8 @@ class NodeId:
         ntype = None
         srv = None
         nsu = None
-        for el in elements:
+        while elements:
+            el = elements.pop(0)  # consume exactly one part of the node name, left-to-right
             if not el:
                 continue
             k, v = el.split("=", 1)
@@ -543,7 +544,11 @@ class NodeId:
                 identifier = int(v.strip())
             elif k == "s":
                 ntype = NodeIdType.String
-                identifier = v
+                # As per https://reference.opcfoundation.org/Core/Part3/v105/docs/8.2.4 and https://reference.opcfoundation.org/Core/Part3/v104/docs/8.2.4,
+                # strings may contain arbitrary non-control unicode characters, even semicolons and equals.
+                # We must now consume the whole rest of the identifier.
+                identifier = String(";".join((v, *elements)))
+                elements = []  # consume everything immediately
             elif k == "g":
                 ntype = NodeIdType.Guid
                 identifier = uuid.UUID(f"urn:uuid:{v}")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -562,7 +562,7 @@ async def test_add_numeric_variable(opc):
 
 async def test_add_string_variable(opc):
     objects = opc.opc.nodes.objects
-    v = await objects.add_variable("ns=3;s=stringid;", "3:stringnodefromstring", [68])
+    v = await objects.add_variable("ns=3;s=stringid", "3:stringnodefromstring", [68])
     nid = ua.NodeId("stringid", 3)
     qn = ua.QualifiedName("stringnodefromstring", 3)
     assert nid == v.nodeid
@@ -612,7 +612,7 @@ async def test_variable_data_type(opc):
 
 async def test_add_string_array_variable(opc):
     objects = opc.opc.nodes.objects
-    v = await objects.add_variable("ns=3;s=stringarrayid;", "9:stringarray", ["l", "b"])
+    v = await objects.add_variable("ns=3;s=stringarrayid", "9:stringarray", ["l", "b"])
     nid = ua.NodeId("stringarrayid", 3)
     qn = ua.QualifiedName("stringarray", 9)
     assert nid == v.nodeid

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from base64 import b64encode
 import pytest
+from asyncua.ua import NodeId, String, NodeIdType, Int16
 
 from asyncua import Node, ua, uamethod
 from asyncua.common import ua_utils
@@ -2097,3 +2098,10 @@ async def test_sql_injection():
     table = "user'"
     with pytest.raises(SqlInjectionError) as _:
         validate_table_name(table)
+
+
+async def test_parse_nodeid_name_contains_multiple_dividers():
+    raw_node_name = "ns=9;s=Line1.nsuri=MACHINE.NS;s=MACHINE.NS.State.Running"
+    expected_node_id = NodeId(Identifier=String("Line1.nsuri=MACHINE.NS;s=MACHINE.NS.State.Running"), NamespaceIndex=Int16(9), NodeIdType=NodeIdType.String)
+    got_node_id = NodeId.from_string(string=raw_node_name)
+    assert got_node_id == expected_node_id

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -612,13 +612,13 @@ def test_numeric_nodeid():
 
 
 def test_qualifiedstring_nodeid():
-    nid = ua.NodeId.from_string('ns=2;s=PLC1.Manufacturer;')
+    nid = ua.NodeId.from_string('ns=2;s=PLC1.Manufacturer')
     assert nid.NamespaceIndex == 2
     assert nid.Identifier == 'PLC1.Manufacturer'
 
 
 def test_strrepr_nodeid():
-    nid = ua.NodeId.from_string('ns=2;s=PLC1.Manufacturer;')
+    nid = ua.NodeId.from_string('ns=2;s=PLC1.Manufacturer')
     assert nid.to_string() == 'ns=2;s=PLC1.Manufacturer'
     # assert repr(nid) == 'ns=2;s=PLC1.Manufacturer;'
 


### PR DESCRIPTION
NodeId calculation from string failed when the Identifier portion contained semicolons.

According to the OPC-UA spec (https://reference.opcfoundation.org/Core/Part3/v104/docs/8.2.4 and https://reference.opcfoundation.org/Core/Part3/v105/docs/8.2.4) there are no limitations to string node identifiers within the unicode charset - they should only not contain unicode control characters. I've already seen some OPC-UA servers where this occurs (see example below).

Example:
The node `ns=9;s=Line1.nsuri=MACHINE.NS;s=MACHINE.NS.State.Running` is regularly deconstructed as NamespaceId `9`, Identifier Type `String`, Identifier `Line1.nsuri=MACHINE.NS;s=MACHINE.NS.State.Running`. Previously this was parsed to have the Identifier `MACHINE.NS.State.Running`, now it is as expected.