### PR TITLE
Fix small bug if imported xml has also the stardard namespace included

### DIFF
--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -54,6 +54,14 @@ class XmlImporter:
         if not present the namespace is registered.
         """
         xml_uris = self.parser.get_used_namespaces()
+
+        # Check if first namespace is the standard namespace and
+        # drop it, to prevent the following code from failing and
+        # misplacing namespace index 1 (user namespace)
+        # to namespace index 0 (server namespace)
+        if xml_uris[0] == 'http://opcfoundation.org/UA/':
+            xml_uris.pop(0)
+
         server_uris = await self.session.get_namespace_array()
         namespaces_map = {}
         for ns_index, ns_uri in enumerate(xml_uris):


### PR DESCRIPTION
This minor adjustment resolves a bug that occurs when importing an XML file with the standard "http://opcfoundation.org/UA/" namespace. Without this fix, the subsequent code would incorrectly shift all namespaces one level deeper, resulting in the following changes:

Level 1 namespaces being treated as Level 0
Level 2 namespaces being treated as Level 1 and so on.