### PR TITLE
Add server-side session watchdog

### DIFF
--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -1,6 +1,6 @@
 import logging
 from enum import Enum
-from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
+from typing import Iterable, Optional, List, Tuple, TYPE_CHECKING
 
 from asyncua import ua
 from asyncua.common.session_interface import AbstractSession

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -1,8 +1,5 @@
-import asyncio
 import logging
-from datetime import datetime, timedelta
 from enum import Enum
-from functools import wraps
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 
 from asyncua import ua
@@ -52,10 +49,6 @@ class InternalSession(AbstractSession):
         InternalSession._auth_counter += 1
         self.logger.info('Created internal session %s', self.name)
         self.session_timeout = None
-        self._closing: bool = False
-        self._session_watchdog_task: Optional[asyncio.Task] = None
-        self._watchdog_interval: float = 1.0
-        self._last_action_time: Optional[datetime] = None
 
     def __str__(self):
         return f'InternalSession(name:{self.name},' \
@@ -67,36 +60,6 @@ class InternalSession(AbstractSession):
     def is_activated(self) -> bool:
         return self.state == SessionState.Activated
 
-    def update_last_action_time(func):
-        """Decorator to set last action time."""
-        if asyncio.iscoroutinefunction(func):
-            @wraps(func)
-            async def wrapper(self, *args, **kwargs):
-                self._last_action_time = datetime.now()
-                result = await func(self, *args, **kwargs)
-                return result
-        else:
-            @wraps(func)
-            def wrapper(self, *args, **kwargs):
-                self._last_action_time = datetime.now()
-                result = func(self, *args, **kwargs)
-                return result
-        return wrapper
-
-    async def _session_watchdog_loop(self):
-        """
-        Checks if the session is alive
-        """
-        timeout = min(self.session_timeout / 2, self._watchdog_interval)
-        timeout_timedelta = timedelta(seconds=self.session_timeout)
-        while not self._closing:
-            await asyncio.sleep(timeout)
-            print(self._last_action_time)
-            if (datetime.now() - timeout_timedelta) > self._last_action_time:
-                self.logger.warning('Session timed out after %ss of inactivity', timeout_timedelta.total_seconds())
-                await self.close_session()
-
-    @update_last_action_time
     async def create_session(self, params: ua.CreateSessionParameters, sockname: Optional[Tuple[str, int]] = None):
         self.logger.info('Create session request')
         result = ua.CreateSessionResult()
@@ -115,13 +78,10 @@ class InternalSession(AbstractSession):
         ep_params = ua.GetEndpointsParameters()
         ep_params.EndpointUrl = params.EndpointUrl
         result.ServerEndpoints = await self.get_endpoints(params=ep_params, sockname=sockname)
-        self._session_watchdog_task = asyncio.create_task(self._session_watchdog_loop())
         return result
 
-    @update_last_action_time
     async def close_session(self, delete_subs=True):
         self.logger.info('close session %s', self.name)
-        self._closing = True
         if self.state == SessionState.Activated:
             InternalSession._current_connections -= 1
         if InternalSession._current_connections < 0:
@@ -130,7 +90,6 @@ class InternalSession(AbstractSession):
         if delete_subs:
             await self.delete_subscriptions(self.subscriptions)
 
-    @update_last_action_time
     def activate_session(self, params, peer_certificate):
         self.logger.info('activate session')
         result = ua.ActivateSessionResult()
@@ -171,7 +130,6 @@ class InternalSession(AbstractSession):
         self.logger.info("Activated internal session %s for user %s", self.name, self.user)
         return result
 
-    @update_last_action_time
     async def read(self, params):
         if self.user is None:
             user = User()
@@ -184,11 +142,9 @@ class InternalSession(AbstractSession):
                                                      ServerItemCallback(params, results, user, self.external))
         return results
 
-    @update_last_action_time
     async def history_read(self, params) -> List[ua.HistoryReadResult]:
         return await self.iserver.history_manager.read_history(params)
 
-    @update_last_action_time
     async def write(self, params):
         if self.user is None:
             user = User()
@@ -201,11 +157,9 @@ class InternalSession(AbstractSession):
                                                      ServerItemCallback(params, write_result, user, self.external))
         return write_result
 
-    @update_last_action_time
     async def browse(self, params):
         return self.iserver.view_service.browse(params)
 
-    @update_last_action_time
     async def browse_next(self, parameters: ua.BrowseNextParameters) -> List[ua.BrowseResult]:
         # TODO
         # ContinuationPoint: https://reference.opcfoundation.org/v104/Core/docs/Part4/7.6/
