### PR TITLE
Fix ReferenceDescriptions for TypeDefinition

### DIFF
--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -783,6 +783,9 @@ class XmlImporter:
                 if ndata.datatype is not None and ndata.datatype in all_nodes:
                     if ndata.datatype not in sorted_nodes:
                         continue
+                if ndata.typedef is not None and ndata.typedef in all_nodes:
+                    if ndata.typedef not in sorted_nodes:
+                        continue
                 if ndata.parent is None or ndata.parent not in all_nodes:
                     add_to_sorted(nid, ndata)
                 else:

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -328,6 +328,10 @@ class NodeManagementService:
                         result.StatusCode = ua.StatusCode(ua.StatusCodes.BadBrowseNameDuplicated)
                         return result
 
+        if not item.TypeDefinition.is_null() and item.TypeDefinition not in self._aspace:
+            result.StatusCode = ua.StatusCode(ua.StatusCodes.BadTypeDefinitionInvalid)
+            return result
+
         nodedata = NodeData(item.RequestedNewNodeId)
 
         self._add_node_attributes(nodedata, item, add_timestamps=check)
@@ -340,7 +344,7 @@ class NodeManagementService:
             self._add_ref_to_parent(nodedata, item, parentdata)
 
         # add type definition
-        if item.TypeDefinition != ua.NodeId():
+        if not item.TypeDefinition.is_null():
             self._add_type_definition(nodedata, item)
 
         result.StatusCode = ua.StatusCode()
@@ -399,7 +403,7 @@ class NodeManagementService:
         addref.IsForward = True  # FIXME in uaprotocol_auto.py
         addref.ReferenceTypeId = ua.NodeId(ua.ObjectIds.HasTypeDefinition)
         addref.TargetNodeId = item.TypeDefinition
-        addref.TargetNodeClass = ua.NodeClass.DataType
+        addref.TargetNodeClass = ua.NodeClass.Unspecified
         self._add_reference_no_check(nodedata, addref)  # FIXME return StatusCode is not evaluated
 
     def delete_nodes(


### PR DESCRIPTION
Followup on #1529, #1794.

As a side-effect, specifying a non-existing TypeDefinition in an AddNodesRequest now leads to BadTypeDefinitionInvalid. For loading UA-Nodeset, this error is already handled in PostponeReferences. Fixed node sorting in XmlImporter.

Previously, some ReferenceDescriptions for non-existing TypeDefinitions also lacked BrowseName and DisplayName.