### PR TITLE
Parse ExtensionObjects with missing length (= -1)

### DIFF
--- a/asyncua/ua/ua_binary.py
+++ b/asyncua/ua/ua_binary.py
@@ -543,7 +543,10 @@ def extensionobject_from_binary(data: Buffer) -> ua.ExtensionObject:
     body = None
     if encoding & (1 << 0):
         length = Primitives.Int32.unpack(data)
-        if length < 1:
+        if length == -1:
+            # Interop fix for old OPC/UA implementations that fail to fill in the length
+            body = data
+        elif length < 1:
             body = Buffer(b"")
         else:
             body = data.copy(length)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -558,6 +558,22 @@ def test_unknown_extension_object():
     assert obj2.Body == b"example of data in custom format"
 
 
+def test_extension_object_missing_length():
+    obj = ua.DataChangeNotification()
+    binary = bytearray(extensionobject_to_binary(obj))
+
+    # Patch the binary to replace the correct length with -1 (i.e. missing),
+    # which some old OPC/UA implementations mistakenly do.
+    # Bytes 0-4 are the node ID, byte 4 is the encoding mask, so the length
+    # is bytes 5-8.
+    binary[5:9] = b'\xff\xff\xff\xff'
+
+    obj2 = extensionobject_from_binary(ua.utils.Buffer(bytes(binary)))
+    assert type(obj) is type(obj2)
+    assert obj.MonitoredItems == obj2.MonitoredItems
+    assert obj.DiagnosticInfos == obj2.DiagnosticInfos
+
+
 def test_datetime():
     now = datetime.now(timezone.utc)
     epch = ua.datetime_to_win_epoch(now)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -566,7 +566,7 @@ def test_extension_object_missing_length():
     # which some old OPC/UA implementations mistakenly do.
     # Bytes 0-4 are the node ID, byte 4 is the encoding mask, so the length
     # is bytes 5-8.
-    binary[5:9] = b'\xff\xff\xff\xff'
+    binary[5:9] = b"\xff\xff\xff\xff"
 
     obj2 = extensionobject_from_binary(ua.utils.Buffer(bytes(binary)))
     assert type(obj) is type(obj2)


### PR DESCRIPTION
Some old OPC/UA implementations omit the length when building ExtensionObjects and instead specify -1.  For interoperability, assume this means the rest of the buffer.  This behavior aligns with a [recent fix](https://github.com/OPCFoundation/UA-.NETStandard/commit/a887f909f1d314cfa7c32989628afa754984c4f1) to the [OPC Foundation's reference implementation](https://github.com/OPCFoundation/UA-.NETStandard).

I've added a UT (test_extension_object_missing_length), and confirmed that it fails before the fix and passes after... and confirmed that no other UTs have been broken.  This is the first time I've contributed to this repo, so please let me know if there's anything else I should do!

Fixes #1801