### PR TITLE
SenderCertificate shall be null if the Message is not signed

### DIFF
--- a/asyncua/common/connection.py
+++ b/asyncua/common/connection.py
@@ -188,7 +188,7 @@ class MessageChunk:
             # SecureOpen message must be in a single chunk (specs, Part 6, 6.7.2)
             chunk = MessageChunk(security_policy.asymmetric_cryptography, body, message_type, ua.ChunkType.Single)
             chunk.SecurityHeader.SecurityPolicyURI = security_policy.URI
-            if security_policy.host_certificate:
+            if security_policy.host_certificate and security_policy.Mode != ua.MessageSecurityMode.None_:
                 chunk.SecurityHeader.SenderCertificate = security_policy.host_certificate
             if security_policy.peer_certificate:
                 chunk.SecurityHeader.ReceiverCertificateThumbPrint = hashlib.sha1(


### PR DESCRIPTION
Fixes regression from #1729.

In the PR mentioned above, host_certificate has also been set for SecurityPolicyNone. This was needed for having password encryption on an unencrypted channel.

This now broke my setup with AspenTech Inmation. According to https://reference.opcfoundation.org/Core/Part6/v105/docs/6.7.2.3, SecurityHeader.SenderCertificate shall be null if the Message is not signed.

As already mentioned in the PR above, SecurityPolicies shouldn't be misused as data containers for stuff with better belongs to server or client objects. I currently don't have time to clean that up, so I only fixed it with omitting SenderCertificate when using MessageSecurityMode.None_.