### PR TITLE
refactor!: custom-types are hidden under aliases on ua

### DIFF
--- a/asyncua/common/manage_nodes.py
+++ b/asyncua/common/manage_nodes.py
@@ -501,7 +501,7 @@ def _guess_datatype(variant: ua.Variant):
             extobj = variant.Value[0]
         else:
             extobj = variant.Value
-        classname = extobj.__class__.__name__
+        classname = extobj.__class__.__alias__ if hasattr(extobj.__class__, '__alias__') else extobj.__class__.__name__
         if hasattr(ua.ObjectIds, classname):
             return ua.NodeId(getattr(ua.ObjectIds, classname))
         if extobj.__class__ in ua.datatype_by_extension_object:

--- a/asyncua/common/structures104.py
+++ b/asyncua/common/structures104.py
@@ -515,6 +515,9 @@ async def load_data_type_definitions(server: Server | Client, base_node: Node = 
     Read DataTypeDefinition attribute on all Structure and Enumeration defined
     on server and generate Python objects in ua namespace to be used to talk with server
     """
+    # Disable backward compatibility
+    ua.uatypes.disable_backward_compatibility()
+    # Execute the expected data-type definition loading
     new_objects = await _load_base_datatypes(server)  # we need to load all basedatatypes alias first
     new_objects.update(await load_enums(server))  # we need all enums to generate structure code
     new_objects.update(await load_enums(server, server.nodes.option_set_type, True))  # also load all optionsets
@@ -544,6 +547,8 @@ async def load_data_type_definitions(server: Server | Client, base_node: Node = 
         if not failed_types:
             break
         dtypes = failed_types
+    # Enable backward compatibility
+    ua.uatypes.enable_backward_compatibility()
     return new_objects
 
 

--- a/asyncua/common/type_dictionary_builder.py
+++ b/asyncua/common/type_dictionary_builder.py
@@ -292,4 +292,4 @@ class StructNode:
 
 def get_ua_class(ua_class_name):
     # return getattr(ua, _to_camel_case(ua_class_name))
-    return getattr(ua, ua_class_name)
+    return ua.get_custom_struct_via_name(ua_class_name)

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -284,7 +284,6 @@ class XmlImporter:
                 nd.parentlink = reftype
 
     async def _add_node_data(self, nodedata, no_namespace_migration=False) -> ua.NodeId:
-        logging.info(f"PARSING {nodedata.displayname} with nodetype: {nodedata.nodetype}")
         if nodedata.nodetype == "UAObject":
             node = await self.add_object(nodedata, no_namespace_migration)
         elif nodedata.nodetype == "UAObjectType":
@@ -484,7 +483,7 @@ class XmlImporter:
             return struct
         # Try to find a perfect matching class
         if fields:
-            struct = ua.get_custom_struct_with_perfect_match(name, fields)
+            struct = ua.get_custom_struct_with_matching_fields(name, fields)
             if struct:
                 return struct
         # If this is not enough, we try to fetch by name
@@ -534,7 +533,7 @@ class XmlImporter:
             if field.name == attname:
                 return field.type
         raise UaError(f"Attribute '{attname}' defined in xml is not found in object '{objclass}'")
-    
+
     def _get_val_type_from_typehint(self, typehint, attname: str):
         return typehint[attname]
 
@@ -740,7 +739,6 @@ class XmlImporter:
         res = await self._get_server().add_nodes([node])
         res[0].StatusCode.check()
         await self._add_refs(obj)
-        logging.info(f"{self.auto_load_definitions} - {is_struct=} - {is_enum=} - {is_alias=} decided for {str(obj)}")
         if self.auto_load_definitions:
             if is_struct:
                 await load_custom_struct_xml_import(node.RequestedNewNodeId, attrs)

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -284,6 +284,7 @@ class XmlImporter:
                 nd.parentlink = reftype
 
     async def _add_node_data(self, nodedata, no_namespace_migration=False) -> ua.NodeId:
+        logging.info(f"PARSING {nodedata.displayname} with nodetype: {nodedata.nodetype}")
         if nodedata.nodetype == "UAObject":
             node = await self.add_object(nodedata, no_namespace_migration)
         elif nodedata.nodetype == "UAObjectType":
@@ -465,9 +466,32 @@ class XmlImporter:
         res[0].StatusCode.check()
         return res[0].AddedNodeId
 
-    def _get_ext_class(self, name: str):
+    def _get_ext_class(self, obj):
+        if hasattr(obj, "value"):
+            name = obj.value.objname
+            fields = []
+            if obj.value.body:
+                fields = [field_name for field_name, default_val in obj.value.body[0][1]]
+        else:
+            name = obj.objname
+            fields = None
+        # Check if the name is in ua
         if hasattr(ua, name):
             return getattr(ua, name)
+        # Else we try to fetch the custom type
+        struct = ua.get_custom_struct_via_nodeid(obj.nodeid)
+        if struct:
+            return struct
+        # Try to find a perfect matching class
+        if fields:
+            struct = ua.get_custom_struct_with_perfect_match(name, fields)
+            if struct:
+                return struct
+        # If this is not enough, we try to fetch by name
+        struct = ua.get_custom_struct_via_name(name)
+        if struct:
+            return struct
+        # Last try is through the alias
         if name in self.aliases.keys():
             nodeid = self.aliases[name]
             class_type = ua.uatypes.get_extensionobject_class_type(nodeid)
@@ -478,18 +502,19 @@ class XmlImporter:
 
     async def _make_ext_obj(self, obj):
         try:
-            extclass = self._get_ext_class(obj.objname)
+            extclass = self._get_ext_class(obj)
         except Exception as exp:
             if self.auto_load_definitions:
                 await (
                     self.session.load_data_type_definitions()
                 )  # load new data type definitions since a customn class should be created
-                extclass = self._get_ext_class(obj.objname)
+                extclass = self._get_ext_class(obj)
             else:
                 raise exp
         resolved_types = get_type_hints(extclass, {"ua": ua})
         args = {}
-        for name, val in obj.body:
+        to_iter = obj.value.body if hasattr(obj, 'value') else obj.body # case array
+        for name, val in to_iter:
             if not isinstance(val, list):
                 raise Exception(
                     "Error val should be a list, this is a python-asyncua bug",
@@ -509,6 +534,9 @@ class XmlImporter:
             if field.name == attname:
                 return field.type
         raise UaError(f"Attribute '{attname}' defined in xml is not found in object '{objclass}'")
+    
+    def _get_val_type_from_typehint(self, typehint, attname: str):
+        return typehint[attname]
 
     def _set_attr(self, atttype, fargs, attname: str, val):
         # tow possible values:
@@ -548,10 +576,17 @@ class XmlImporter:
             for attname2, v2 in val:
                 if attname2 != "EncodingMask":
                     # Skip Encoding Mask used for optional types
-                    resolved_sub_type = get_type_hints(atttype, {"ua": ua})
-                    sub_atttype = resolved_sub_type[attname2]
-                    # sub_atttype = self._get_val_type(atttype, attname2)
-                    self._set_attr(sub_atttype, subargs, attname2, v2)
+                    sub_atttype = self._get_val_type(atttype, attname2)
+                    try:
+                        self._set_attr(sub_atttype, subargs, attname2, v2)
+                    except AttributeError:
+                        # Some subtypes where not resolved yet!
+                        resolved_subtype = get_type_hints(atttype, {"ua": ua})
+                        sub_atttype = self._get_val_type_from_typehint(resolved_subtype, attname2)
+                        self._set_attr(sub_atttype, subargs, attname2, v2)
+
+
+
             subargs.pop("Encoding", None)
             fargs[attname] = atttype(**subargs)  # type: ignore[operator]
         else:
@@ -565,6 +600,8 @@ class XmlImporter:
         if obj.valuetype == "ListOfExtensionObject":
             values = []
             for ext in obj.value:
+                # Extend the value with parent nodeid type:
+                ext.nodeid = obj.nodeid
                 extobj = await self._make_ext_obj(ext)
                 values.append(extobj)
             return ua.Variant(values, ua.VariantType.ExtensionObject)
@@ -580,7 +617,7 @@ class XmlImporter:
                 return ua.Variant(obj.value)
             return ua.Variant([getattr(ua, vtype)(v) for v in obj.value])
         if obj.valuetype == "ExtensionObject":
-            extobj = await self._make_ext_obj(obj.value)
+            extobj = await self._make_ext_obj(obj)
             return ua.Variant(extobj, getattr(ua.VariantType, obj.valuetype))
         if obj.valuetype == "Guid":
             return ua.Variant(uuid.UUID(obj.value), getattr(ua.VariantType, obj.valuetype))
@@ -703,6 +740,7 @@ class XmlImporter:
         res = await self._get_server().add_nodes([node])
         res[0].StatusCode.check()
         await self._add_refs(obj)
+        logging.info(f"{self.auto_load_definitions} - {is_struct=} - {is_enum=} - {is_alias=} decided for {str(obj)}")
         if self.auto_load_definitions:
             if is_struct:
                 await load_custom_struct_xml_import(node.RequestedNewNodeId, attrs)

--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -160,6 +160,8 @@ class XmlImporter:
         """
         import xml and return added nodes
         """
+        # Disable backward compatibility
+        ua.uatypes.disable_backward_compatibility()
         if (xmlpath is None and xmlstring is None) or (xmlpath and xmlstring):
             raise ValueError("Expected either xmlpath or xmlstring, not both or neither.")
         _logger.info("Importing XML file %s", xmlpath)
@@ -199,6 +201,8 @@ class XmlImporter:
                 self.refs,
             )
         await self._check_if_namespace_meta_information_is_added()
+        # Enable backward compatibility
+        ua.uatypes.enable_backward_compatibility()
         return nodes
 
     async def _add_missing_reverse_references(self, new_nodes: list[Node]) -> set[Node]:

--- a/asyncua/ua/__init__.py
+++ b/asyncua/ua/__init__.py
@@ -6,8 +6,10 @@ from .status_codes import StatusCodes
 from .uaprotocol_auto import *
 from .uaprotocol_hand import *
 from .uatypes import *  # TODO: This should be renamed to uatypes_hand
+from .uatypes import get_extensionobject_class_type
 from .uaerrors import UaStatusCodeErrors
 import dataclasses
+from typing import Any
 
 import sys
 _current_module = sys.modules[__name__]
@@ -28,16 +30,15 @@ def delete_custom_struct_via_name(name: str):
             break
 
     del _current_module.__dict__[found_key]
-    logging.info(f"deleted {found_key}")
 
-def get_custom_struct_via_name(name: str) -> type | None:
+def get_custom_struct_via_name(name: str) -> Any | None:
     """Return the closest found custom struct for the given name
 
     Args:
         name (str): Name of the custom_struct
 
     Returns:
-        type: Associated class or None if nothing was found
+        Any | None: Associated class or None if nothing was found
 
     ..warning::
         It is not recommended to use this function because, in case of custom structs that
@@ -54,7 +55,16 @@ def get_custom_struct_via_name(name: str) -> type | None:
             return val
     return None
 
-def get_custom_struct_with_perfect_match(name: str, fields: list):
+def get_custom_struct_with_matching_fields(name: str, fields: list[str]) -> Any | None:
+    """Return the first found custom struct that matches the given name and list of fields
+
+    Args:
+        name (str): Name of the custom_struct
+        fields (list[str]): List of expected fields the custom struct should have.
+
+    Returns:
+        Any | None: The finding custom struct. Else None.
+    """
     found_classes = []
     for key, val in _current_module.__dict__.items():
         if name in key and name == val.__name__:
@@ -71,13 +81,13 @@ def get_custom_struct_with_perfect_match(name: str, fields: list):
             return clazz
     return None
 
-def get_custom_struct_via_nodeid(node_id: ObjectIds) -> type | None:
+def get_custom_struct_via_nodeid(node_id: ObjectIds) -> Any | None:
     """Return the custom struct associated to the node id
 
     Args:
         node_id (ObjectIds): NodeId
 
     Returns:
-        type | None: Class if found
+        Any | None: Class if found
     """
     return get_extensionobject_class_type(node_id)

--- a/asyncua/ua/__init__.py
+++ b/asyncua/ua/__init__.py
@@ -7,3 +7,77 @@ from .uaprotocol_auto import *
 from .uaprotocol_hand import *
 from .uatypes import *  # TODO: This should be renamed to uatypes_hand
 from .uaerrors import UaStatusCodeErrors
+import dataclasses
+
+import sys
+_current_module = sys.modules[__name__]
+
+def get_real(name):
+    if name in _current_module.__dict__:
+        return _current_module.__dict__[name]
+    return None
+
+def delete_custom_struct_via_name(name: str):
+    if name in _current_module.__dict__:
+        del _current_module.__dict__[name]
+    # substring fallback
+    found_key = None
+    for key, value in _current_module.__dict__.items():
+        if name in key and name == value.__name__:
+            found_key = key
+            break
+
+    del _current_module.__dict__[found_key]
+    logging.info(f"deleted {found_key}")
+
+def get_custom_struct_via_name(name: str) -> type | None:
+    """Return the closest found custom struct for the given name
+
+    Args:
+        name (str): Name of the custom_struct
+
+    Returns:
+        type: Associated class or None if nothing was found
+
+    ..warning::
+        It is not recommended to use this function because, in case of custom structs that
+        share the same name, only the first found will be returned.
+        Use instead `ua.get_custom_struct_via_nodeid`
+
+    """
+    # exact match
+    if name in _current_module.__dict__:
+        return _current_module.__dict__[name]
+    # substring fallback
+    for key, val in _current_module.__dict__.items():
+        if name in key and name == val.__name__:
+            return val
+    return None
+
+def get_custom_struct_with_perfect_match(name: str, fields: list):
+    found_classes = []
+    for key, val in _current_module.__dict__.items():
+        if name in key and name == val.__name__:
+            found_classes.append(val)
+
+    for clazz in found_classes:
+        clazz_fields = [field.name for field in dataclasses.fields(clazz)]
+        if set(clazz_fields) == set(fields):
+            return clazz
+    # If you reach here, no match was found. We now search for a dataclass that contains the fields
+    for clazz in found_classes:
+        clazz_fields = [field.name for field in dataclasses.fields(clazz)]
+        if set(fields).issubset(set(clazz_fields)):
+            return clazz
+    return None
+
+def get_custom_struct_via_nodeid(node_id: ObjectIds) -> type | None:
+    """Return the custom struct associated to the node id
+
+    Args:
+        node_id (ObjectIds): NodeId
+
+    Returns:
+        type | None: Class if found
+    """
+    return get_extensionobject_class_type(node_id)

--- a/asyncua/ua/ua_binary.py
+++ b/asyncua/ua/ua_binary.py
@@ -623,7 +623,7 @@ def extensionobject_to_binary(obj):
         encoding = 0
         body = None
     else:
-        name = obj.__class__.__alias__ if hasattr(obj.__class__, '__alias__') else obj.__class__.__name__ 
+        name = obj.__class__.__alias__ if hasattr(obj.__class__, '__alias__') else obj.__class__.__name__
         type_id = ua.extension_object_typeids[name]
         encoding = 0x01
         body = struct_to_binary(obj)

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -1288,6 +1288,33 @@ def get_extensionobject_class_type(typeid):
     return None
 
 
+def disable_backward_compatibility():
+    """Remove all backward compatibility so that it does not impact the node creation
+    """
+    for type_name in datatype_aliases:
+        import asyncua.ua
+        if hasattr(asyncua.ua, type_name):
+            delattr(asyncua.ua, type_name)
+
+
+def enable_backward_compatibility():
+    """Check all the custom types and create a simpled named for each of them
+    """
+    for type_name, list_of_alias_names in datatype_aliases.items():
+
+        import asyncua.ua
+
+        # Becaue there are no unregister function, we need to verify that the type
+        # is still available and was not manually deleted
+        compatible_type = None
+        for previously_register_type in list_of_alias_names:
+            if hasattr(asyncua.ua, previously_register_type):
+                compatible_type = getattr(asyncua.ua, previously_register_type)
+                break
+        if compatible_type:
+            setattr(asyncua.ua, type_name, compatible_type)
+
+
 class SecurityPolicyType(IntEnum):
     """
     The supported types of SecurityPolicy.

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -1236,6 +1236,12 @@ dataid_aliases: dict[str, list[str]] = {}
 def register_extension_object(name, encoding_nodeid, class_type, datatype_nodeid=None):
     """
     Register a new extension object for automatic decoding and make them available in ua module
+    over the following functions:
+
+    * :code:`ua.get_custom_struct_via_nodeid(nodeid)` is the preferred method
+    * :code:`ua.get_custom_struct_with_matching_fields('MyStruct', ['field_1', 'field_2'])`
+    * :code:`ua.get_custom_struct_via_nodeid('MyStruct')`
+
     """
     _logger.info(
         "registering new extension object: %s %s %s %s",
@@ -1269,7 +1275,6 @@ def register_extension_object(name, encoding_nodeid, class_type, datatype_nodeid
     import asyncua.ua
 
     setattr(asyncua.ua, new_name, class_type)
-    logging.info(f"Added {new_name} as custom_type")
 
 
 def get_extensionobject_class_type(typeid):
@@ -1279,10 +1284,6 @@ def get_extensionobject_class_type(typeid):
     if typeid in extension_objects_by_typeid:
         return extension_objects_by_typeid[typeid]
     if typeid in dataid_aliases:
-        # Small check to the unknown
-        if len(dataid_aliases[typeid]) > 1:
-            for val in dataid_aliases[typeid]:
-                logging.warning(f"{typeid} could be {val}")
         return extension_objects_by_typeid[dataid_aliases[typeid][0]]
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -133,7 +133,7 @@ async def server():
             new_struct_field("MyBool", ua.VariantType.Boolean),
             new_struct_field("MyUInt32", ua.VariantType.UInt32),
         ],
-    ) 
+    )
     await srv.load_data_type_definitions()
     fetched_struct = ua.uatypes.get_extensionobject_class_type(var_node.nodeid)
     await srv.nodes.objects.add_variable(idx, "my_struct", ua.Variant(fetched_struct(), ua.VariantType.ExtensionObject))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,14 +7,13 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import closing
 from multiprocessing import Condition, Event, Process
 from pathlib import Path
+
 import pytest
 
-from asyncua import Client
-from asyncua import Server, ua
-from asyncua.common.structures104 import new_struct, new_struct_field
-from asyncua.client.ua_client import UASocketProtocol
+from asyncua import Client, Server, ua
 from asyncua.client.ha.ha_client import HaClient, HaConfig, HaMode
 from asyncua.client.ua_client import UASocketProtocol
+from asyncua.common.structures104 import new_struct, new_struct_field
 from asyncua.server.history import HistoryDict
 from asyncua.server.history_sql import HistorySQLite
 

--- a/tests/test_alias_functionality.py
+++ b/tests/test_alias_functionality.py
@@ -1,0 +1,434 @@
+"""
+Tests for the __alias__ functionality that allows multiple datatypes
+with the same name to coexist
+"""
+
+import pytest
+
+from asyncua import Server, ua, uamethod
+from asyncua.common.structures104 import new_struct, new_struct_field
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_multiple_structs_same_name_different_fields(opc):
+    """
+    Test that multiple structs with the same name but different fields
+    can be registered and retrieved correctly using their NodeId
+    """
+    idx = 2
+
+    # Create first struct named "MyStruct" with specific fields
+    struct1_node, _ = await new_struct(
+        opc.opc,
+        idx,
+        "MyStruct",
+        [
+            new_struct_field("Field1", ua.VariantType.Int32),
+            new_struct_field("Field2", ua.VariantType.String),
+        ],
+    )
+
+    # Create second struct with the SAME name but different fields
+    struct2_node, _ = await new_struct(
+        opc.opc,
+        idx,
+        "MyStruct",
+        [
+            new_struct_field("Field1", ua.VariantType.Boolean),
+            new_struct_field("Field3", ua.VariantType.Double),
+            new_struct_field("Field4", ua.VariantType.UInt32),
+        ],
+    )
+
+    # Load the data type definitions
+    await opc.opc.load_data_type_definitions()
+
+    # Retrieve the structs by their NodeIds
+    struct1_class = ua.get_custom_struct_via_nodeid(struct1_node.nodeid)
+    struct2_class = ua.get_custom_struct_via_nodeid(struct2_node.nodeid)
+
+    # Verify they are different classes
+    assert struct1_class is not None
+    assert struct2_class is not None
+    assert struct1_class != struct2_class
+
+    # Verify both have __alias__ attribute
+    assert hasattr(struct1_class, '__alias__')
+    assert hasattr(struct2_class, '__alias__')
+
+    # Verify both have the same __name__ but different __alias__
+    assert struct1_class.__name__ == "MyStruct"
+    assert struct2_class.__name__ == "MyStruct"
+    assert struct1_class.__alias__ != struct2_class.__alias__
+
+    # Verify the structs have the correct fields
+    import dataclasses
+    struct1_fields = {f.name for f in dataclasses.fields(struct1_class)}
+    struct2_fields = {f.name for f in dataclasses.fields(struct2_class)}
+
+    assert "Field1" in struct1_fields
+    assert "Field2" in struct1_fields
+    assert "Field3" not in struct1_fields
+    assert "Field4" not in struct1_fields
+
+    assert "Field1" in struct2_fields
+    assert "Field2" not in struct2_fields
+    assert "Field3" in struct2_fields
+    assert "Field4" in struct2_fields
+
+    # Verify we can instantiate both structs
+    instance1 = struct1_class()
+    instance2 = struct2_class()
+
+    assert instance1 is not None
+    assert instance2 is not None
+
+    # Verify instances have correct fields
+    assert hasattr(instance1, 'Field1')
+    assert hasattr(instance1, 'Field2')
+    assert not hasattr(instance1, 'Field3')
+
+    assert hasattr(instance2, 'Field1')
+    assert hasattr(instance2, 'Field3')
+    assert hasattr(instance2, 'Field4')
+    assert not hasattr(instance2, 'Field2')
+
+
+async def test_alias_in_datatype_aliases_dict(opc):
+    """
+    Test that the datatype_aliases dictionary correctly tracks all aliases
+    """
+    idx = 3
+    struct_name = "SharedName"
+
+    # Create two structs with the same name
+    _, _ = await new_struct(
+        opc.opc,
+        idx,
+        struct_name,
+        [new_struct_field("X", ua.VariantType.Int32)],
+    )
+
+    _, _ = await new_struct(
+        opc.opc,
+        idx,
+        struct_name,
+        [new_struct_field("Y", ua.VariantType.String)],
+    )
+
+    await opc.opc.load_data_type_definitions()
+
+    # Check that datatype_aliases contains the shared name
+    assert struct_name in ua.datatype_aliases
+
+    # Check that there are at least 2 aliases registered for this name
+    aliases_list = ua.datatype_aliases[struct_name]
+    assert len(aliases_list) >= 2
+
+    # Verify each alias is accessible in the ua module
+    for alias in aliases_list:
+        assert hasattr(ua, alias), f"Alias {alias} not found in ua module"
+        struct_class = getattr(ua, alias)
+        assert struct_class.__name__ == struct_name
+
+
+async def test_backward_compatibility_mode(opc):
+    """
+    Test that backward compatibility mode works correctly with aliases
+    """
+    idx = 4
+    struct_name = "CompatTestStruct"
+
+    # Create a struct
+    struct_node, _ = await new_struct(
+        opc.opc,
+        idx,
+        struct_name,
+        [new_struct_field("Value", ua.VariantType.Int64)],
+    )
+
+    await opc.opc.load_data_type_definitions()
+
+    # Get the struct class via nodeid
+    struct_class = ua.get_custom_struct_via_nodeid(struct_node.nodeid)
+    assert struct_class is not None
+
+    # Verify the alias is properly set
+    assert hasattr(struct_class, '__alias__')
+    assert struct_class.__alias__ != struct_name
+
+    # Test that enabling backward compatibility makes the simple name available
+    ua.enable_backward_compatibility()
+
+    # The simple name should now be accessible (if it's the first/only one registered)
+    # Note: This might not work if multiple structs with same name exist
+    if hasattr(ua, struct_name):
+        simple_access = getattr(ua, struct_name)
+        assert simple_access is not None
+
+
+async def test_get_custom_struct_with_matching_fields(opc):
+    """
+    Test retrieving structs by name and fields when multiple structs share a name
+    """
+    idx = 5
+    struct_name = "MultiFieldStruct"
+
+    # Create first struct
+    await new_struct(
+        opc.opc,
+        idx,
+        struct_name,
+        [
+            new_struct_field("Alpha", ua.VariantType.Int32),
+            new_struct_field("Beta", ua.VariantType.String),
+        ],
+    )
+
+    # Create second struct with different fields
+    await new_struct(
+        opc.opc,
+        idx,
+        struct_name,
+        [
+            new_struct_field("Gamma", ua.VariantType.Double),
+            new_struct_field("Delta", ua.VariantType.Boolean),
+        ],
+    )
+
+    await opc.opc.load_data_type_definitions()
+
+    # Retrieve by matching fields
+    struct_alpha = ua.get_custom_struct_with_matching_fields(
+        struct_name, ["Alpha", "Beta"]
+    )
+    struct_gamma = ua.get_custom_struct_with_matching_fields(
+        struct_name, ["Gamma", "Delta"]
+    )
+
+    assert struct_alpha is not None
+    assert struct_gamma is not None
+    assert struct_alpha != struct_gamma
+
+    # Verify the fields match
+    import dataclasses
+    alpha_fields = {f.name for f in dataclasses.fields(struct_alpha)}
+    gamma_fields = {f.name for f in dataclasses.fields(struct_gamma)}
+
+    assert alpha_fields == {"Alpha", "Beta"}
+    assert gamma_fields == {"Gamma", "Delta"}
+
+
+async def test_alias_preserves_original_name(opc):
+    """
+    Test that the alias mechanism preserves the original struct name
+    """
+    idx = 6
+    original_name = "OriginalStructName"
+
+    struct_node, _ = await new_struct(
+        opc.opc,
+        idx,
+        original_name,
+        [new_struct_field("Data", ua.VariantType.UInt32)],
+    )
+
+    await opc.opc.load_data_type_definitions()
+
+    struct_class = ua.get_custom_struct_via_nodeid(struct_node.nodeid)
+
+    # The __name__ should still be the original name
+    assert struct_class.__name__ == original_name
+
+    # But __alias__ should be different (unique)
+    assert struct_class.__alias__ != original_name
+
+    # The alias should be accessible in the ua module
+    assert hasattr(ua, struct_class.__alias__)
+    assert getattr(ua, struct_class.__alias__) == struct_class
+
+
+async def test_multiple_structs_serialization(opc):
+    """
+    Test that structs with same name but different aliases serialize/deserialize correctly
+    """
+    idx = 7
+    struct_name = "SerializableStruct"
+
+    # Create two different structs with the same name
+    struct1_node, _ = await new_struct(
+        opc.opc,
+        idx,
+        struct_name,
+        [new_struct_field("IntValue", ua.VariantType.Int32)],
+    )
+
+    struct2_node, _ = await new_struct(
+        opc.opc,
+        idx,
+        struct_name,
+        [new_struct_field("StringValue", ua.VariantType.String)],
+    )
+
+    await opc.opc.load_data_type_definitions()
+
+    # Get the struct classes
+    struct1_class = ua.get_custom_struct_via_nodeid(struct1_node.nodeid)
+    struct2_class = ua.get_custom_struct_via_nodeid(struct2_node.nodeid)
+
+    # Create variables using these structs
+    instance1 = struct1_class()
+    instance1.IntValue = 42
+
+    instance2 = struct2_class()
+    instance2.StringValue = "test value"
+
+    # Create OPC UA variables
+    var1 = await opc.opc.nodes.objects.add_variable(
+        idx, "var_struct1", ua.Variant(instance1, ua.VariantType.ExtensionObject)
+    )
+
+    var2 = await opc.opc.nodes.objects.add_variable(
+        idx, "var_struct2", ua.Variant(instance2, ua.VariantType.ExtensionObject)
+    )
+
+    # Read back the values
+    read_val1 = await var1.read_value()
+    read_val2 = await var2.read_value()
+
+    # Verify the read values match what we wrote
+    assert read_val1.IntValue == 42
+    assert read_val2.StringValue == "test value"
+
+    # Verify they are instances of the correct classes
+    assert isinstance(read_val1, struct1_class)
+    assert isinstance(read_val2, struct2_class)
+    assert struct1_class != struct2_class
+
+
+async def test_two_servers_same_method_name_different_struct_parameters():
+    """
+    Test that two servers can have methods with the same name taking parameters
+    of custom types that share the same name but have different structures.
+    This is a critical test for the alias functionality in distributed systems.
+    """
+    # Create first server
+    server1 = Server()
+    await server1.init()
+    server1.set_endpoint("opc.tcp://127.0.0.1:48641")
+
+    # Register namespace and create custom struct for server1
+    ns1 = await server1.register_namespace("http://server1.example.com")
+    struct1_node, _ = await new_struct(
+        server1,
+        ns1,
+        "RequestData",
+        [
+            new_struct_field("UserId", ua.VariantType.Int32),
+            new_struct_field("Action", ua.VariantType.String),
+        ],
+    )
+    await server1.load_data_type_definitions()
+
+    # Get the struct class for server1
+    RequestData1 = ua.get_custom_struct_via_nodeid(struct1_node.nodeid)
+
+    # Define method for server1
+    @uamethod
+    def process_request_server1(parent, request):
+        """Server1's method - multiplies UserId by 10 and appends ' processed' to Action"""
+        result = RequestData1()
+        result.UserId = request.UserId * 10
+        result.Action = f"{request.Action} processed"
+        return result
+
+    # Add method to server1
+    await server1.nodes.objects.add_method(
+        ns1,
+        "ProcessRequest",
+        process_request_server1,
+        [RequestData1],
+        [RequestData1],
+    )
+
+    # Create second server
+    server2 = Server()
+    await server2.init()
+    server2.set_endpoint("opc.tcp://127.0.0.1:48642")
+
+    # Register namespace and create custom struct for server2 (same name, different structure)
+    ns2 = await server2.register_namespace("http://server2.example.com")
+    struct2_node, _ = await new_struct(
+        server2,
+        ns2,
+        "RequestData",
+        [
+            new_struct_field("ClientId", ua.VariantType.String),
+            new_struct_field("Priority", ua.VariantType.Int32),
+            new_struct_field("Data", ua.VariantType.Double),
+        ],
+    )
+    await server2.load_data_type_definitions()
+
+    # Get the struct class for server2
+    RequestData2 = ua.get_custom_struct_via_nodeid(struct2_node.nodeid)
+
+    # Define method for server2
+    @uamethod
+    def process_request_server2(parent, request):
+        """Server2's method - concatenates ClientId with Priority and doubles the Data"""
+        result = RequestData2()
+        result.ClientId = f"{request.ClientId}_{request.Priority}"
+        result.Priority = request.Priority + 100
+        result.Data = request.Data * 2.0
+        return result
+
+    # Add method to server2
+    await server2.nodes.objects.add_method(
+        ns2,
+        "ProcessRequest",
+        process_request_server2,
+        [RequestData2],
+        [RequestData2],
+    )
+
+    try:
+        # Start both servers
+        await server1.start()
+        await server2.start()
+
+        # Test server1's method
+        input1 = RequestData1()
+        input1.UserId = 5
+        input1.Action = "login"
+        method1 = await server1.nodes.objects.get_child([f"{ns1}:ProcessRequest"])
+        result1 = await server1.nodes.objects.call_method(method1, input1)
+        assert isinstance(result1, RequestData1)
+        assert result1.UserId == 50  # 5 * 10
+        assert result1.Action == "login processed"
+
+        # Test server2's method
+        input2 = RequestData2()
+        input2.ClientId = "CLIENT123"
+        input2.Priority = 5
+        input2.Data = 3.14
+        method2 = await server2.nodes.objects.get_child([f"{ns2}:ProcessRequest"])
+        result2 = await server2.nodes.objects.call_method(method2, input2)
+
+        assert isinstance(result2, RequestData2)
+        assert result2.ClientId == "CLIENT123_5"
+        assert result2.Priority == 105  # 5 + 100
+        assert result2.Data == 6.28  # 3.14 * 2
+
+        # Verify results are of different types
+        assert type(result1) is not type(result2)
+        # Verify that both aliases are registered in ua module
+        assert hasattr(ua, RequestData1.__alias__)
+        assert hasattr(ua, RequestData2.__alias__)
+        assert getattr(ua, RequestData1.__alias__) == RequestData1
+        assert getattr(ua, RequestData2.__alias__) == RequestData2
+    finally:
+        # Clean up
+        await server1.stop()
+        await server2.stop()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -13,6 +13,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from asyncua.ua import NodeId, String, NodeIdType, Int16
+import logging
 
 from asyncua import Node, ua, uamethod
 from asyncua.common import ua_utils
@@ -1288,22 +1290,26 @@ async def test_guid_node_id():
 
 
 async def test_import_xml_data_type_definition(opc):
-    if hasattr(ua, "MySubstruct"):
-        delattr(ua, "MySubstruct")
-    if hasattr(ua, "MyStruct"):
-        delattr(ua, "MyStruct")
+    logger_to_silence = logging.getLogger('asyncua.server.address_space')
+    logger_to_silence.setLevel('ERROR')
+
+    # Needed because when many test suites are running, residual types make the test fail
+    if ua.get_custom_struct_via_name("MySubstruct"):
+        ua.delete_custom_struct_via_name("MySubstruct")
+    if ua.get_custom_struct_via_name("MyStruct"):
+        ua.delete_custom_struct_via_name("MyStruct")
 
     nodes = await opc.opc.import_xml("tests/substructs.xml")
-    assert hasattr(ua, "MySubstruct")
-    assert hasattr(ua, "MyStruct")
+    assert ua.get_custom_struct_via_name("MySubstruct")
+    assert ua.get_custom_struct_via_name("MyStruct")
 
-    datatype = opc.opc.get_node(ua.MySubstruct.data_type)
+    datatype = opc.opc.get_node(ua.get_custom_struct_via_name("MyStruct").data_type)
     sdef = await datatype.read_data_type_definition()
     assert isinstance(sdef, ua.StructureDefinition)
-    s = ua.MyStruct()
+    s = ua.get_custom_struct_via_name("MyStruct")()
 
     s.toto = 0.1
-    ss = ua.MySubstruct()
+    ss = ua.get_custom_struct_via_name("MySubstruct")()
     assert ss.titi is None
     assert ss.opt_array is None
     assert isinstance(ss.structs, list)
@@ -1311,7 +1317,7 @@ async def test_import_xml_data_type_definition(opc):
     ss.structs.append(s)
     ss.structs.append(s)
 
-    var = await opc.opc.nodes.objects.add_variable(2, "MySubStructVar", ss, datatype=ua.MySubstruct.data_type)
+    var = await opc.opc.nodes.objects.add_variable(2, "MySubStructVar", ss, datatype=ua.get_custom_struct_via_name("MySubstruct").data_type)
 
     s2 = await var.read_value()
     assert s2.structs[1].toto == ss.structs[1].toto == 0.1
@@ -1328,12 +1334,12 @@ async def test_import_xml_data_type_definition(opc):
 
 async def test_import_xml_data_no_auto_load_type_definition(opc):
     # if al present in ua remove it (left overs of other tests)
-    if hasattr(ua, "MySubstruct"):
-        delattr(ua, "MySubstruct")
-    if hasattr(ua, "MyStruct"):
-        delattr(ua, "MyStruct")
-    if hasattr(ua, "MyEnum"):
-        delattr(ua, "MyEnum")
+    if ua.get_custom_struct_via_name("MySubstruct"):
+        ua.delete_custom_struct_via_name("MySubstruct")
+    if ua.get_custom_struct_via_name("MyStruct"):
+        ua.delete_custom_struct_via_name("MyStruct")
+    if ua.get_custom_struct_via_name("MyEnum"):
+        ua.delete_custom_struct_via_name("MyEnum")
     await opc.opc.import_xml("tests/substructs.xml", auto_load_definitions=False)
     assert hasattr(ua, "MySubstruct") is False
     assert hasattr(ua, "MyStruct") is False
@@ -1466,7 +1472,7 @@ async def test_custom_struct_(opc):
     )
 
     await opc.opc.load_data_type_definitions()
