### PR TITLE
Add callback to delete subscriptions

### DIFF
--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -85,7 +85,13 @@ class InternalSession(AbstractSession):
         if InternalSession._current_connections < 0:
             InternalSession._current_connections = 0
         self.state = SessionState.Closed
-        await self.delete_subscriptions(list(self.subscription_service.subscriptions.keys()))
+        await self.delete_subscriptions(
+            [
+                id
+                for id, sub in self.subscription_service.subscriptions.items()
+                if sub.session_id == self.session_id
+            ]
+        )
 
     def activate_session(self, params, peer_certificate):
         self.logger.info('activate session')
@@ -195,7 +201,7 @@ class InternalSession(AbstractSession):
         return await self.iserver.method_service.call(params)
 
     async def create_subscription(self, params, callback, request_callback=None):
-        result = await self.subscription_service.create_subscription(params, callback, request_callback=request_callback)
+        result = await self.subscription_service.create_subscription(params, callback, self.session_id, request_callback=request_callback)
         return result
 
     async def create_monitored_items(self, params: ua.CreateMonitoredItemsParameters):

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -196,7 +196,12 @@ class InternalSession(AbstractSession):
         return await self.iserver.method_service.call(params)
 
     async def create_subscription(self, params, callback, request_callback=None):
-        result = await self.subscription_service.create_subscription(params, callback, request_callback=request_callback)
+        result = await self.subscription_service.create_subscription(
+            params,
+            callback,
+            request_callback=request_callback,
+            delete_callback=self.delete_subscriptions,
+        )
         self.subscriptions.append(result.SubscriptionId)
         return result
 
@@ -220,6 +225,7 @@ class InternalSession(AbstractSession):
 
     async def delete_subscriptions(self, ids):
         # This is an async method, dues to symmetry with client code
+        self.subscriptions = [id for id in self.subscriptions if id not in ids]
         return await self.subscription_service.delete_subscriptions(ids)
 
     async def delete_monitored_items(self, params):

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -85,7 +85,7 @@ class InternalSession(AbstractSession):
         if InternalSession._current_connections < 0:
             InternalSession._current_connections = 0
         self.state = SessionState.Closed
-        await self.delete_subscriptions(self.subscription_service.subscriptions.keys())
+        await self.delete_subscriptions(list(self.subscription_service.subscriptions.keys()))
 
     def activate_session(self, params, peer_certificate):
         self.logger.info('activate session')

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -195,11 +195,7 @@ class InternalSession(AbstractSession):
         return await self.iserver.method_service.call(params)
 
     async def create_subscription(self, params, callback, request_callback=None):
-        result = await self.subscription_service.create_subscription(
-            params,
-            callback,
-            request_callback=request_callback,
-        )
+        result = await self.subscription_service.create_subscription(params, callback, request_callback=request_callback)
         return result
 
     async def create_monitored_items(self, params: ua.CreateMonitoredItemsParameters):

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -34,7 +34,9 @@ class InternalSubscription:
         :param request_callback: Callback for getting queued publish requests.
             If None, publishing will be done without waiting for a token and no
             acknowledging will be expected (for server internal subscriptions)
