### PR TITLE
Avoid logging non-exceptional exception, and fix error in log format

### DIFF
--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -509,7 +509,8 @@ async def load_data_type_definitions(
             except NotImplementedError:
                 _logger.exception("Structure type %s not implemented", dts.sdef)
             except (AttributeError, RuntimeError):
-                _logger.exception("Failed to resolve datatypes", dts.sdef)
+                if log_ex:
+                    _logger.exception("Failed to resolve datatype %s", dts.sdef)
                 failed_types.append(dts)
         if not failed_types:
             break


### PR DESCRIPTION
If loading data types out of order it is expected to get an exception in `load_data_typ_definitions`. We shouldn't report this to the log file until we give up on loading types.

This also fixes an error in the log format string, which leads to an exception when logging.