### PR TITLE
feat: support nested structures.

### DIFF
--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -213,6 +213,8 @@ class {struct_name}{base_class}:
             uatype = ua.basetype_by_datatype[sfield.DataType]
         elif sfield.DataType == data_type:
             uatype = struct_name
+        elif sfield.DataType != data_type and isinstance(sfield, ua.uaprotocol_auto.StructureField):
+            uatype = "uaprotocol_auto.StructureField" #field name is also a structure
         else:
             if log_error:
                 _logger.error("Unknown datatype for field: %s in structure:%s, please report", sfield, struct_name)
@@ -260,6 +262,7 @@ class {struct_name}{base_class}:
     else:
         for fname, uatype, default_value in fields:
             code += f"    {fname}: {uatype} = {default_value}\n"
+    print(f"testprint: structure {fname} has Python class {code}")
     return code
 
 


### PR DESCRIPTION
For nested structures the function `make_structure_code` in `asyncua.common.structures104.py` raised a RuntimeError exception. 
I now added for structure fields, which are structures again a further elif branch, which checks if the datatype is different and if it is a StrucutreField and then I assign the type `uaprotocol_auto.StructureField`.

My first tests with nested structures look quite good:

```@dataclass
class ReadOnly:

    '''
    ReadOnly structure autogenerated from StructureDefinition object
    '''

    data_type = ua.NodeId.from_string('''ns=4;i=3007''')

    Header: ua.uaprotocol_auto.StructureField = field(default_factory=ua.uaprotocol_auto.StructureField)
    Return_data: ua.Return_data = field(default_factory=ua.Return_data)
```

And also structure with base types looks good:

```
@dataclass
class ReadWrite:

    '''
    ReadWrite structure autogenerated from StructureDefinition object
    '''

    data_type = ua.NodeId.from_string('''ns=4;i=3008''')

    KeepAlive: ua.Boolean = True
    Res_Bit1: ua.Boolean = True
    Res_Bit2: ua.Boolean = True
    Res_Bit3: ua.Boolean = True
    Res_Bit4: ua.Boolean = True
    Res_Bit5: ua.Boolean = True
    Res_Bit6: ua.Boolean = True
    Res_Bit7: ua.Boolean = True
```

If the pull request gets accepted I will remove the print statement before we/you merge it into master.