### PR TITLE
Don't reset attribute_value_callback on write

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -794,7 +794,7 @@ class AddressSpace:
             attval.value_setter(node, attr, value)
         else:
             attval.value = value
-        attval.value_callback = None
+            attval.value_callback = None
 
         for k, v in attval.datachange_callbacks.items():
             try:


### PR DESCRIPTION
Currently i am using ```set_attribute_value_callback``` and ```set_attribute_value_setter``` on the Server. I do this to be able to manage the Value in my own Data structure.
Currently i have the problem, that when ever the Value is written by ```write_attribute_value``` i can not read the value again.
This is because ```attval.value_callback``` is reset to ```None``` even if a value setter is used.
This causes the Value and the value callback to be ```None```, which will result in ```None``` being returned by ```read_attribute_value``` which cant be serialized.

This fixes this Problem by only setting the ```attval.value_callback``` to ```None``` if no value Setter is defined.