-        :param delete_callback: Optional callback to delete the subscription
+        :param delete_callback: Optional callback to call when the subscription
+            is stopped due to the publish count exceeding the
+            RevisedLifetimeCount.
         """
         self.logger = logging.getLogger(__name__)
         self.data: ua.CreateSubscriptionResult = data

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -23,6 +23,7 @@ class InternalSubscription:
         data: ua.CreateSubscriptionResult,
         aspace: AddressSpace,
         callback,
+        session_id,
         request_callback=None,
         delete_callback=None,
     ):
@@ -31,6 +32,7 @@ class InternalSubscription:
         :param data: Create Subscription Result
         :param aspace: Server Address Space
         :param callback: Callback for publishing
+        :param session_id: Id of the session that owns this subscription.
         :param request_callback: Callback for getting queued publish requests.
             If None, publishing will be done without waiting for a token and no
             acknowledging will be expected (for server internal subscriptions)
@@ -44,6 +46,7 @@ class InternalSubscription:
         self.pub_request_callback = request_callback
         self.monitored_item_srv = MonitoredItemService(self, aspace)
         self.delete_callback = delete_callback
+        self.session_id = session_id
         self._triggered_datachanges: Dict[int, List[ua.MonitoredItemNotification]] = {}
         self._triggered_events: Dict[int, List[ua.EventFieldList]] = {}
         self._triggered_statuschanges: list = []

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -128,10 +128,9 @@ class InternalSubscription:
             self.logger.warning("Subscription %s has expired, publish cycle count(%s) > lifetime count (%s)", self,
                                 self._publish_cycles_count, self.data.RevisedLifetimeCount)
             # FIXME this will never be send since we do not have publish request anyway
+            await self.stop()
             if self.delete_callback:
-                await self.delete_callback()
-            else:
-                await self.stop()
+                self.delete_callback()
             return False
         if not self.has_published_results():
             return False

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -128,6 +128,7 @@ class InternalSubscription:
             self.logger.warning("Subscription %s has expired, publish cycle count(%s) > lifetime count (%s)", self,
                                 self._publish_cycles_count, self.data.RevisedLifetimeCount)
             # FIXME this will never be send since we do not have publish request anyway
+            await self.monitored_item_srv.trigger_statuschange(ua.StatusCode(ua.StatusCodes.BadTimeout))
             await self.stop()
             if self.delete_callback:
                 self.delete_callback()

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -41,7 +41,7 @@ class SubscriptionService:
             self.aspace,
             callback,
             request_callback=request_callback,
-            delete_callback=lambda: delete_callback([result.SubscriptionId]),
+            delete_callback=lambda: self.subscriptions.pop([result.SubscriptionId], None),
         )
         await internal_sub.start()
         self.subscriptions[result.SubscriptionId] = internal_sub

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -27,7 +27,7 @@ class SubscriptionService:
         self._conditions = {}
 
     async def create_subscription(
-        self, params, callback, request_callback=None, delete_callback=None
+        self, params, callback, session_id, request_callback=None
     ):
         self.logger.info("create subscription")
         result = ua.CreateSubscriptionResult()
@@ -40,6 +40,7 @@ class SubscriptionService:
             result,
             self.aspace,
             callback,
+            session_id,
             request_callback=request_callback,
             delete_callback=lambda: self.subscriptions.pop(result.SubscriptionId, None),
         )

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -41,7 +41,7 @@ class SubscriptionService:
             self.aspace,
             callback,
             request_callback=request_callback,
-            delete_callback=lambda: self.subscriptions.pop([result.SubscriptionId], None),
+            delete_callback=lambda: self.subscriptions.pop(result.SubscriptionId, None),
         )
         await internal_sub.start()
         self.subscriptions[result.SubscriptionId] = internal_sub

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -26,7 +26,9 @@ class SubscriptionService:
         self.standard_events = {}
         self._conditions = {}
 
-    async def create_subscription(self, params, callback, request_callback=None):
+    async def create_subscription(
+        self, params, callback, request_callback=None, delete_callback=None
+    ):
         self.logger.info("create subscription")
         result = ua.CreateSubscriptionResult()
         result.RevisedPublishingInterval = params.RequestedPublishingInterval
@@ -34,7 +36,13 @@ class SubscriptionService:
         result.RevisedMaxKeepAliveCount = params.RequestedMaxKeepAliveCount
         self._sub_id_counter += 1
         result.SubscriptionId = self._sub_id_counter
-        internal_sub = InternalSubscription(result, self.aspace, callback, request_callback=request_callback)
+        internal_sub = InternalSubscription(
+            result,
+            self.aspace,
+            callback,
+            request_callback=request_callback,
+            delete_callback=lambda: delete_callback([result.SubscriptionId]),
+        )
         await internal_sub.start()
         self.subscriptions[result.SubscriptionId] = internal_sub
         return result


### PR DESCRIPTION
As discussed [here](https://github.com/FreeOpcUa/opcua-asyncio/pull/1654#issuecomment-2162116152), we need to clean up some subscription objects when a subscription deletion within `internal_subscription.py` due to an exceeded `RevisedLifetimeCount`. In this PR, I implement a callback that cleans up the subscription objects in the subscription service that is called when the subscription is stopped in this fashion.