-    mystruct = ua.MyMyStruct()
+    mystruct = ua.get_custom_struct_via_name('MyMyStruct')()
     mystruct.MyUInt32 = [78, 79]
     var = await opc.opc.nodes.objects.add_variable(
         idx, "my_struct", ua.Variant(mystruct, ua.VariantType.ExtensionObject)
@@ -1492,7 +1498,7 @@ async def test_custom_struct_with_optional_fields(opc):
 
     await opc.opc.load_data_type_definitions()
 
-    my_struct_optional = ua.MyOptionalStruct()
+    my_struct_optional = ua.get_custom_struct_via_name('MyOptionalStruct')()
     assert my_struct_optional.MyBool is not None
     assert my_struct_optional.MyUInt32 is not None
     assert my_struct_optional.MyString is None
@@ -1511,7 +1517,7 @@ async def test_custom_struct_with_optional_fields(opc):
     assert val.MyInt64 == -67
     assert val.MyString is None
 
-    my_struct_optional = ua.MyOptionalStruct()
+    my_struct_optional = ua.get_custom_struct_via_name('MyOptionalStruct')()
     my_struct_optional.MyUInt32 = 45
     my_struct_optional.MyInt64 = -67
     my_struct_optional.MyString = "abc"
@@ -1535,7 +1541,7 @@ async def test_custom_struct_union(opc):
         is_union=True,
     )
     await opc.opc.load_data_type_definitions()
