### PR TITLE
Fixed type hint for EventNotificationHandler protocol

### DIFF
--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -58,7 +58,7 @@ class DataChangeNotificationHandler(Protocol):
 
 
 class EventNotificationHandler(Protocol):
-    def event_notification(self, event: ua.EventNotificationList) -> None:
+    def event_notification(self, event: Event) -> None:
         """
         called for every event notification from server
         """
@@ -82,7 +82,7 @@ class DataChangeNotificationHandlerAsync(Protocol):
 
 
 class EventNotificationHandlerAsync(Protocol):
-    async def event_notification(self, event: ua.EventNotificationList) -> None:
+    async def event_notification(self, event: Event) -> None:
         """
         called for every event notification from server
         """
@@ -131,7 +131,7 @@ class Subscription:
         self._client_handle = 200
         self._handler: SubscriptionHandler = handler
         self.parameters: ua.CreateSubscriptionParameters = params  # move to data class
-        self._monitored_items: dict[int,SubscriptionItemData] = {}
+        self._monitored_items: dict[int, SubscriptionItemData] = {}
         self.subscription_id: int | None = None
 
     async def init(self) -> ua.CreateSubscriptionResult:


### PR DESCRIPTION
Here it's quite clear that the type hint for the event_notification method should be Event:

https://github.com/FreeOpcUa/opcua-asyncio/blob/b6a4a18d16c059eeeb5a21818bcd10540d04ddfb/asyncua/common/subscription.py#L203-L212
