### PR TITLE
Aware time in the examples

### DIFF
--- a/examples/server-events-history.py
+++ b/examples/server-events-history.py
@@ -2,18 +2,17 @@ import sys
 
 sys.path.insert(0, "..")
 import time
-from datetime import datetime
+from datetime import datetime, UTC
 
 from asyncua import ua, Server
 from asyncua.server.history_sql import HistorySQLite
-
 
 if __name__ == "__main__":
     # setup our server
     server = Server()
     server.set_endpoint("opc.tcp://0.0.0.0:4840/freeopcua/server/")
 
-    # setup our own namespace, not really necessary but should as spec
+    # set up our own namespace, not really necessary but should as spec
     uri = "http://examples.freeopcua.github.io"
     idx = server.register_namespace(uri)
 
@@ -76,7 +75,7 @@ if __name__ == "__main__":
             serverevgen.trigger(message="Server Event Message")
 
             # read event history from sql
-            end_time = datetime.utcnow()
+            end_time = datetime.now(UTC)
             server_event_history = server_node.read_event_history(None, end_time, 0)
 
     finally:

--- a/examples/server-example.py
+++ b/examples/server-example.py
@@ -1,13 +1,11 @@
 import asyncio
 import copy
 import logging
-from datetime import datetime
 import time
+from datetime import datetime, UTC
 from math import sin
 
-
 from asyncua import ua, uamethod, Server
-
 
 _logger = logging.getLogger(__name__)
 
@@ -56,7 +54,7 @@ async def main():
         ]
     )
 
-    # setup our own namespace
+    # set up our own namespace
     uri = "http://examples.freeopcua.github.io"
     idx = await server.register_namespace(uri)
 
@@ -83,11 +81,11 @@ async def main():
     await myvar.set_writable()  # Set MyVariable to be writable by clients
     mystringvar = await myobj.add_variable(idx, "MyStringVariable", "Really nice string")
     await mystringvar.set_writable()  # Set MyVariable to be writable by clients
-    mydtvar = await myobj.add_variable(idx, "MyDateTimeVar", datetime.utcnow())
+    mydtvar = await myobj.add_variable(idx, "MyDateTimeVar", datetime.now(UTC))
     await mydtvar.set_writable()  # Set MyVariable to be writable by clients
     myarrayvar = await myobj.add_variable(idx, "myarrayvar", [6.7, 7.9])
     myuintvar = await myobj.add_variable(idx, "myuintvar", ua.UInt16(4))
-    await myobj.add_variable(idx, "myStronglytTypedVariable", ua.Variant([], ua.VariantType.UInt32))
+    await myobj.add_variable(idx, "myStronglyTypedVariable", ua.Variant([], ua.VariantType.UInt32))
     await myarrayvar.set_writable(True)
     myprop = await myobj.add_property(idx, "myproperty", "I am a property")
     mymethod = await myobj.add_method(idx, "mymethod", func, [ua.VariantType.Int64], [ua.VariantType.Boolean])

--- a/examples/server-methods.py
+++ b/examples/server-methods.py
@@ -73,7 +73,7 @@ async def main():
     myvar = await myobj.add_variable(idx, "MyVariable", 6.7)
     await myvar.set_writable()  # Set MyVariable to be writable by clients
     myarrayvar = await myobj.add_variable(idx, "myarrayvar", [6.7, 7.9])
-    await myobj.add_variable(idx, "myStronglytTypedVariable", ua.Variant([], ua.VariantType.UInt32))
+    await myobj.add_variable(idx, "myStronglyTypedVariable", ua.Variant([], ua.VariantType.UInt32))
     await myobj.add_property(idx, "myproperty", "I am a property")
     await myobj.add_method(idx, "mymethod", func, [ua.VariantType.Int64], [ua.VariantType.Boolean])
 

--- a/examples/sync/server-example.py
+++ b/examples/sync/server-example.py
@@ -1,10 +1,10 @@
-from threading import Thread
 import copy
 import logging
-from datetime import datetime
-import time
-from math import sin
 import sys
+import time
+from datetime import datetime, UTC
+from math import sin
+from threading import Thread
 
 sys.path.insert(0, "../..")
 
@@ -18,7 +18,6 @@ except ImportError:
         myvars.update(locals())
         shell = code.InteractiveConsole(myvars)
         shell.interact()
-
 
 from asyncua import ua, uamethod
 from asyncua.sync import Server, ThreadLoop
@@ -128,10 +127,10 @@ if __name__ == "__main__":
         myvar.set_writable()  # Set MyVariable to be writable by clients
         mystringvar = myobj.add_variable(idx, "MyStringVariable", "Really nice string")
         mystringvar.set_writable()  # Set MyVariable to be writable by clients
-        mydtvar = myobj.add_variable(idx, "MyDateTimeVar", datetime.utcnow())
+        mydtvar = myobj.add_variable(idx, "MyDateTimeVar", datetime.now(UTC))
         mydtvar.set_writable()  # Set MyVariable to be writable by clients
         myarrayvar = myobj.add_variable(idx, "myarrayvar", [6.7, 7.9])
-        myarrayvar = myobj.add_variable(idx, "myStronglytTypedVariable", ua.Variant([], ua.VariantType.UInt32))
+        myarrayvar = myobj.add_variable(idx, "myStronglyTypedVariable", ua.Variant([], ua.VariantType.UInt32))
         myprop = myobj.add_property(idx, "myproperty", "I am a property")
         mymethod = myobj.add_method(idx, "mymethod", func, [ua.VariantType.Int64], [ua.VariantType.Boolean])
         multiply_node = myobj.add_method(

--- a/examples/sync/server-example.py
+++ b/examples/sync/server-example.py
@@ -19,6 +19,7 @@ except ImportError:
         shell = code.InteractiveConsole(myvars)
         shell.interact()
 
+
 from asyncua import ua, uamethod
 from asyncua.sync import Server, ThreadLoop
 


### PR DESCRIPTION
datetime.datetime.utcnow() is deprecated.
So I use ".now(UTC)"" and "from datetime import datetime, UTC". And fix typos. Optimize imports