### PR TITLE
Fixed function signature in `Node`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix inconsistent type annotations as reported by mypy
   [#1277](https://github.com/FreeOpcUa/opcua-asyncio/pull/1277)
-
+- Fixed incorrect function signature in Node and it's Sync wrapper
+  [#1690](https://github.com/FreeOpcUa/opcua-asyncio/pull/1690)
+  
 ## [1.0.2] - 2022-04-05
 
 ### Added

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -227,7 +227,7 @@ class Node:
         v = ua.Variant(value, ua.VariantType.UInt32)
         await self.write_attribute(ua.AttributeIds.ArrayDimensions, ua.DataValue(v))
 
-    async def read_array_dimensions(self) -> list[int]:
+    async def read_array_dimensions(self) -> List[int]:
         """
         Read and return ArrayDimensions attribute of node
         """

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -227,7 +227,7 @@ class Node:
         v = ua.Variant(value, ua.VariantType.UInt32)
         await self.write_attribute(ua.AttributeIds.ArrayDimensions, ua.DataValue(v))
 
-    async def read_array_dimensions(self) -> int:
+    async def read_array_dimensions(self) -> list[int]:
         """
         Read and return ArrayDimensions attribute of node
         """

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -739,7 +739,7 @@ class SyncNode:
         pass
 
     @syncmethod
-    def read_array_dimensions(self) -> int:  # type: ignore[empty-body]
+    def read_array_dimensions(self) -> List[int]:  # type: ignore[empty-body]
         pass
 
     @syncmethod


### PR DESCRIPTION
Fixed function signature of `read_array_dimensions` in asyncua/common/node.

ArrayDimentions is always a `list` of `int`s because OPC UA has support for multidimentional arrays. This is specified in the OPC UA standard at the end of [this](https://reference.opcfoundation.org/Core/Part6/v105/docs/5.2.2.16) page. But the return type in asyncua was is specified as `int`. This can generate false type-checker errors. Fix is to just change signature. The fucntion already correctly returns a list of integers.

Let me know if you want me to add a changelog entry also 😊