### PR TITLE
fix: NodeId change for class DataValue

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -1087,7 +1087,7 @@ class DataValue:
     :vartype ServerPicoseconds: int
     """
 
-    data_type = NodeId(25)
+    data_type = NodeId(23)
 
     Encoding: Byte = field(default=0, repr=False, init=False, compare=False)
     Value: Optional[Variant] = None

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -15,6 +15,8 @@ from datetime import datetime, timedelta, timezone
 from enum import IntEnum
 from typing import Any, Generic, List, Optional, Union
 
+from asyncua.ua.object_ids import ObjectIds
+
 # hack to support python < 3.8
 if sys.version_info.minor < 10:
 
@@ -1087,7 +1089,7 @@ class DataValue:
     :vartype ServerPicoseconds: int
     """
 
-    data_type = NodeId(23)
+    data_type = NodeId(Int32(ObjectIds.DataValue))
 
     Encoding: Byte = field(default=0, repr=False, init=False, compare=False)
     Value: Optional[Variant] = None


### PR DESCRIPTION
According to ObjectIds, [DataValue = 23](https://github.com/FreeOpcUa/opcua-asyncio/blob/447bdf7596ba07c0aac239919e28471b0b3efd45/asyncua/ua/object_ids.py?plain=1#L28), and not 25 as it was before this commit. [25 is DiagnosticInfo](https://github.com/FreeOpcUa/opcua-asyncio/blob/447bdf7596ba07c0aac239919e28471b0b3efd45/asyncua/ua/object_ids.py?plain=1#L30), which can also be seen on line 1137 in the uatypes.py file.

(this is my first PR in this repo, and I found it while "just browsing around", so feel free to tell me if I'm completely off here 😉)

Edit: Now using `ObjectIds.DataValue` instead of `23` to make it more obvious.