### PR TITLE
Use iscoroutinefunction method from inspect module

### DIFF
--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -4,6 +4,7 @@ Low level binary client
 
 import asyncio
 import copy
+import inspect
 import logging
 from collections.abc import Awaitable, Callable
 
@@ -563,7 +564,7 @@ class UaClient(AbstractSession):
         for subid, callback in self._subscription_callbacks.items():
             try:
                 parameters = ua.PublishResult(subid, NotificationMessage=notification_message)
-                if asyncio.iscoroutinefunction(callback):
+                if inspect.iscoroutinefunction(callback):
                     await callback(parameters)
                 else:
                     callback(parameters)
@@ -657,7 +658,7 @@ class UaClient(AbstractSession):
                 )
             else:
                 try:
-                    if asyncio.iscoroutinefunction(callback):
+                    if inspect.iscoroutinefunction(callback):
                         await callback(response.Parameters)
                     else:
                         callback(response.Parameters)

--- a/asyncua/common/callback.py
+++ b/asyncua/common/callback.py
@@ -2,7 +2,7 @@
 server side implementation of callback event
 """
 
-import asyncio
+import inspect
 from collections import OrderedDict
 from enum import Enum
 
@@ -68,7 +68,7 @@ class CallbackService:
         return event
 
     async def call_listener(self, event, listener):
-        if asyncio.iscoroutinefunction(listener):
+        if inspect.iscoroutinefunction(listener):
             await listener(event, self)
         else:
             listener(event, self)

--- a/asyncua/common/methods.py
+++ b/asyncua/common/methods.py
@@ -4,7 +4,7 @@ High level method related functions
 
 from __future__ import annotations
 
-from asyncio import iscoroutinefunction
+import inspect
 from collections.abc import Iterable
 from functools import wraps
 from typing import Any
@@ -79,7 +79,7 @@ def uamethod(func):
     arguments and output to and from variants
     """
 
-    if iscoroutinefunction(func):
+    if inspect.iscoroutinefunction(func):
 
         @wraps(func)
         async def wrapper(parent, *args):

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import collections.abc
+import inspect
 import logging
 from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Protocol, overload
@@ -189,7 +190,7 @@ class Subscription:
 
         try:
             tasks = [self._handler.datachange_notification(*args) for args in known_handles_args]
-            if asyncio.iscoroutinefunction(self._handler.datachange_notification):
+            if inspect.iscoroutinefunction(self._handler.datachange_notification):
                 await asyncio.gather(*tasks)
         except Exception as ex:
             self.logger.exception("Exception calling data change handler. Error: %s", ex)
@@ -204,7 +205,7 @@ class Subscription:
             result.server_handle = data.server_handle
             if hasattr(self._handler, "event_notification"):
                 try:
-                    if asyncio.iscoroutinefunction(self._handler.event_notification):
+                    if inspect.iscoroutinefunction(self._handler.event_notification):
                         await self._handler.event_notification(result)
                     else:
                         self._handler.event_notification(result)
@@ -218,7 +219,7 @@ class Subscription:
             self.logger.error("DataChange subscription has no status_change_notification method")
             return
         try:
-            if asyncio.iscoroutinefunction(self._handler.status_change_notification):
+            if inspect.iscoroutinefunction(self._handler.status_change_notification):
                 await self._handler.status_change_notification(status)
             else:
                 self._handler.status_change_notification(status)

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import collections.abc
 import dataclasses
+import inspect
 import logging
 import pickle
 import shelve
@@ -617,7 +618,7 @@ class MethodService:
         return res
 
     async def _run_method(self, func, parent, *args):
-        if asyncio.iscoroutinefunction(func):
+        if inspect.iscoroutinefunction(func):
             return await func(parent, *args)
         p = partial(func, parent, *args)
         res = await asyncio.get_event_loop().run_in_executor(self._pool, p)
@@ -788,7 +789,7 @@ class AddressSpace:
             dv = ua.DataValue(StatusCode=ua.StatusCode(ua.StatusCodes.BadAttributeIdInvalid))
             return dv
         attval = node.attributes[attr]
-        # TODO: async support by using asyncio.iscoroutinefunction()
+        # TODO: async support by using inspect.iscoroutinefunction()
         if attval.value_callback:
             return attval.value_callback(nodeid, attr)
         return attval.value  # type: ignore[return-value] # .value must be filled


### PR DESCRIPTION
The `asyncio.iscoroutinefunction` method was deprecated in python 3.14. `inspect.iscoroutinefunction` should be used instead, and was added in py 3.5, so it's compatible with all supported versions.

I noticed this while testing a project with the 1.2 beta release and py 3.14, which generated the warning 100s of times.

Might be sensible to [turn warnings into errors with pytest](https://docs.pytest.org/en/latest/how-to/capture-warnings.html#controlling-warnings) to pick up deprecations early.