@@ -213,52 +167,41 @@ class InternalSession(AbstractSession):
         # BrowseNext: https://reference.opcfoundation.org/Core/Part4/v104/5.8.3/
         raise NotImplementedError
 
-    @update_last_action_time
     async def register_nodes(self, nodes: List[ua.NodeId]) -> List[ua.NodeId]:
         self.logger.info("Node registration not implemented")
         return nodes
 
-    @update_last_action_time
     async def unregister_nodes(self, nodes: List[ua.NodeId]) -> List[ua.NodeId]:
         self.logger.info("Node registration not implemented")
         return nodes
 
-    @update_last_action_time
     async def translate_browsepaths_to_nodeids(self, params):
         return self.iserver.view_service.translate_browsepaths_to_nodeids(params)
 
-    @update_last_action_time
     async def add_nodes(self, params):
         return self.iserver.node_mgt_service.add_nodes(params, self.user)
 
-    @update_last_action_time
     async def delete_nodes(self, params):
         return self.iserver.node_mgt_service.delete_nodes(params, self.user)
 
-    @update_last_action_time
     async def add_references(self, params):
         return self.iserver.node_mgt_service.add_references(params, self.user)
 
-    @update_last_action_time
     async def delete_references(self, params):
         return self.iserver.node_mgt_service.delete_references(params, self.user)
 
-    @update_last_action_time
     def add_method_callback(self, methodid, callback):
         return self.aspace.add_method_callback(methodid, callback)
 
-    @update_last_action_time
     async def call(self, params):
         """COROUTINE"""
         return await self.iserver.method_service.call(params)
 
-    @update_last_action_time
     async def create_subscription(self, params, callback, request_callback=None):
         result = await self.subscription_service.create_subscription(params, callback, request_callback=request_callback)
         self.subscriptions.append(result.SubscriptionId)
         return result
 
-    @update_last_action_time
     async def create_monitored_items(self, params: ua.CreateMonitoredItemsParameters):
         """Returns Future"""
         subscription_result = await self.subscription_service.create_monitored_items(params)
@@ -267,7 +210,6 @@ class InternalSession(AbstractSession):
                                                                         self.external))
         return subscription_result
 
-    @update_last_action_time
     async def modify_monitored_items(self, params):
         subscription_result = self.subscription_service.modify_monitored_items(params)
         await self.iserver.callback_service.dispatch(CallbackType.ItemSubscriptionModified,
@@ -275,16 +217,13 @@ class InternalSession(AbstractSession):
                                                                         self.external))
         return subscription_result
 
-    @update_last_action_time
     def republish(self, params):
         return self.subscription_service.republish(params)
 
-    @update_last_action_time
     async def delete_subscriptions(self, ids):
         # This is an async method, dues to symmetry with client code
         return await self.subscription_service.delete_subscriptions(ids)
 
-    @update_last_action_time
     async def delete_monitored_items(self, params):
         # This is an async method, dues to symmetry with client code
         subscription_result = self.subscription_service.delete_monitored_items(params)
@@ -294,15 +233,12 @@ class InternalSession(AbstractSession):
 
         return subscription_result
 
-    @update_last_action_time
     def publish(self, acks: Optional[Iterable[ua.SubscriptionAcknowledgement]] = None):
         return self.subscription_service.publish(acks or [])
 
-    @update_last_action_time
     def modify_subscription(self, params):
         return self.subscription_service.modify_subscription(params)
 
-    @update_last_action_time
     async def transfer_subscriptions(self, params: ua.TransferSubscriptionsParameters) -> List[ua.TransferResult]:
         # Subscriptions aren't bound to a Session and can be transfered!
         # https://reference.opcfoundation.org/Core/Part4/v104/5.13.7/

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -66,7 +66,7 @@ class InternalSession(AbstractSession):
 
     def is_activated(self) -> bool:
         return self.state == SessionState.Activated
-    
+
     def update_last_action_time(func):
         """Decorator to set last action time."""
         if asyncio.iscoroutinefunction(func):
@@ -82,7 +82,7 @@ class InternalSession(AbstractSession):
                 result = func(self, *args, **kwargs)
                 return result
         return wrapper
