### PR TITLE
[xmlimporter] Support to make auto load type definitions optional

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -816,11 +816,11 @@ class Client:
     async def delete_nodes(self, nodes: Iterable[Node], recursive=False) -> Tuple[List[Node], List[ua.StatusCode]]:
         return await delete_nodes(self.uaclient, nodes, recursive)
 
-    async def import_xml(self, path=None, xmlstring=None, strict_mode=True) -> List[ua.NodeId]:
+    async def import_xml(self, path=None, xmlstring=None, strict_mode=True, auto_load_definitions: bool = True) -> List[ua.NodeId]:
         """
         Import nodes defined in xml
         """
-        importer = XmlImporter(self, strict_mode=strict_mode)
+        importer = XmlImporter(self, strict_mode=strict_mode, auto_load_definitions=auto_load_definitions)
         return await importer.import_xml(path, xmlstring)
 
     async def export_xml(self, nodes, path, export_values: bool = False) -> None:

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -718,11 +718,11 @@ class Server:
             await custom_t.add_method(idx, method[0], method[1], method[2], method[3])
         return custom_t
 
-    async def import_xml(self, path=None, xmlstring=None, strict_mode=True):
+    async def import_xml(self, path=None, xmlstring=None, strict_mode=True, auto_load_definitions: bool = True):
         """
         Import nodes defined in xml
         """
-        importer = XmlImporter(self, strict_mode)
+        importer = XmlImporter(self, strict_mode, auto_load_definitions)
         return await importer.import_xml(path, xmlstring)
 
     async def export_xml(self, nodes, path, export_values: bool = False):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1327,8 +1327,12 @@ async def test_guid_node_id():
 
 
 async def test_import_xml_data_type_definition(opc):
+    if hasattr(ua, "MySubstruct"):
+        delattr(ua, "MySubstruct")
+    if hasattr(ua, "MyStruct"):
+        delattr(ua, "MyStruct")
+
     nodes = await opc.opc.import_xml("tests/substructs.xml")
-    await opc.opc.load_data_type_definitions()
     assert hasattr(ua, "MySubstruct")
     assert hasattr(ua, "MyStruct")
 
@@ -1362,6 +1366,19 @@ async def test_import_xml_data_type_definition(opc):
     [n.append(opc.opc.get_node(node)) for node in nodes]
     await opc.opc.delete_nodes(n)
 
+async def test_import_xml_data_no_auto_load_type_definition(opc):
+    # if al present in ua remove it (left overs of other tests)
+    if hasattr(ua, "MySubstruct"):
+        delattr(ua, "MySubstruct")
+    if hasattr(ua, "MyStruct"):
+        delattr(ua, "MyStruct")
+    if hasattr(ua, "MyEnum"):
+        delattr(ua, "MyEnum")
+    await opc.opc.import_xml("tests/substructs.xml", auto_load_definitions = False)
+    assert hasattr(ua, "MySubstruct") is False
+    assert hasattr(ua, "MyStruct") is False
+    assert hasattr(ua, "MyEnum") is False
+
 
 async def test_struct_data_type(opc):
     assert isinstance(ua.AddNodesItem.data_type, ua.NodeId)
@@ -1372,8 +1389,10 @@ async def test_struct_data_type(opc):
 
 
 async def test_import_xml_enum_data_type_definition(opc):
+    if hasattr(ua, "MyEnum"):
+        delattr(ua, "MyEnum")
+
     nodes = await opc.opc.import_xml("tests/testenum104.xml")
-    await opc.opc.load_data_type_definitions()
     assert hasattr(ua, "MyEnum")
     e = ua.MyEnum.val2
     var = await opc.opc.nodes.objects.add_variable(


### PR DESCRIPTION

To the `import_xml` an optional argument `auto_load_definitions` is added. Default is True.

Case:
With commit https://github.com/FreeOpcUa/opcua-asyncio/commit/de8269e4dadcbc2e12773a35b415f55e54e8709c `import_xml` automatic load(on the fly code generation) the type defintions.

When using your own extension object and enum implementation (with `ua.register_extension_object`  `ua.register_enum`) this is unwanted behaviour.

Previous work flow was:
* import xml
* register own extension object and enum implementations
* for the remain stuff call `load_data_type_definitions()`

To make this possible again an option is required to prevent the auto load definitions when calling the `import_xml` method.