### PR TITLE
Add support for reading structure with subtyped values

### DIFF
--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -179,6 +179,7 @@ def make_structure_code(data_type, struct_name, sdef, log_error=True):
         ua.StructureType.Structure,
         ua.StructureType.StructureWithOptionalFields,
         ua.StructureType.Union,
+        ua.StructureType.StructureWithSubtypedValues,
     ):
         raise NotImplementedError(
             f"Only StructureType implemented, not {ua.StructureType(sdef.StructureType).name} for node {struct_name} with DataTypdeDefinition {sdef}"
@@ -240,8 +241,11 @@ class {struct_name}{base_class}:
         elif sfield.ValueRank >= 1 or sfield.ArrayDimensions:
             uatype = f"typing.List[{uatype}]"
         if sfield.IsOptional:
-            uatype = f"typing.Optional[{uatype}]"
-            default_value = "None"
+            if sdef.StructureType is ua.StructureType.StructureWithSubtypedValues:
+                uatype = f"typing.Annotated[{uatype}, 'AllowSubtypes']"
+            else:
+                uatype = f"typing.Optional[{uatype}]"
+                default_value = "None"
         fields.append((fname, uatype, default_value))
     if is_union:
         # Generate getter and setter to mimic opc ua union access


### PR DESCRIPTION
This PR adds support for loading data types definitions for types that have StructureType set to StructureWithSubtypedValues, and to read the corresponding values. It does this by simply wrapping the types that should be allowed to have subtypes in a typing.Annotated, which ends up giving the right result because of how ua.uatypes.type_allow_subclass is defined. I'm not sure if this is the most proper way of doing this

As far as I can tell this is not enough to *write* such a value, or at least I haven't manage to figure out how to set that up. Since I wasn't able to write any values I also weren't able to add any tests that check reading structures with subtypes. I have however successfully tested loading data types and reading values from an external server

There is also the UnionWithSubtypedValues structure type which I'm ignoring here because I haven't seen it used anywhere

This patch requires python 3.9 but that seems to already be the minimum according to pyproject.toml even though the readme says 3.8

Also see issue #1319
