### PR TITLE
ClientNonce and/or peer_certificate may be None

### DIFF
--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -203,10 +203,11 @@ class UaProcessor:
             response = ua.CreateSessionResponse()
             response.Parameters = sessiondata
             response.Parameters.ServerCertificate = self._connection.security_policy.host_certificate
-            if self._connection.security_policy.peer_certificate is None:
-                data = params.ClientNonce
-            else:
-                data = self._connection.security_policy.peer_certificate + params.ClientNonce
+            data = b""
+            if self._connection.security_policy.peer_certificate is not None:
+                data += self._connection.security_policy.peer_certificate
+            if params.ClientNonce is not None:
+                data += params.ClientNonce
             response.Parameters.ServerSignature.Signature = (
                 self._connection.security_policy.asymmetric_cryptography.signature(data)
             )


### PR DESCRIPTION
The ClientNonce and also the peer_certificate can be set to None, this fixes the resulting TypeError

```
Traceback (most recent call last):
  File "...\Python312-32\Lib\site-packages\asyncua\server\uaprocessor.py", line 147, in process_message
    return await self._process_message(typeid, requesthdr, seqhdr, body)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...\Python312-32\Lib\site-packages\asyncua\server\uaprocessor.py", line 213, in _process_message
    data = self._connection.security_policy.peer_certificate + params.ClientNonce
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
TypeError: can't concat NoneType to bytes
       ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
```

fixes #1821