-    
+
     async def _session_watchdog_loop(self):
         """
         Checks if the session is alive

--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -1,8 +1,10 @@
+import asyncio
 import copy
 import time
 import logging
 from typing import Deque, Optional, Dict
 from collections import deque
+from datetime import datetime, timedelta, timezone
 
 from asyncua import ua
 from ..ua.ua_binary import nodeid_from_binary, struct_from_binary, struct_to_binary, uatcp_to_binary
@@ -31,6 +33,7 @@ class UaProcessor:
         self.name = transport.get_extra_info('peername')
         self.sockname = transport.get_extra_info('sockname')
         self.session: Optional[InternalSession] = None
+        self.session_last_activity: Optional[datetime] = None
         self._transport = transport
         # deque for Publish Requests
         self._publish_requests: Deque[PublishRequestData] = deque()
@@ -39,6 +42,9 @@ class UaProcessor:
         self._publish_results_subs: Dict[ua.IntegerId, bool] = {}
         self._limits = copy.deepcopy(limits)  # Copy limits because they get overriden
         self._connection = SecureConnection(ua.SecurityPolicy(), self._limits)
+        self._closing: bool = False
+        self._session_watchdog_task: Optional[asyncio.Task] = None
+        self._watchdog_interval: float = 1.0
 
     def set_policies(self, policies):
         self._connection.set_policy_factories(policies)
@@ -178,6 +184,8 @@ class UaProcessor:
                 if self._connection.security_policy.permissions.check_validity(user, typeid, body) is False:
                     raise ua.uaerrors.BadUserAccessDenied
 
+        self.session_last_activity = datetime.now(timezone.utc)
+
         if typeid == ua.NodeId(ua.ObjectIds.CreateSessionRequest_Encoding_DefaultBinary):
             _logger.info("Create session request (%s)", user)
             params = struct_from_binary(ua.CreateSessionParameters, body)
@@ -185,6 +193,8 @@ class UaProcessor:
             self.session = self.iserver.create_session(self.name, external=True)
             # get a session creation result to send back
             sessiondata = await self.session.create_session(params, sockname=self.sockname)
+            self._closing = False
+            self._session_watchdog_task = asyncio.create_task(self._session_watchdog_loop())
             response = ua.CreateSessionResponse()
             response.Parameters = sessiondata
             response.Parameters.ServerCertificate = self._connection.security_policy.host_certificate
@@ -202,6 +212,7 @@ class UaProcessor:
             _logger.info("Close session request (%s)", user)
             if self.session:
                 deletesubs = ua.ua_binary.Primitives.Boolean.unpack(body)
+                self._closing = True
                 await self.session.close_session(deletesubs)
             else:
                 _logger.info("Request to close non-existing session (%s)", user)
@@ -507,5 +518,18 @@ class UaProcessor:
         everything we should
         """
         _logger.info("Cleanup client connection: %s", self.name)
+        self._closing = True
         if self.session:
             await self.session.close_session(True)
+
+    async def _session_watchdog_loop(self):
+        """
+        Checks if the session is alive
+        """
+        timeout = min(self.session.session_timeout / 2, self._watchdog_interval)
+        timeout_timedelta = timedelta(seconds=self.session.session_timeout)
+        while not self._closing:
+            await asyncio.sleep(timeout)
+            if (datetime.now(timezone.utc) - timeout_timedelta) > self.session_last_activity:
+                _logger.warning('Session timed out after %ss of inactivity', timeout_timedelta.total_seconds())
+                await self.close()


### PR DESCRIPTION
As discussed [here](https://github.com/FreeOpcUa/opcua-asyncio/issues/116#issuecomment-2155642372), to comply with [section 5.6.2](https://reference.opcfoundation.org/Core/Part4/v104/docs/5.6.2) of the spec, the server should close a session that is inactive within its session timeout:

> [Sessions](https://reference.opcfoundation.org/search/17?t=Sessions) are terminated by the [Server](https://reference.opcfoundation.org/search/17?t=Server) automatically if the [Client](https://reference.opcfoundation.org/search/17?t=Client) fails to issue a [Service](https://reference.opcfoundation.org/search/17?t=Service) request on the [Session](https://reference.opcfoundation.org/search/17?t=Session) within the timeout period negotiated by the [Server](https://reference.opcfoundation.org/search/17?t=Server) in the [CreateSession](https://reference.opcfoundation.org/search/17?t=CreateSession) [Service](https://reference.opcfoundation.org/search/17?t=Service) response. This protects the [Server](https://reference.opcfoundation.org/search/17?t=Server) against [Client](https://reference.opcfoundation.org/search/17?t=Client) failures and against situations where a failed underlying connection cannot be re-established. [Clients](https://reference.opcfoundation.org/search/17?t=Clients) shall be prepared to submit requests in a timely manner to prevent the [Session](https://reference.opcfoundation.org/search/17?t=Session) from closing automatically.

I no longer think this will actually resolve anything in https://github.com/FreeOpcUa/opcua-asyncio/issues/116, but I think it's useful nonetheless if we want to comply with the spec.