### PR TITLE
Add `@functools.wraps(func)` to the `wrapper` function of `@uamethod`

### DIFF
--- a/asyncua/common/methods.py
+++ b/asyncua/common/methods.py
@@ -5,6 +5,7 @@ High level method related functions
 from __future__ import annotations
 
 from asyncio import iscoroutinefunction
+from functools import wraps
 from typing import Any, Iterable, List, Union
 
 import asyncua
@@ -77,12 +78,14 @@ def uamethod(func):
     """
 
     if iscoroutinefunction(func):
+        @wraps(func)
         async def wrapper(parent, *args):
             func_args = _format_call_inputs(parent, *args)
             result = await func(*func_args)
             return _format_call_outputs(result)
 
     else:
+        @wraps(func)
         def wrapper(parent, *args):
             func_args = _format_call_inputs(parent, *args)
             result = func(*func_args)


### PR DESCRIPTION
This way we can decorate a function which is already decorated with `@uamethod` again and things like `func.__name__` will correctly return the name of the decorated function and not `wrapper`.

E.g., the following will now correctly print `Calling my_method ...`. Without `@wraps(func)` it would have printed `Calling wrapper ...`:

```py
from functools import wraps

def my_decorator(func):
  @wraps(func)
  def wrapper(*args, **kwargs):
    print(f"Calling {func.__name__} with {args=} and {kwargs=}")

@my_decorator
@uamethod
def my_method(parent, arg1, arg2):
  print(f"my_method called with {arg1=} and {arg2=}")
```