### PR TITLE
Fix type hints to allow Path

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -182,8 +182,8 @@ class Client:
     async def set_security(
         self,
         policy: Type[ua.SecurityPolicy],
-        certificate: Union[str, uacrypto.CertProperties, bytes],
-        private_key: Union[str, uacrypto.CertProperties, bytes],
+        certificate: Union[str, uacrypto.CertProperties, bytes, Path],
+        private_key: Union[str, uacrypto.CertProperties, bytes, Path],
         private_key_password: Optional[Union[str, bytes]] = None,
         server_certificate: Optional[Union[str, uacrypto.CertProperties, bytes]] = None,
         mode: ua.MessageSecurityMode = ua.MessageSecurityMode.SignAndEncrypt,

--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -226,7 +226,7 @@ class Server:
         return f"OPC UA Server({self.endpoint.geturl()})"
     __repr__ = __str__
 
-    async def load_certificate(self, path_or_content: Union[str, bytes], format: str = None):
+    async def load_certificate(self, path_or_content: Union[str, bytes, Path], format: str = None):
         """
         load server certificate from file, either pem or der
         """


### PR DESCRIPTION
This fixes a couple of `pyright` warnings I noticed with tests.﻿

See https://github.com/FreeOpcUa/opcua-asyncio/pull/1179 for context