### PR TITLE
add: Number in uatypes.py

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -93,6 +93,10 @@ class UaUnion:
     pass
 
 
+class Number(float):
+    pass
+
+
 class SByte(int):
     pass
 


### PR DESCRIPTION
@oroulet not sure why Number is missing!? its just an abstract BaseDataType....

```
(env) C:\Users\Andreas\Documents\GitHub\opcua-tutorial>C:/Users/Andreas/Documents/GitHub/opcua-tutorial/env/Scripts/python.exe "c:/Users/Andreas/Documents/GitHub/opcua-tutorial/client/BaseClient copy.py"
WARNING:asyncua.client.client:Requested session timeout to be 300000ms, got 3000000ms instead
WARNING:asyncua.common.structures104:renamed 3DVector to _3DVector due to Python syntax
WARNING:asyncua.common.structures104:renamed 3DCartesianCoordinates to _3DCartesianCoordinates due to Python syntax
WARNING:asyncua.common.structures104:renamed 3DOrientation to _3DOrientation due to Python syntax
WARNING:asyncua.common.structures104:renamed 3DFrame to _3DFrame due to Python syntax
ERROR:asyncua.common.structures104:Failed to execute auto-generated code from UA datatype:

@dataclass
class CyclicProcessValueDataType:

    '''
    CyclicProcessValueDataType structure autogenerated from StructureDefinition object
    '''

    data_type = ua.NodeId.from_string('''ns=27;i=3003''')

    AnalogSignal: ua.Number = field(default_factory=ua.Number)
    Setpoint: ua.Number = field(default_factory=ua.Number)
    CycleCount: ua.Counter = ua.UInt32(0)
    IsActive: ua.Boolean = True
Traceback (most recent call last):
  File "C:\Users\Andreas\Documents\GitHub\opcua-tutorial\env\Lib\site-packages\asyncua\common\structures104.py", line 299, in _generate_object
    exec(code, env)
  File "<string>", line 4, in <module>
  File "<string>", line 12, in CyclicProcessValueDataType
AttributeError: module 'asyncua.ua' has no attribute 'Number'
Traceback (most recent call last):
  File "c:\Users\Andreas\Documents\GitHub\opcua-tutorial\client\BaseClient copy.py", line 24, in <module>
    asyncio.run(main())
  File "C:\Users\Andreas\AppData\Local\Programs\Python\Python311\Lib\asyncio\runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "C:\Users\Andreas\AppData\Local\Programs\Python\Python311\Lib\asyncio\runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Andreas\AppData\Local\Programs\Python\Python311\Lib\asyncio\base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "C:\Users\Andreas\Documents\GitHub\opcua-tutorial\env\Lib\site-packages\asyncua\client\client.py", line 875, in load_data_type_definitions
    return await load_data_type_definitions(self, node, overwrite_existing=overwrite_existing)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                            nitions
  File "C:\Users\Andreas\Documents\GitHub\opcua-tutorial\env\Lib\site-packages\asyncua\common\structures104.py", line 482, in load_data_type_definitions
    env = await _generate_object(dts.name, dts.sdef, data_type=dts.data_type, log_fail=log_ex)                                            pe_definitions
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Andreas\Documents\GitHub\opcua-tutorial\env\Lib\site-packages\asyncua\common\structures104.py", line 299, in _generate_object                                                                                                                                      ject
    exec(code, env)
  File "<string>", line 4, in <module>
  File "<string>", line 12, in CyclicProcessValueDataType
AttributeError: module 'asyncua.ua' has no attribute 'Number'

```