### PR TITLE
Fixes for using activate_session to change users.

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -143,12 +143,12 @@ class Client:
         """
         self._username = username
 
-    def set_password(self, pwd: str) -> None:
+    def set_password(self, pwd: str | None) -> None:
         """
         Set user password for the connection.
         initial password from the URL will be overwritten
         """
-        if not isinstance(pwd, str):
+        if pwd is not None and not isinstance(pwd, str):
             raise TypeError(f"Password must be a string, got {pwd} of type {type(pwd)}")
         self._password = pwd
 


### PR DESCRIPTION
- The updated ServerNonce was not saved after activate_session, which means that subsequent activate_sessions would fail with BadIdentityTokenInvalid.
- The self._password attribute of Client was checked in _add_user_auth function, instead of its own password argument.