-    my_union = ua.MyUnionStruct()
+    my_union = ua.get_custom_struct_via_name('MyUnionStruct')()
     my_union.MyInt64 = 555
     var = await opc.opc.nodes.objects.add_variable(
         idx, "my_union_struct", ua.Variant(my_union, ua.VariantType.ExtensionObject)
@@ -1562,7 +1568,7 @@ async def test_custom_struct_union(opc):
         is_union=True,
     )
     await opc.opc.load_data_type_definitions()
-    my_union = ua.MyDuplicateTypeUnionStruct()
+    my_union = ua.get_custom_struct_via_name('MyDuplicateTypeUnionStruct')()
     my_union.MyInt64 = 555
     var = await opc.opc.nodes.objects.add_variable(
         idx,
@@ -1612,8 +1618,8 @@ async def test_custom_struct_of_struct(opc):
 
     await opc.opc.load_data_type_definitions()
 
-    mystruct = ua.MyMotherStruct2()
-    mystruct.MySubStruct = ua.MySubStruct2()
+    mystruct = ua.get_custom_struct_via_name('MyMotherStruct2')()
+    mystruct.MySubStruct = ua.get_custom_struct_via_name('MySubStruct2')()
     mystruct.MySubStruct.MyUInt32 = 78
     var = await opc.opc.nodes.objects.add_variable(idx, "my_mother_struct", mystruct)
     val = await var.read_value()
@@ -1645,8 +1651,8 @@ async def test_custom_list_of_struct(opc):
 
     await opc.opc.load_data_type_definitions()
 
-    mystruct = ua.MyMotherStruct3()
-    mystruct.MySubStruct = [ua.MySubStruct3()]
+    mystruct = ua.get_custom_struct_via_name('MyMotherStruct3')()
+    mystruct.MySubStruct = [ua.get_custom_struct_via_name('MyMotherStruct3')()]
     mystruct.MySubStruct[0].MyUInt32 = 78
     var = await opc.opc.nodes.objects.add_variable(
         idx, "my_mother_struct3", ua.Variant(mystruct, ua.VariantType.ExtensionObject)
@@ -1681,14 +1687,14 @@ async def test_custom_struct_with_enum(opc):
 
     await opc.opc.load_data_type_definitions()
 
-    mystruct = ua.MyStructEnum()
-    mystruct.MyEnum = ua.MyCustEnum2.tutu
+    mystruct = ua.get_custom_struct_via_name('MyStructEnum')()
+    mystruct.MyEnum = ua.get_custom_struct_via_name('MyCustEnum2').tutu
     var = await opc.opc.nodes.objects.add_variable(
         idx, "my_struct2", ua.Variant(mystruct, ua.VariantType.ExtensionObject)
     )
     val = await var.read_value()
-    assert val.MyEnum == ua.MyCustEnum2.tutu
-    assert isinstance(val.MyEnum, ua.MyCustEnum2)
+    assert val.MyEnum == ua.get_custom_struct_via_name('MyCustEnum2').tutu
+    assert isinstance(val.MyEnum, ua.get_custom_struct_via_name('MyCustEnum2'))
 
 
 async def test_nested_struct_arrays(opc):
@@ -1715,8 +1721,9 @@ async def test_nested_struct_arrays(opc):
 
     await opc.opc.load_data_type_definitions()
 
-    mystruct = ua.MyNestedStruct()
-    mystruct.MyStructArray = [ua.MyStruct4(), ua.MyStruct4()]
+    mystruct = ua.get_custom_struct_via_name('MyNestedStruct')()
+    mystruct.MyStructArray = [ua.get_custom_struct_via_name('MyStruct4')(), ua.get_custom_struct_via_name('MyStruct4')()]
+    mystruct.MyStructArray = [ua.get_custom_struct_via_name('MyStruct4')(), ua.get_custom_struct_via_name('MyStruct4')()]
     var = await opc.opc.nodes.objects.add_variable(idx, "nested", ua.Variant(mystruct, ua.VariantType.ExtensionObject))
     val = await var.read_value()
     assert len(val.MyStructArray) == 2
@@ -1799,10 +1806,10 @@ async def test_custom_struct_recursive(opc):
     assert sdef.Fields[0].Name == "Subparameters"
 
     # Check encoding / decoding
-    param = ua.MyParameterType(Value=2)
-    param.Subparameters.append(ua.MyParameterType(Value=1))
+    param = ua.get_custom_struct_via_name('MyParameterType')(Value=2)
+    param.Subparameters.append(ua.get_custom_struct_via_name('MyParameterType')(Value=1))
     bin = struct_to_binary(param)
-    res = struct_from_binary(ua.MyParameterType, ua.utils.Buffer(bin))
+    res = struct_from_binary(ua.get_custom_struct_via_name('MyParameterType'), ua.utils.Buffer(bin))
     assert param == res
 
     with expect_file_creation("custom_struct_recursive_export.xml") as path:
@@ -1858,8 +1865,8 @@ async def test_custom_struct_of_struct_with_spaces(opc):
 
     await opc.opc.load_data_type_definitions()
 
-    mystruct = ua.My_Mother_Struct()
-    mystruct.My_Sub_Struct = ua.My_Sub_Struct_1()
+    mystruct = ua.get_custom_struct_via_name('My_Mother_Struct')()
+    mystruct.My_Sub_Struct = ua.get_custom_struct_via_name('My_Sub_Struct_1')()
     mystruct.My_Sub_Struct.My_UInt32 = 78
     var = await opc.opc.nodes.objects.add_variable(idx, "my mother struct", mystruct)
     val = await var.read_value()
@@ -1890,11 +1897,11 @@ async def test_custom_method_with_struct(opc):
         ua.NodeId("ServerMethodWithStruct", 10),
         ua.QualifiedName("ServerMethodWithStruct", 10),
         func,
-        [ua.MyStructArg],
-        [ua.MyStructArg],
+        [ua.get_custom_struct_via_name('MyStructArg')],
+        [ua.get_custom_struct_via_name('MyStructArg')],
     )
 
-    mystruct = ua.MyStructArg()
+    mystruct = ua.get_custom_struct_via_name('MyStructArg')()
     mystruct.MyUInt32 = [78, 79]
 
     assert data_type.nodeid == mystruct.data_type
@@ -1920,25 +1927,25 @@ async def test_custom_method_with_enum(opc):
 
     @uamethod
     def func(parent, myenum1, myenum2, myenum3):
-        assert myenum1 == ua.MyCustEnumForMethod.titi
-        return ua.MyCustEnumForMethod.toto
+        assert myenum1 == ua.get_custom_struct_via_name('MyCustEnumForMethod').titi
+        return ua.get_custom_struct_via_name('MyCustEnumForMethod').toto
 
     methodid = await opc.server.nodes.objects.add_method(
         ua.NodeId("servermethodwithenum", 10),
         ua.QualifiedName("servermethodwithenum", 10),
         func,
-        [ua.MyCustEnumForMethod, enum_node, enum_node.nodeid],
-        [ua.MyCustEnumForMethod],
+        [ua.get_custom_struct_via_name('MyCustEnumForMethod'), enum_node, enum_node.nodeid],
+        [ua.get_custom_struct_via_name('MyCustEnumForMethod')],
     )
 
     result = await opc.opc.nodes.objects.call_method(
         methodid,
-        ua.MyCustEnumForMethod.titi,
-        ua.MyCustEnumForMethod.titi,
-        ua.MyCustEnumForMethod.titi,
+        ua.get_custom_struct_via_name('MyCustEnumForMethod').titi,
+        ua.get_custom_struct_via_name('MyCustEnumForMethod').titi,
+        ua.get_custom_struct_via_name('MyCustEnumForMethod').titi,
     )
 
-    assert result == ua.MyCustEnumForMethod.toto
+    assert result == ua.get_custom_struct_via_name('MyCustEnumForMethod').toto
 
 
 async def test_sub_class(opc):
@@ -2003,7 +2010,7 @@ async def test_alias(opc):
     val = await var.read_value()
     assert val == "1234"
 
-    v = ua.MyAliasStruct()
+    v = ua.get_custom_struct_via_name('MyAliasStruct')()
     var = await opc.opc.nodes.objects.add_variable(idx, "AliasedStruct", v, datatype=data_type.nodeid)
     val = await var.read_value()
     assert val == v
@@ -2027,7 +2034,7 @@ async def test_custom_struct_with_strange_chars(opc):
     )
 
     await opc.opc.load_data_type_definitions()
-    mystruct = ua.Siemens()
+    mystruct = ua.get_custom_struct_via_name('Siemens')()
     mystruct.My_UInt32 = [78, 79]
     mystruct.My_Bool = False
     var = await opc.opc.nodes.objects.add_variable(

--- a/tests/test_custom_structures.py
+++ b/tests/test_custom_structures.py
@@ -442,7 +442,7 @@ async def test_optionsets(srv):
             c.set_typeid(m.name, m.typeid.to_string())
     await srv.dict_builder.set_dict_byte_string()
     await srv.srv.load_type_definitions()
-    v = ua.ProcessValueType(name="XXX", id="YYY")
+    v = ua.get_custom_struct_via_name('ProcessValueType')(name="XXX", id="YYY")
     bitfield_var = await srv.srv.nodes.objects.add_variable(
         ua.NodeId(NamespaceIndex=srv.idx),
         "BitFieldSetsTest",
@@ -474,7 +474,8 @@ async def test_optionsets(srv):
     assert v == bit_res
     assert bit_res.description is not None
     assert bit_res.cavityId is not None
-    curved = ua.CurveDataType(Data=[ua.CurvePointDataType(0.1, 0.2), ua.CurvePointDataType(0.1, 0.2)])
+    CurvePointDataType = ua.get_custom_struct_via_name('CurvePointDataType')
+    curved = ua.get_custom_struct_via_name('CurveDataType')(Data=[CurvePointDataType(0.1, 0.2), CurvePointDataType(0.1, 0.2)])
     curved_var = await srv.srv.nodes.objects.add_variable(
         ua.NodeId(NamespaceIndex=srv.idx),
         "CurvePointDataType",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -897,3 +897,21 @@ async def test_start_server_when_port_is_in_use(server: Server):
         await server2.start()
     # now it should still be possible to stop the server with exceptions
     await server2.stop()
+
+async def test_conflicting_datastruct_resolution(server: Server, server_with_conflict_datastruct: Server):
+    """ Cross check if the stored variable is different depending on the server"""
+    # Define helper functions:
+    async def return_struct(srv: Server):
+        found_child = None
+        for child in await srv.nodes.objects.get_children():
+            if "my_struct" == (await child.read_browse_name()).Name:
+                found_child = child
+        if found_child:
+            return await found_child.read_value()
+
+    # Fetch parameter
+    param1 = await return_struct(server)
+    param2 = await return_struct(server_with_conflict_datastruct)
+    # We should have 2 different structure
+    assert param1 != param2
+ 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -908,10 +908,10 @@ async def test_conflicting_datastruct_resolution(server: Server, server_with_con
                 found_child = child
         if found_child:
             return await found_child.read_value()
+        return None
 
     # Fetch parameter
     param1 = await return_struct(server)
     param2 = await return_struct(server_with_conflict_datastruct)
     # We should have 2 different structure
     assert param1 != param2
- 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -291,7 +291,7 @@ def test_create_enum_sync_client(client):
 def test_create_struct_sync(server):
     idx = 4
 
-    new_struct(
+    var_node, _ = new_struct(
         server,
         idx,
         "MyMyStruct",
@@ -302,7 +302,7 @@ def test_create_struct_sync(server):
     )
 
     server.load_data_type_definitions()
-    mystruct = ua.MyMyStruct()
+    mystruct = ua.get_custom_struct_via_nodeid(var_node.nodeid)()
     mystruct.MyUInt32 = [78, 79]
     var = server.nodes.objects.add_variable(idx, "my_struct", mystruct)
     val = var.read_value()
@@ -312,7 +312,7 @@ def test_create_struct_sync(server):
 def test_create_struct_sync_client(client):
     idx = 4
 
-    new_struct(
+    var_node, _ = new_struct(
         client,
         idx,
         "MyMyStruct",
@@ -323,7 +323,7 @@ def test_create_struct_sync_client(client):
     )
 
     client.load_data_type_definitions()
-    mystruct = ua.MyMyStruct()
+    mystruct = ua.get_custom_struct_via_nodeid(var_node.nodeid)()
     mystruct.MyUInt32 = [78, 79]
     var = client.nodes.objects.add_variable(idx, "my_struct", mystruct)
     val = var.read_value()

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -291,6 +291,48 @@ def test_create_enum_sync_client(client):
 def test_create_struct_sync(server):
     idx = 4
 
+    new_struct(
+        server,
+        idx,
+        "MyMyStruct",
+        [
+            new_struct_field("MyBool", ua.VariantType.Boolean),
+            new_struct_field("MyUInt32", ua.VariantType.UInt32, array=True),
+        ],
+    )
+
+    server.load_data_type_definitions()
+    mystruct = ua.MyMyStruct()
+    mystruct.MyUInt32 = [78, 79]
+    var = server.nodes.objects.add_variable(idx, "my_struct", mystruct)
+    val = var.read_value()
+    assert val.MyUInt32 == [78, 79]
+
+
+def test_create_struct_sync_client(client):
+    idx = 4
+
+    new_struct(
+        client,
+        idx,
+        "MyMyStruct",
+        [
+            new_struct_field("MyBool", ua.VariantType.Boolean),
+            new_struct_field("MyUInt32", ua.VariantType.UInt32, array=True),
+        ],
+    )
+
+    client.load_data_type_definitions()
+    mystruct = ua.MyMyStruct()
+    mystruct.MyUInt32 = [78, 79]
+    var = client.nodes.objects.add_variable(idx, "my_struct", mystruct)
+    val = var.read_value()
+    assert val.MyUInt32 == [78, 79]
+
+
+def test_create_struct_sync_with_nodeid(server):
+    idx = 4
+
     var_node, _ = new_struct(
         server,
         idx,
@@ -309,7 +351,7 @@ def test_create_struct_sync(server):
     assert val.MyUInt32 == [78, 79]
 
 
-def test_create_struct_sync_client(client):
+def test_create_struct_sync_client_with_nodeid(client):
     idx = 4
 
     var_node, _ = new_struct(

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -659,7 +659,7 @@ async def test_xml_union(opc, tmpdir):
     o2 = opc.opc.get_node(new_nodes[0])
     assert o == o2
     await opc.opc.load_data_type_definitions()
-    t = ua.MyUnionStruct2()
+    t = ua.get_custom_struct_via_nodeid(o.nodeid)()
     t.MyString = "abc"
     assert t.MyString == "abc"
     assert t.MyInt64 is None
@@ -706,7 +706,7 @@ async def test_xml_struct_optional(opc, tmpdir):
     o2 = opc.opc.get_node(new_nodes[0])
     assert o == o2
     await opc.opc.load_data_type_definitions()
-    t = ua.MyOptionalStruct2()
+    t = ua.get_custom_struct_via_nodeid(o.nodeid)()
     t.MyInt64 = 5
     assert t.MyString is None
     assert t.MyInt64 == 5
@@ -724,10 +724,10 @@ async def test_xml_struct_with_value(opc, tmpdir):
     )
     await opc.opc.load_data_type_definitions()
     valnode = await opc.opc.nodes.objects.add_variable(
-        idx, "my_struct", ua.Variant(ua.MyStructWithValue(), ua.VariantType.ExtensionObject)
+        idx, "my_struct", ua.Variant(ua.get_custom_struct_via_nodeid(my_struct.nodeid)(), ua.VariantType.ExtensionObject)
     )
 
-    new_value = ua.MyStructWithValue()
+    new_value = ua.get_custom_struct_via_nodeid(my_struct.nodeid)()
     new_value.int_value = 14
     await valnode.write_value(ua.Variant(new_value, ua.VariantType.ExtensionObject))
 
@@ -766,10 +766,10 @@ async def test_xml_struct_in_struct_with_value(opc, tmpdir):
     )
     await opc.opc.load_data_type_definitions()
     valnode = await opc.opc.nodes.objects.add_variable(
-        idx, "my_outer_struct", ua.Variant(ua.MyOuterStruct(), ua.VariantType.ExtensionObject)
+        idx, "my_outer_struct", ua.Variant(ua.get_custom_struct_via_nodeid(outer_struct.nodeid)(), ua.VariantType.ExtensionObject)
     )
 
-    new_value = ua.MyOuterStruct()
+    new_value = ua.get_custom_struct_via_nodeid(outer_struct.nodeid)()
     new_value.inner_struct_value.int_value = 42
     await valnode.write_value(ua.Variant(new_value, ua.VariantType.ExtensionObject))
 

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -659,7 +659,7 @@ async def test_xml_union(opc, tmpdir):
     o2 = opc.opc.get_node(new_nodes[0])
     assert o == o2
     await opc.opc.load_data_type_definitions()
-    t = ua.get_custom_struct_via_nodeid(o.nodeid)()
+    t = ua.MyUnionStruct2()
     t.MyString = "abc"
     assert t.MyString == "abc"
     assert t.MyInt64 is None
@@ -706,7 +706,7 @@ async def test_xml_struct_optional(opc, tmpdir):
     o2 = opc.opc.get_node(new_nodes[0])
     assert o == o2
     await opc.opc.load_data_type_definitions()
-    t = ua.get_custom_struct_via_nodeid(o.nodeid)()
+    t = ua.MyOptionalStruct2()
     t.MyInt64 = 5
     assert t.MyString is None
     assert t.MyInt64 == 5
@@ -724,10 +724,10 @@ async def test_xml_struct_with_value(opc, tmpdir):
     )
     await opc.opc.load_data_type_definitions()
     valnode = await opc.opc.nodes.objects.add_variable(
-        idx, "my_struct", ua.Variant(ua.get_custom_struct_via_nodeid(my_struct.nodeid)(), ua.VariantType.ExtensionObject)
+        idx, "my_struct", ua.Variant(ua.MyStructWithValue(), ua.VariantType.ExtensionObject)
     )
 
-    new_value = ua.get_custom_struct_via_nodeid(my_struct.nodeid)()
+    new_value = ua.MyStructWithValue()
     new_value.int_value = 14
     await valnode.write_value(ua.Variant(new_value, ua.VariantType.ExtensionObject))
 
@@ -766,10 +766,10 @@ async def test_xml_struct_in_struct_with_value(opc, tmpdir):
     )
     await opc.opc.load_data_type_definitions()
     valnode = await opc.opc.nodes.objects.add_variable(
-        idx, "my_outer_struct", ua.Variant(ua.get_custom_struct_via_nodeid(outer_struct.nodeid)(), ua.VariantType.ExtensionObject)
+        idx, "my_outer_struct", ua.Variant(ua.MyOuterStruct(), ua.VariantType.ExtensionObject)
     )
 
-    new_value = ua.get_custom_struct_via_nodeid(outer_struct.nodeid)()
+    new_value = ua.MyOuterStruct()
     new_value.inner_struct_value.int_value = 42
     await valnode.write_value(ua.Variant(new_value, ua.VariantType.ExtensionObject))
 


### PR DESCRIPTION
In a nutshell, when a data-type is registered, it is registered on ua with a unique id _. The registered class has an __alias__ attribute too. Because, nodes are unique (at least per opcua namespeces), I can assign the right data-type to the right node.

I extended ua with 3 core methods that should be used to find any struct stored on ua:

get_custom_struct_via_nodeid() <- can be used like: ua.get_custom_struct_via_nodeid(await value_node.read_data_type())
get_custom_struct_with_perfect_match() <- that can be used get_custom_struct_with_perfect_match('MyStruct', ['field1', 'field2') that would return the structure that matches your name and contains the field names you need.
get_custom_struct_via_name() <- my least favorite, it returns the first struct that matches the given name.