### PR TITLE
resilient reconnect and recovery

### DIFF
--- a/asyncua/client/__init__.py
+++ b/asyncua/client/__init__.py
@@ -1,1 +1,3 @@
 from .client import Client
+from .ua_client import UaClient
+from .ua_session import UaSession

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -357,7 +357,7 @@ class Client:
                 self.disconnect_socket()
         return servers
 
-    async def connect_and_find_servers_on_network(self) -> list[ua.FindServersOnNetworkResult]:
+    async def connect_and_find_servers_on_network(self) -> ua.FindServersOnNetworkResult:
         """
         Connect, ask server for a list of known servers on network, and disconnect
         """
@@ -492,7 +492,7 @@ class Client:
             self.secure_channel_timeout = result.SecurityToken.RevisedLifetime
 
     async def close_secure_channel(self):
-        return await self.uaclient.close_secure_channel()
+        await self.uaclient.close_secure_channel()
 
     async def get_endpoints(self) -> list[ua.EndpointDescription]:
         """Get a list of OPC-UA endpoints."""
@@ -519,8 +519,9 @@ class Client:
             params = ua.RegisterServer2Parameters()
             params.Server = serv
             params.DiscoveryConfiguration = discovery_configuration
-            return await self.uaclient.register_server2(params)
-        return await self.uaclient.register_server(serv)
+            await self.uaclient.register_server2(params)
+            return
+        await self.uaclient.register_server(serv)
 
     async def unregister_server(
         self, server: "asyncua.server.Server", discovery_configuration: ua.DiscoveryConfiguration | None = None
@@ -540,8 +541,9 @@ class Client:
             params = ua.RegisterServer2Parameters()
             params.Server = serv
             params.DiscoveryConfiguration = discovery_configuration
-            return await self.uaclient.unregister_server2(params)
-        return await self.uaclient.unregister_server(serv)
+            await self.uaclient.unregister_server2(params)
+            return
+        await self.uaclient.unregister_server(serv)
 
     async def find_servers(self, uris: Iterable[str] | None = None) -> list[ua.ApplicationDescription]:
         """
@@ -556,7 +558,7 @@ class Client:
         params.ServerUris = list(uris)
         return await self.uaclient.find_servers(params)
 
-    async def find_servers_on_network(self) -> list[ua.FindServersOnNetworkResult]:
+    async def find_servers_on_network(self) -> ua.FindServersOnNetworkResult:
         params = ua.FindServersOnNetworkParameters()
         return await self.uaclient.find_servers_on_network(params)
 

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -1,8 +1,9 @@
 import asyncio
 import dataclasses
+import inspect
 import logging
 import socket
-from collections.abc import Callable, Coroutine, Iterable, Sequence
+from collections.abc import Awaitable, Callable, Coroutine, Iterable, Sequence
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import ParseResult, unquote, urlparse
@@ -25,7 +26,7 @@ from ..common.xmlexporter import XmlExporter
 from ..common.xmlimporter import XmlImporter
 from ..crypto import security_policies, uacrypto
 from ..crypto.validator import CertificateValidatorMethod
-from .ua_client import UaClient
+from .ua_client import SubscriptionStaleError, UaClient
 
 _logger = logging.getLogger(__name__)
 
@@ -44,7 +45,7 @@ class Client:
     _password: str | None = None
     strip_url_credentials: bool = True
 
-    def __init__(self, url: str, timeout: float = 4, watchdog_intervall: float = 1.0) -> None:
+    def __init__(self, url: str, timeout: float = 4, watchdog_intervall: float = 1.0):
         """
         :param url: url of the server.
             if you are unsure of url, write at least hostname
@@ -77,7 +78,8 @@ class Client:
         self.secure_channel_id = None
         self.secure_channel_timeout = 3600000  # 1 hour
         self.session_timeout = 3600000  # 1 hour
-        self.connection_lost_callback: Callable[[Exception], Coroutine[Any, Any, None]] | None = None
+        self.connection_lost_callback: Callable[[Exception], Awaitable[None] | None] | None = None
+        self.on_reconnected: Callable[[], Coroutine[Any, Any, None]] | None = None
         self._policy_ids: list[ua.UserTokenPolicy] = []
         self.uaclient: UaClient = UaClient(timeout)
         self.uaclient.pre_request_hook = self.check_connection
@@ -85,6 +87,7 @@ class Client:
         self.user_private_key: PrivateKeyTypes | None = None
         self.user_certificate_chain: list[x509.Certificate] = []
         self._server_nonce = None
+        self._session_authentication_token: ua.NodeId | None = None
         self._session_counter = 1
         self.nodes: Shortcuts = Shortcuts(self.uaclient)
         self.max_messagesize = 0  # No limits
@@ -93,20 +96,55 @@ class Client:
         self._monitor_server_task = None
         self._locale = ["en"]
         self._watchdog_intervall = watchdog_intervall
-        self._closing: bool = False
+        self._reconnect_task: asyncio.Task | None = None
+        self._reconnect_lock = asyncio.Lock()
+        self._reconnect_event = asyncio.Event()
+        self._managed_subscriptions: set[Subscription] = set()
+        self._managed_subscriptions_by_id: dict[int, Subscription] = {}
+        self._stale_recovery_attempted_subscriptions: set[Subscription] = set()
+        self.reconnect_enabled: bool = False
+        self.auto_recreate_invalid_subscriptions: bool = False
+        self.reconnect_initial_delay: float = 1.0
+        self.reconnect_max_delay: float = 30.0
+        self.reconnect_max_retries: int | None = None
+        self.reconnect_request_timeout: float = timeout
         self.certificate_validator: CertificateValidatorMethod | None = None
         """hook to validate a certificate, raises a ServiceError when not valid"""
 
-    async def __aenter__(self) -> "Client":
+    def _set_state(self, state: UaClient.CONNECTION_STATE) -> None:
+        if not self.uaclient.try_set_connection_state(state):
+            self._reconnect_event.clear()
+            return
+        if state == UaClient.CONNECTION_STATE.SESSION_READY:
+            self._reconnect_event.set()
+        else:
+            self._reconnect_event.clear()
+        return
+
+    def _is_disconnect_requested(self) -> bool:
+        return self.uaclient.connection_state == UaClient.CONNECTION_STATE.DISCONNECTING
+
+    def _index_managed_subscription(self, subscription: Subscription) -> None:
+        subscription_id = subscription.subscription_id
+        if subscription_id is None:
+            return
+        self._managed_subscriptions_by_id[int(subscription_id)] = subscription
+
+    def _refresh_managed_subscription_index(self) -> None:
+        self._managed_subscriptions_by_id = {
+            int(subscription.subscription_id): subscription
+            for subscription in self._managed_subscriptions
+            if subscription.subscription_id is not None
+        }
+
+    async def __aenter__(self):
         await self.connect()
         return self
 
-    async def __aexit__(
-        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: Any
-    ) -> None:
+    async def __aexit__(self, exc_type, exc_value, traceback):
         await self.disconnect()
 
-    def __str__(self) -> str:
+    def __str__(self):
         return f"Client({self.server_url.geturl()})"
 
     __repr__ = __str__
@@ -289,48 +327,51 @@ class Client:
         """
         Connect, ask server for endpoints, and disconnect
         """
-        await self.connect_socket()
-        try:
-            await self.send_hello()
-            await self.open_secure_channel()
+        async with self.uaclient.internal_service_calls():
+            await self.connect_socket()
             try:
-                endpoints = await self.get_endpoints()
+                await self.send_hello()
+                await self.open_secure_channel()
+                try:
+                    endpoints = await self.get_endpoints()
+                finally:
+                    await self.close_secure_channel()
             finally:
-                await self.close_secure_channel()
-        finally:
-            self.disconnect_socket()
+                self.disconnect_socket()
         return endpoints
 
     async def connect_and_find_servers(self) -> list[ua.ApplicationDescription]:
         """
         Connect, ask server for a list of known servers, and disconnect
         """
-        await self.connect_socket()
-        try:
-            await self.send_hello()
-            await self.open_secure_channel()  # spec says it should not be necessary to open channel
+        async with self.uaclient.internal_service_calls():
+            await self.connect_socket()
             try:
-                servers = await self.find_servers()
+                await self.send_hello()
+                await self.open_secure_channel()  # spec says it should not be necessary to open channel
+                try:
+                    servers = await self.find_servers()
+                finally:
+                    await self.close_secure_channel()
             finally:
-                await self.close_secure_channel()
-        finally:
-            self.disconnect_socket()
+                self.disconnect_socket()
         return servers
 
-    async def connect_and_find_servers_on_network(self) -> ua.FindServersOnNetworkResult:
+    async def connect_and_find_servers_on_network(self) -> list[ua.FindServersOnNetworkResult]:
         """
         Connect, ask server for a list of known servers on network, and disconnect
         """
-        await self.connect_socket()
-        try:
-            await self.send_hello()
-            await self.open_secure_channel()
+        async with self.uaclient.internal_service_calls():
+            await self.connect_socket()
             try:
-                servers = await self.find_servers_on_network()
+                await self.send_hello()
+                await self.open_secure_channel()
+                try:
+                    servers = await self.find_servers_on_network()
+                finally:
+                    await self.close_secure_channel()
             finally:
-                await self.close_secure_channel()
-        finally:
-            self.disconnect_socket()
+                self.disconnect_socket()
         return servers
 
     async def connect(self) -> None:
@@ -339,20 +380,15 @@ class Client:
         Connect, create and activate session
         """
         _logger.info("connect")
+        self.uaclient.pre_request_hook = None
+        self._set_state(UaClient.CONNECTION_STATE.SESSION_ESTABLISHING)
         await self.connect_socket()
         try:
             await self.send_hello()
             await self.open_secure_channel()
             try:
-                await self.create_session()
-                try:
-                    await self.activate_session(
-                        username=self._username, password=self._password, certificate=self.user_certificate
-                    )
-                except Exception:
-                    # clean up session
-                    await self.close_session()
-                    raise
+                async with self.uaclient.internal_service_calls():
+                    await self.try_restore_state()
             except Exception:
                 # clean up secure channel
                 await self.close_secure_channel()
@@ -360,7 +396,11 @@ class Client:
         except Exception:
             # clean up open socket
             self.disconnect_socket()
+            self._set_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+            self.uaclient.pre_request_hook = self.check_connection
             raise
+        self.uaclient.pre_request_hook = self.check_connection
+        self._set_state(UaClient.CONNECTION_STATE.SESSION_READY)
 
     async def connect_sessionless(self) -> None:
         """
@@ -368,14 +408,15 @@ class Client:
         Connect without a session
         """
         _logger.info("connect")
-        await self.connect_socket()
-        try:
-            await self.send_hello()
-            await self.open_secure_channel()
-        except Exception:
-            # clean up open socket
-            self.disconnect_socket()
-            raise
+        async with self.uaclient.internal_service_calls():
+            await self.connect_socket()
+            try:
+                await self.send_hello()
+                await self.open_secure_channel()
+            except Exception:
+                # clean up open socket
+                self.disconnect_socket()
+                raise
 
     async def disconnect(self) -> None:
         """
@@ -383,11 +424,20 @@ class Client:
         Close session, secure channel and socket
         """
         _logger.info("disconnect")
+        self._set_state(UaClient.CONNECTION_STATE.DISCONNECTING)
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+            try:
+                await self._reconnect_task
+            except (asyncio.CancelledError, Exception):
+                pass
         try:
-            await self.close_session()
-            await self.close_secure_channel()
+            async with self.uaclient.internal_service_calls():
+                await self.close_session()
+                await self.close_secure_channel()
         finally:
             self.disconnect_socket()
+            self._set_state(UaClient.CONNECTION_STATE.DISCONNECTED)
 
     async def disconnect_sessionless(self) -> None:
         """
@@ -441,7 +491,7 @@ class Client:
             )
             self.secure_channel_timeout = result.SecurityToken.RevisedLifetime
 
-    async def close_secure_channel(self) -> None:
+    async def close_secure_channel(self):
         return await self.uaclient.close_secure_channel()
 
     async def get_endpoints(self) -> list[ua.EndpointDescription]:
@@ -469,8 +519,8 @@ class Client:
             params = ua.RegisterServer2Parameters()
             params.Server = serv
             params.DiscoveryConfiguration = discovery_configuration
-            await self.uaclient.register_server2(params)
-        await self.uaclient.register_server(serv)
+            return await self.uaclient.register_server2(params)
+        return await self.uaclient.register_server(serv)
 
     async def unregister_server(
         self, server: "asyncua.server.Server", discovery_configuration: ua.DiscoveryConfiguration | None = None
@@ -490,8 +540,8 @@ class Client:
             params = ua.RegisterServer2Parameters()
             params.Server = serv
             params.DiscoveryConfiguration = discovery_configuration
-            await self.uaclient.unregister_server2(params)
-        await self.uaclient.unregister_server(serv)
+            return await self.uaclient.unregister_server2(params)
+        return await self.uaclient.unregister_server(serv)
 
     async def find_servers(self, uris: Iterable[str] | None = None) -> list[ua.ApplicationDescription]:
         """
@@ -506,7 +556,7 @@ class Client:
         params.ServerUris = list(uris)
         return await self.uaclient.find_servers(params)
 
-    async def find_servers_on_network(self) -> ua.FindServersOnNetworkResult:
+    async def find_servers_on_network(self) -> list[ua.FindServersOnNetworkResult]:
         params = ua.FindServersOnNetworkParameters()
         return await self.uaclient.find_servers_on_network(params)
 
@@ -516,7 +566,6 @@ class Client:
         If you want to modify settings look at code of these methods
         and make your own
         """
-        self._closing = False
         desc = ua.ApplicationDescription()
         desc.ApplicationUri = self.application_uri
         desc.ProductUri = self.product_uri
@@ -540,6 +589,8 @@ class Client:
         params.RequestedSessionTimeout = self.session_timeout
         params.MaxResponseMessageSize = 0  # means no max size
         response = await self.uaclient.create_session(params)
+        self._session_authentication_token = response.AuthenticationToken
+        self._session_counter += 1
         if self.security_policy.host_certificate is None:
             data = nonce
         else:
@@ -579,30 +630,247 @@ class Client:
                 response.RevisedSessionTimeout,
             )
             self.session_timeout = response.RevisedSessionTimeout
-        self._renew_channel_task = asyncio.create_task(self._renew_channel_loop())
-        self._monitor_server_task = asyncio.create_task(self._monitor_server_loop())
+        self._ensure_background_tasks_running()
         return response
+
+    def _ensure_background_tasks_running(self) -> None:
+        if self._renew_channel_task is None or self._renew_channel_task.done():
+            self._renew_channel_task = asyncio.create_task(self._renew_channel_loop())
+        if self._monitor_server_task is None or self._monitor_server_task.done():
+            self._monitor_server_task = asyncio.create_task(self._monitor_server_loop())
+
+    async def try_restore_state(self) -> None:
+        subscription_ids = self.uaclient.get_subscription_ids()
+        expected_sequences = {
+            subscription_id: self.uaclient.get_next_sequence_number(subscription_id)
+            for subscription_id in subscription_ids
+        }
+
+        reused_existing_session, invalid_transfer_subscription_ids = await self._create_or_recover_session(
+            subscription_ids
+        )
+
+        await self._recover_subscriptions(
+            subscription_ids,
+            expected_sequences,
+            reused_existing_session,
+            invalid_transfer_subscription_ids,
+        )
+
+    async def _create_or_recover_session(self, subscription_ids: list[int]) -> tuple[bool, set[int]]:
+        reused_existing_session = await self._try_reuse_existing_session()
+        if reused_existing_session:
+            return True, set()
+
+        invalid_transfer_subscription_ids = await self._create_new_session_and_transfer_subscriptions(subscription_ids)
+        return False, invalid_transfer_subscription_ids
+
+    async def _try_reuse_existing_session(self) -> bool:
+        if self._session_authentication_token is None or self.uaclient.protocol is None:
+            return False
+
+        self.uaclient.protocol.authentication_token = self._session_authentication_token
+        try:
+            await self.activate_session(
+                username=self._username,
+                password=self._password,
+                certificate=self.user_certificate,
+            )
+            return True
+        except Exception:
+            _logger.info("ActivateSession on existing session failed, creating a new session")
+            return False
+
+    async def _create_new_session_and_transfer_subscriptions(self, subscription_ids: list[int]) -> set[int]:
+        invalid_transfer_subscription_ids: set[int] = set()
+
+        await self.create_session()
+        try:
+            await self.activate_session(
+                username=self._username,
+                password=self._password,
+                certificate=self.user_certificate,
+            )
+        except Exception:
+            await self.close_session()
+            raise
+
+        if not subscription_ids:
+            return invalid_transfer_subscription_ids
+
+        transfer = ua.TransferSubscriptionsParameters()
+        transfer.SubscriptionIds = subscription_ids
+        transfer.SendInitialValues = False
+        transfer_results = await self.uaclient.transfer_subscriptions(transfer)
+        for subscription_id, transfer_result in zip(subscription_ids, transfer_results):
+            if not transfer_result.StatusCode.is_good():
+                _logger.warning(
+                    "TransferSubscriptions failed for subscription %s with status %s",
+                    subscription_id,
+                    transfer_result.StatusCode,
+                )
+                if transfer_result.StatusCode.value == ua.StatusCodes.BadSubscriptionIdInvalid:
+                    invalid_transfer_subscription_ids.add(subscription_id)
+        return invalid_transfer_subscription_ids
+
+    async def _cancel_background_tasks(self, disable_pre_hook: bool = False) -> None:
+        if self._monitor_server_task:
+            if not self._monitor_server_task.done():
+                self._monitor_server_task.cancel()
+            try:
+                await self._monitor_server_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._monitor_server_task = None
+        if disable_pre_hook:
+            self.uaclient.pre_request_hook = None
+        if self._renew_channel_task:
+            if not self._renew_channel_task.done():
+                self._renew_channel_task.cancel()
+            try:
+                await self._renew_channel_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._renew_channel_task = None
 
     async def check_connection(self) -> None:
         # can be used to check if the client is still connected
         # if not it throws the underlying exception
+        current_task = asyncio.current_task()
+        if self.uaclient.connection_state == UaClient.CONNECTION_STATE.DISCONNECTING:
+            raise ConnectionError("Client is disconnecting")
+        if not self._is_disconnect_requested() and not self._is_protocol_open() and current_task is not self._reconnect_task:
+            await self.uaclient.inform_subscriptions(ua.StatusCode(ua.StatusCodes.BadShutdown))
+            if self.reconnect_enabled:
+                await self._schedule_reconnect(ConnectionError("Connection is closed"))
+            else:
+                raise ConnectionError("Connection is closed")
+        if (
+            self.uaclient.connection_state == UaClient.CONNECTION_STATE.SESSION_ESTABLISHING
+            and not self._is_disconnect_requested()
+            and current_task is not self._reconnect_task
+        ):
+            deadline = asyncio.get_running_loop().time() + self.reconnect_request_timeout
+            while not self._is_disconnect_requested():
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    raise ConnectionError("Reconnect timeout")
+                try:
+                    await asyncio.wait_for(self._reconnect_event.wait(), remaining)
+                except asyncio.TimeoutError as exc:
+                    raise ConnectionError("Reconnect timeout") from exc
+                if self._is_protocol_open():
+                    break
+                # Event may have been set before the protocol is fully usable, keep waiting.
+                await asyncio.sleep(0)
         if self._renew_channel_task is not None:
             if self._renew_channel_task.done():
-                await self._renew_channel_task
+                try:
+                    await self._renew_channel_task
+                except Exception as exc:
+                    await self._schedule_reconnect(exc)
+                    if self._reconnect_task is not None and current_task is not self._reconnect_task:
+                        try:
+                            await asyncio.wait_for(self._reconnect_event.wait(), self.reconnect_request_timeout)
+                            return
+                        except asyncio.TimeoutError as err:
+                            raise ConnectionError("Reconnect timeout") from err
+                    raise
         if self._monitor_server_task is not None:
             if self._monitor_server_task.done():
-                await self._monitor_server_task
+                try:
+                    await self._monitor_server_task
+                except Exception as exc:
+                    await self._schedule_reconnect(exc)
+                    if self._reconnect_task is not None and current_task is not self._reconnect_task:
+                        try:
+                            await asyncio.wait_for(self._reconnect_event.wait(), self.reconnect_request_timeout)
+                            return
+                        except asyncio.TimeoutError as err:
+                            raise ConnectionError("Reconnect timeout") from err
+                    raise
         if self.uaclient._publish_task is not None:
             if self.uaclient._publish_task.done():
-                await self.uaclient._publish_task
+                try:
+                    await self.uaclient._publish_task
+                except Exception as exc:
+                    if isinstance(exc, SubscriptionStaleError):
+                        recovered = await self._try_recover_stale_subscriptions(exc.subscription_ids)
+                        if recovered:
+                            return
+                    await self._lost_connection(exc)
+                    await self.uaclient.inform_subscriptions(ua.StatusCode(ua.StatusCodes.BadShutdown))
+                    await self._schedule_reconnect(exc)
+                    if self._reconnect_task is not None and current_task is not self._reconnect_task:
+                        try:
+                            await asyncio.wait_for(self._reconnect_event.wait(), self.reconnect_request_timeout)
+                            return
+                        except asyncio.TimeoutError as err:
+                            raise ConnectionError("Reconnect timeout") from err
+                    raise
 
-    async def _monitor_server_loop(self) -> None:
+    async def _try_recover_stale_subscriptions(self, stale_subscription_ids: Sequence[int]) -> bool:
+        stale_ids = {int(subscription_id) for subscription_id in stale_subscription_ids}
+        if not stale_ids:
+            return False
+
+        active_subscriptions = [sub for sub in self._managed_subscriptions if sub.subscription_id is not None]
+        if not active_subscriptions:
+            return False
+
+        active_ids = {int(sub.subscription_id) for sub in active_subscriptions if sub.subscription_id is not None}
+        stale_ids.intersection_update(active_ids)
+        if not stale_ids:
+            return False
+
+        if stale_ids == active_ids:
+            _logger.warning(
+                "All active managed subscriptions are stale (%s); escalating to reconnect",
+                sorted(stale_ids),
+            )
+            return False
+
+        stale_subscriptions = [
+            sub for sub in active_subscriptions if sub.subscription_id is not None and int(sub.subscription_id) in stale_ids
+        ]
+        recoverable_subscriptions = [
+            sub for sub in stale_subscriptions if sub not in self._stale_recovery_attempted_subscriptions
+        ]
+        if not recoverable_subscriptions:
+            _logger.warning(
+                "Stale subscriptions already recovered once (%s); escalating to reconnect",
+                sorted(stale_ids),
+            )
+            return False
+
+        for subscription in recoverable_subscriptions:
+            self._stale_recovery_attempted_subscriptions.add(subscription)
+            try:
+                old_id, new_id = await subscription.recreate()
+                self._managed_subscriptions_by_id.pop(int(old_id), None)
+                self._managed_subscriptions_by_id[int(new_id)] = subscription
+                _logger.warning("Recovered stale subscription %s by recreation as %s", old_id, new_id)
+            except Exception:
+                _logger.exception(
+                    "Failed to recover stale subscription %s by recreation",
+                    subscription.subscription_id,
+                )
+                return False
+
+        await self.uaclient.restart_publish_loop()
+        return True
+
+    def _is_protocol_open(self) -> bool:
+        protocol = self.uaclient.protocol
+        return protocol is not None and protocol.transport is not None and protocol.state == protocol.OPEN
+
+    async def _monitor_server_loop(self):
         """
         Checks if the server is alive
         """
         timeout = min(self.session_timeout / 1000 / 2, self._watchdog_intervall)
         try:
-            while not self._closing:
+            while not self._is_disconnect_requested():
                 await asyncio.sleep(timeout)
                 # @FIXME handle state change
                 _ = await self.nodes.server_state.read_value()
@@ -610,22 +878,30 @@ class Client:
             _logger.info("connection error in watchdog loop %s", e, exc_info=True)
             await self._lost_connection(e)
             await self.uaclient.inform_subscriptions(ua.StatusCode(ua.StatusCodes.BadShutdown))
+            if self.reconnect_enabled:
+                await self._schedule_reconnect(e)
+                return
             raise
         except Exception as e:
             _logger.exception("Error in watchdog loop")
             await self._lost_connection(e)
             await self.uaclient.inform_subscriptions(ua.StatusCode(ua.StatusCodes.BadShutdown))
+            if self.reconnect_enabled:
+                await self._schedule_reconnect(e)
+                return
             raise
 
-    async def _lost_connection(self, ex: Exception) -> None:
+    async def _lost_connection(self, ex: Exception):
         if not self.connection_lost_callback:
             return
         try:
-            await self.connection_lost_callback(ex)
+            result = self.connection_lost_callback(ex)
+            if inspect.isawaitable(result):
+                await result
         except Exception as ex:
             _logger.exception("Error calling connection_lost_callback")
 
-    async def _renew_channel_loop(self) -> None:
+    async def _renew_channel_loop(self):
         """
         Renew the SecureChannel before the SecureChannelTimeout will happen.
         In theory, we could do that only if no session activity,
@@ -635,7 +911,7 @@ class Client:
             # Part4 5.5.2.1:
             # Clients should request a new SecurityToken after 75 % of its lifetime has elapsed
             duration = self.secure_channel_timeout * 0.75 / 1000
-            while not self._closing:
+            while not self._is_disconnect_requested():
                 await asyncio.sleep(duration)
                 _logger.debug("renewing channel")
                 await self.open_secure_channel(renew=True)
@@ -643,10 +919,155 @@ class Client:
                 _logger.debug("server state is: %s ", val)
         except ConnectionError as e:
             _logger.info("connection error  in watchdog loop %s", e, exc_info=True)
+            if self.reconnect_enabled:
+                await self._schedule_reconnect(e)
+                return
             raise
         except Exception:
             _logger.exception("Error while renewing session")
+            if self.reconnect_enabled:
+                await self._schedule_reconnect(ConnectionError("Error while renewing session"))
+                return
             raise
+
+    async def _schedule_reconnect(self, cause: Exception) -> None:
+        if self._is_disconnect_requested() or not self.reconnect_enabled:
+            return
+        if self._reconnect_task and not self._reconnect_task.done():
+            return
+        self._set_state(UaClient.CONNECTION_STATE.SESSION_ESTABLISHING)
+        self._reconnect_task = asyncio.create_task(self._reconnect_loop(cause))
+
+    async def _prepare_reconnect_transport(self) -> None:
+        await self._cancel_background_tasks(disable_pre_hook=False)
+        self.disconnect_socket()
+        self.uaclient.pre_request_hook = self.check_connection
+        await self.connect_socket()
+        await self.send_hello()
+        await self.open_secure_channel()
+
+    async def _recover_subscriptions(
+        self,
+        subscription_ids: list[int],
+        expected_sequences: dict[int, int],
+        reused_existing_session: bool,
+        invalid_transfer_subscription_ids: set[int],
+    ) -> None:
+        if not subscription_ids:
+            return
+
+        invalid_subscription_ids = await self._republish_subscriptions(expected_sequences)
+        if not reused_existing_session:
+            invalid_subscription_ids.update(invalid_transfer_subscription_ids)
+        if invalid_subscription_ids:
+            _logger.warning(
+                "Detected invalid subscriptions after reconnect: %s. Potential data loss may have occurred during interruption.",
+                sorted(invalid_subscription_ids),
+            )
+        if self.auto_recreate_invalid_subscriptions:
+            await self._recreate_invalid_subscriptions(invalid_subscription_ids)
+        elif invalid_subscription_ids:
+            _logger.warning(
+                "Automatic recreation of invalid subscriptions is disabled; set auto_recreate_invalid_subscriptions=True to enable",
+            )
+        await self.uaclient.restart_publish_loop()
+
+    async def _finalize_successful_reconnect(self, attempt: int) -> None:
+        self._ensure_background_tasks_running()
+        self._set_state(UaClient.CONNECTION_STATE.SESSION_READY)
+        self._stale_recovery_attempted_subscriptions.clear()
+        _logger.warning("Reconnect successful on attempt %s", attempt)
+        if self.on_reconnected is not None:
+            try:
+                await self.on_reconnected()
+            except Exception:
+                _logger.exception("Error in on_reconnected callback")
+
+    async def _reconnect_loop(self, cause: Exception) -> None:
+        async with self._reconnect_lock:
+            if self._is_disconnect_requested() or not self.reconnect_enabled:
+                return
+
+            self._set_state(UaClient.CONNECTION_STATE.SESSION_ESTABLISHING)
+            attempt = 0
+            delay = max(0.0, self.reconnect_initial_delay)
+            _logger.warning("Starting reconnect loop after connection loss: %s", cause)
+
+            while not self._is_disconnect_requested():
+                if self.reconnect_max_retries is not None and attempt >= self.reconnect_max_retries:
+                    _logger.error("Reconnect aborted after %s attempts", attempt)
+                    self._set_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+                    return
+
+                attempt += 1
+                if self.reconnect_max_retries is None:
+                    _logger.warning("Reconnect attempt %s", attempt)
+                else:
+                    _logger.warning("Reconnect attempt %s/%s", attempt, self.reconnect_max_retries)
+                try:
+                    await self._prepare_reconnect_transport()
+                    async with self.uaclient.internal_service_calls():
+                        await self.try_restore_state()
+                    await self._finalize_successful_reconnect(attempt)
+                    return
+                except Exception:
+                    _logger.exception("Reconnect attempt %s failed", attempt)
+                    if self._is_disconnect_requested():
+                        return
+                    if delay > 0:
+                        await asyncio.sleep(delay)
+                    delay = min(max(1.0, delay * 2.0), self.reconnect_max_delay)
+
+    async def _republish_subscriptions(self, expected_sequences: dict[int, int]) -> set[int]:
+        invalid_subscription_ids: set[int] = set()
+        for subscription_id, sequence_number in expected_sequences.items():
+            current = sequence_number
+            while True:
+                try:
+                    notification_message = await self.uaclient.republish(subscription_id, current)
+                    await self.uaclient.dispatch_notification_message(subscription_id, notification_message)
+                    current += 1
+                except ua.UaStatusCodeError as err:
+                    if err.code == ua.StatusCodes.BadMessageNotAvailable:
+                        break
+                    if err.code == ua.StatusCodes.BadSubscriptionIdInvalid:
+                        _logger.warning(
+                            "Republish failed because subscription %s is invalid and must be recreated",
+                            subscription_id,
+                        )
+                        invalid_subscription_ids.add(subscription_id)
+                        break
+                    raise
+        return invalid_subscription_ids
+
+    async def _recreate_invalid_subscriptions(self, invalid_subscription_ids: set[int]) -> None:
+        if not invalid_subscription_ids:
+            return
+
+        for subscription_id in invalid_subscription_ids:
+            subscription = self._managed_subscriptions_by_id.get(int(subscription_id))
+            if subscription is None:
+                # Fallback for stale index states, then resync this entry.
+                subscription = next(
+                    (sub for sub in self._managed_subscriptions if sub.subscription_id == subscription_id),
+                    None,
+                )
+                if subscription is not None:
+                    self._index_managed_subscription(subscription)
+            if subscription is None:
+                _logger.warning(
+                    "Cannot recreate subscription %s automatically because it is not managed by Client",
+                    subscription_id,
+                )
+                continue
+
+            try:
+                old_id, new_id = await subscription.recreate()
+                self._managed_subscriptions_by_id.pop(int(old_id), None)
+                self._managed_subscriptions_by_id[int(new_id)] = subscription
+                _logger.warning("Recreated invalid subscription %s as %s", old_id, new_id)
+            except Exception:
+                _logger.exception("Failed to recreate invalid subscription %s", subscription_id)
 
     def server_policy(self, token_type: ua.UserTokenType) -> ua.UserTokenPolicy:
         """
@@ -694,17 +1115,11 @@ class Client:
         self._server_nonce = res.ServerNonce
         return res
 
-    def _add_anonymous_auth(self, params: ua.ActivateSessionParameters) -> None:
+    def _add_anonymous_auth(self, params):
         params.UserIdentityToken = ua.AnonymousIdentityToken()
         params.UserIdentityToken.PolicyId = self.server_policy(ua.UserTokenType.Anonymous).PolicyId
 
-    def _add_certificate_auth(
-        self,
-        params: ua.ActivateSessionParameters,
-        certificate: x509.Certificate,
-        challenge: bytes,
-        certificate_chain: list[x509.Certificate] | None = None,
-    ) -> None:
+    def _add_certificate_auth(self, params, certificate, challenge, certificate_chain=None):
         params.UserIdentityToken = ua.X509IdentityToken()
         params.UserIdentityToken.CertificateData = uacrypto.der_from_x509(certificate)
         certificate_chain = certificate_chain or []
@@ -718,7 +1133,7 @@ class Client:
         params.UserTokenSignature.Algorithm = alg
         params.UserTokenSignature.Signature = sig
 
-    def _add_user_auth(self, params: ua.ActivateSessionParameters, username: str | None, password: str | None) -> None:
+    def _add_user_auth(self, params, username: str, password: str):
         params.UserIdentityToken = ua.UserNameIdentityToken()
         params.UserIdentityToken.UserName = username
         policy = self.server_policy(ua.UserTokenType.UserName)
@@ -737,7 +1152,7 @@ class Client:
             params.UserIdentityToken.EncryptionAlgorithm = uri
         params.UserIdentityToken.PolicyId = policy.PolicyId
 
-    def _encrypt_password(self, password: str, policy_uri: str) -> tuple[bytes, str]:
+    def _encrypt_password(self, password: str, policy_uri) -> tuple[bytes, str]:
         pubkey = uacrypto.x509_from_der(self.security_policy.peer_certificate).public_key()
         # see specs part 4, 7.36.3: if the token is encrypted, password
         # shall be converted to UTF-8 and serialized with server nonce
@@ -752,21 +1167,8 @@ class Client:
         """
         Close session
         """
-        self._closing = True
-        if self._monitor_server_task:
-            self._monitor_server_task.cancel()
-            try:
-                await self._monitor_server_task
-            except (asyncio.CancelledError, Exception):
-                pass
-        # disable hook because we kill our monitor task, so we are going to get CancelledError at every request
-        self.uaclient.pre_request_hook = None
-        if self._renew_channel_task:
-            self._renew_channel_task.cancel()
-            try:
-                await self._renew_channel_task
-            except (asyncio.CancelledError, Exception):
-                pass
+        await self._cancel_background_tasks(disable_pre_hook=True)
+        self._session_authentication_token = None
         return await self.uaclient.close_session(True)
 
     def get_root_node(self) -> Node:
@@ -811,6 +1213,8 @@ class Client:
             params.Priority = 0
         subscription = Subscription(self.uaclient, params, handler)
         results = await subscription.init()
+        self._managed_subscriptions.add(subscription)
+        self._index_managed_subscription(subscription)
         new_params = self.get_subscription_revised_params(params, results)
         if new_params:
             results = await subscription.update(new_params)
@@ -856,7 +1260,21 @@ class Client:
         """
         Deletes the provided list of subscription_ids
         """
-        return await self.uaclient.delete_subscriptions(subscription_ids)
+        subscription_id_list = list(subscription_ids)
+        subscription_id_set = {int(subscription_id) for subscription_id in subscription_id_list}
+        self._managed_subscriptions = {
+            subscription
+            for subscription in self._managed_subscriptions
+            if subscription.subscription_id not in subscription_id_list
+        }
+        for subscription_id in subscription_id_set:
+            self._managed_subscriptions_by_id.pop(subscription_id, None)
+        if len(self._managed_subscriptions_by_id) != len(
+            [subscription for subscription in self._managed_subscriptions if subscription.subscription_id is not None]
+        ):
+            self._refresh_managed_subscription_index()
+        self._stale_recovery_attempted_subscriptions.intersection_update(self._managed_subscriptions)
+        return await self.uaclient.delete_subscriptions(subscription_id_list)
 
     def get_keepalive_count(self, period: float) -> int:
         """
@@ -880,17 +1298,11 @@ class Client:
         _logger.info("get_namespace_index %s %r", type(uries), uries)
         return uries.index(uri)
 
-    async def delete_nodes(
-        self, nodes: Iterable[Node], recursive: bool = False
-    ) -> tuple[list[Node], list[ua.StatusCode]]:
+    async def delete_nodes(self, nodes: Iterable[Node], recursive=False) -> tuple[list[Node], list[ua.StatusCode]]:
         return await delete_nodes(self.uaclient, nodes, recursive)
 
     async def import_xml(
-        self,
-        path: str | None = None,
-        xmlstring: str | None = None,
-        strict_mode: bool = True,
-        auto_load_definitions: bool = True,
+        self, path=None, xmlstring=None, strict_mode=True, auto_load_definitions: bool = True
     ) -> list[ua.NodeId]:
         """
         Import nodes defined in xml
@@ -898,7 +1310,7 @@ class Client:
         importer = XmlImporter(self, strict_mode=strict_mode, auto_load_definitions=auto_load_definitions)
         return await importer.import_xml(path, xmlstring)
 
-    async def export_xml(self, nodes: Iterable[Node], path: str, export_values: bool = False) -> None:
+    async def export_xml(self, nodes, path, export_values: bool = False) -> None:
         """
         Export defined nodes to xml
         :param export_values: exports values from variants
@@ -920,7 +1332,7 @@ class Client:
         await ns_node.write_value(uries)
         return len(uries) - 1
 
-    async def load_type_definitions(self, nodes: Iterable[Node] | None = None) -> dict[str, type]:
+    async def load_type_definitions(self, nodes=None):
         """
         Load custom types (custom structures/extension objects) definition from server
         Generate Python classes for custom structures/extension objects defined in server

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -26,7 +26,7 @@ from ..common.xmlexporter import XmlExporter
 from ..common.xmlimporter import XmlImporter
 from ..crypto import security_policies, uacrypto
 from ..crypto.validator import CertificateValidatorMethod
-from .ua_client import SubscriptionStaleError, UaClient
+from .ua_client import SubscriptionStaleError, UaClient, UaSession
 
 _logger = logging.getLogger(__name__)
 
@@ -676,12 +676,23 @@ class Client:
         if self._session_authentication_token is None or self.uaclient.protocol is None:
             return False
 
-        self.uaclient.protocol.authentication_token = self._session_authentication_token
+        target_session = next(
+            (
+                session
+                for session in self.uaclient.get_sessions()
+                if session.authentication_token == self._session_authentication_token
+            ),
+            None,
+        )
+        if target_session is None:
+            return False
+
         try:
             await self.activate_session(
                 username=self._username,
                 password=self._password,
                 certificate=self.user_certificate,
+                session=target_session,
             )
             return True
         except Exception:
@@ -1095,6 +1106,7 @@ class Client:
         username: str | None = None,
         password: str | None = None,
         certificate: x509.Certificate | None = None,
+        session: UaSession | None = None,
     ) -> ua.ActivateSessionResult:
         """
         Activate session using either username and password or private_key
@@ -1118,7 +1130,7 @@ class Client:
             self._add_certificate_auth(params, user_certificate, challenge, self.user_certificate_chain)
         else:
             self._add_user_auth(params, username, password)
-        res = await self.uaclient.activate_session(params)
+        res = await self.uaclient.activate_session(params, session=session)
         self._server_nonce = res.ServerNonce
         return res
 

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -640,11 +640,18 @@ class Client:
             self._monitor_server_task = asyncio.create_task(self._monitor_server_loop())
 
     async def try_restore_state(self) -> None:
-        subscription_ids = self.uaclient.get_subscription_ids()
-        expected_sequences = {
-            subscription_id: self.uaclient.get_next_sequence_number(subscription_id)
-            for subscription_id in subscription_ids
-        }
+        subscription_ids: list[int] = []
+        expected_sequences: dict[int, int] = {}
+        try:
+            subscription_ids = self.uaclient.get_subscription_ids()
+            expected_sequences = {
+                subscription_id: self.uaclient.get_next_sequence_number(subscription_id)
+                for subscription_id in subscription_ids
+            }
+        except ua.UaError:
+            # No active default session yet (e.g. initial connect).
+            # Continue by creating/activating a new session and restoring nothing.
+            pass
 
         reused_existing_session, invalid_transfer_subscription_ids = await self._create_or_recover_session(
             subscription_ids

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -115,7 +115,7 @@ class Client:
         if not self.uaclient.try_set_connection_state(state):
             self._reconnect_event.clear()
             return
-        if state == UaClient.CONNECTION_STATE.SESSION_READY:
+        if state == UaClient.CONNECTION_STATE.CHANNEL_READY:
             self._reconnect_event.set()
         else:
             self._reconnect_event.clear()
@@ -381,7 +381,7 @@ class Client:
         """
         _logger.info("connect")
         self.uaclient.pre_request_hook = None
-        self._set_state(UaClient.CONNECTION_STATE.SESSION_ESTABLISHING)
+        self._set_state(UaClient.CONNECTION_STATE.CONNECTING)
         await self.connect_socket()
         try:
             await self.send_hello()
@@ -400,7 +400,7 @@ class Client:
             self.uaclient.pre_request_hook = self.check_connection
             raise
         self.uaclient.pre_request_hook = self.check_connection
-        self._set_state(UaClient.CONNECTION_STATE.SESSION_READY)
+        self._set_state(UaClient.CONNECTION_STATE.CHANNEL_READY)
 
     async def connect_sessionless(self) -> None:
         """
@@ -746,7 +746,7 @@ class Client:
             else:
                 raise ConnectionError("Connection is closed")
         if (
-            self.uaclient.connection_state == UaClient.CONNECTION_STATE.SESSION_ESTABLISHING
+            self.uaclient.connection_state == UaClient.CONNECTION_STATE.CONNECTING
             and not self._is_disconnect_requested()
             and current_task is not self._reconnect_task
         ):
@@ -935,7 +935,7 @@ class Client:
             return
         if self._reconnect_task and not self._reconnect_task.done():
             return
-        self._set_state(UaClient.CONNECTION_STATE.SESSION_ESTABLISHING)
+        self._set_state(UaClient.CONNECTION_STATE.CONNECTING)
         self._reconnect_task = asyncio.create_task(self._reconnect_loop(cause))
 
     async def _prepare_reconnect_transport(self) -> None:
@@ -974,7 +974,7 @@ class Client:
 
     async def _finalize_successful_reconnect(self, attempt: int) -> None:
         self._ensure_background_tasks_running()
-        self._set_state(UaClient.CONNECTION_STATE.SESSION_READY)
+        self._set_state(UaClient.CONNECTION_STATE.CHANNEL_READY)
         self._stale_recovery_attempted_subscriptions.clear()
         _logger.warning("Reconnect successful on attempt %s", attempt)
         if self.on_reconnected is not None:
@@ -988,7 +988,7 @@ class Client:
             if self._is_disconnect_requested() or not self.reconnect_enabled:
                 return
 
-            self._set_state(UaClient.CONNECTION_STATE.SESSION_ESTABLISHING)
+            self._set_state(UaClient.CONNECTION_STATE.CONNECTING)
             attempt = 0
             delay = max(0.0, self.reconnect_initial_delay)
             _logger.warning("Starting reconnect loop after connection loss: %s", cause)

--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -45,7 +45,7 @@ class Client:
     _password: str | None = None
     strip_url_credentials: bool = True
 
-    def __init__(self, url: str, timeout: float = 4, watchdog_intervall: float = 1.0):
+    def __init__(self, url: str, timeout: float = 4, watchdog_intervall: float = 1.0) -> None:
         """
         :param url: url of the server.
             if you are unsure of url, write at least hostname
@@ -137,14 +137,16 @@ class Client:
             if subscription.subscription_id is not None
         }
 
-    async def __aenter__(self):
+    async def __aenter__(self) -> "Client":
         await self.connect()
         return self
 
-    async def __aexit__(self, exc_type, exc_value, traceback):
+    async def __aexit__(
+        self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: Any
+    ) -> None:
         await self.disconnect()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"Client({self.server_url.geturl()})"
 
     __repr__ = __str__
@@ -491,7 +493,7 @@ class Client:
             )
             self.secure_channel_timeout = result.SecurityToken.RevisedLifetime
 
-    async def close_secure_channel(self):
+    async def close_secure_channel(self) -> None:
         await self.uaclient.close_secure_channel()
 
     async def get_endpoints(self) -> list[ua.EndpointDescription]:
@@ -884,7 +886,7 @@ class Client:
         protocol = self.uaclient.protocol
         return protocol is not None and protocol.transport is not None and protocol.state == protocol.OPEN
 
-    async def _monitor_server_loop(self):
+    async def _monitor_server_loop(self) -> None:
         """
         Checks if the server is alive
         """
@@ -911,7 +913,7 @@ class Client:
                 return
             raise
 
-    async def _lost_connection(self, ex: Exception):
+    async def _lost_connection(self, ex: Exception) -> None:
         if not self.connection_lost_callback:
             return
         try:
@@ -921,7 +923,7 @@ class Client:
         except Exception as ex:
             _logger.exception("Error calling connection_lost_callback")
 
-    async def _renew_channel_loop(self):
+    async def _renew_channel_loop(self) -> None:
         """
         Renew the SecureChannel before the SecureChannelTimeout will happen.
         In theory, we could do that only if no session activity,
@@ -1136,11 +1138,17 @@ class Client:
         self._server_nonce = res.ServerNonce
         return res
 
-    def _add_anonymous_auth(self, params):
+    def _add_anonymous_auth(self, params: ua.ActivateSessionParameters) -> None:
         params.UserIdentityToken = ua.AnonymousIdentityToken()
         params.UserIdentityToken.PolicyId = self.server_policy(ua.UserTokenType.Anonymous).PolicyId
 
-    def _add_certificate_auth(self, params, certificate, challenge, certificate_chain=None):
+    def _add_certificate_auth(
+        self,
+        params: ua.ActivateSessionParameters,
+        certificate: x509.Certificate,
+        challenge: bytes,
+        certificate_chain: Sequence[x509.Certificate] | None = None,
+    ) -> None:
         params.UserIdentityToken = ua.X509IdentityToken()
         params.UserIdentityToken.CertificateData = uacrypto.der_from_x509(certificate)
         certificate_chain = certificate_chain or []
@@ -1154,7 +1162,9 @@ class Client:
         params.UserTokenSignature.Algorithm = alg
         params.UserTokenSignature.Signature = sig
 
-    def _add_user_auth(self, params, username: str, password: str):
+    def _add_user_auth(
+        self, params: ua.ActivateSessionParameters, username: str | None, password: str | None
+    ) -> None:
         params.UserIdentityToken = ua.UserNameIdentityToken()
         params.UserIdentityToken.UserName = username
         policy = self.server_policy(ua.UserTokenType.UserName)
@@ -1173,7 +1183,7 @@ class Client:
             params.UserIdentityToken.EncryptionAlgorithm = uri
         params.UserIdentityToken.PolicyId = policy.PolicyId
 
-    def _encrypt_password(self, password: str, policy_uri) -> tuple[bytes, str]:
+    def _encrypt_password(self, password: str, policy_uri: str) -> tuple[bytes, str]:
         pubkey = uacrypto.x509_from_der(self.security_policy.peer_certificate).public_key()
         # see specs part 4, 7.36.3: if the token is encrypted, password
         # shall be converted to UTF-8 and serialized with server nonce
@@ -1319,11 +1329,15 @@ class Client:
         _logger.info("get_namespace_index %s %r", type(uries), uries)
         return uries.index(uri)
 
-    async def delete_nodes(self, nodes: Iterable[Node], recursive=False) -> tuple[list[Node], list[ua.StatusCode]]:
+    async def delete_nodes(self, nodes: Iterable[Node], recursive: bool = False) -> tuple[list[Node], list[ua.StatusCode]]:
         return await delete_nodes(self.uaclient, nodes, recursive)
 
     async def import_xml(
-        self, path=None, xmlstring=None, strict_mode=True, auto_load_definitions: bool = True
+        self,
+        path: str | Path | None = None,
+        xmlstring: str | None = None,
+        strict_mode: bool = True,
+        auto_load_definitions: bool = True,
     ) -> list[ua.NodeId]:
         """
         Import nodes defined in xml
@@ -1331,7 +1345,7 @@ class Client:
         importer = XmlImporter(self, strict_mode=strict_mode, auto_load_definitions=auto_load_definitions)
         return await importer.import_xml(path, xmlstring)
 
-    async def export_xml(self, nodes, path, export_values: bool = False) -> None:
+    async def export_xml(self, nodes: Iterable[Node], path: str | Path, export_values: bool = False) -> None:
         """
         Export defined nodes to xml
         :param export_values: exports values from variants
@@ -1353,7 +1367,7 @@ class Client:
         await ns_node.write_value(uries)
         return len(uries) - 1
 
-    async def load_type_definitions(self, nodes=None):
+    async def load_type_definitions(self, nodes: Any = None) -> Any:
         """
         Load custom types (custom structures/extension objects) definition from server
         Generate Python classes for custom structures/extension objects defined in server

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -193,7 +193,7 @@ class UASocketProtocol(asyncio.Protocol):
 
     def _send_request(
         self,
-        request: ua.BaseRequest,
+        request: Any,
         timeout: float = 1,
         message_type: ua.MessageType = ua.MessageType.SecureMessage,
         authentication_token: ua.NodeId | None = None,
@@ -228,7 +228,7 @@ class UASocketProtocol(asyncio.Protocol):
 
     async def send_request(
         self,
-        request: ua.BaseRequest,
+        request: Any,
         timeout: float | None = None,
         message_type: ua.MessageType = ua.MessageType.SecureMessage,
         authentication_token: ua.NodeId | None = None,
@@ -268,12 +268,12 @@ class UASocketProtocol(asyncio.Protocol):
 
     def check_answer(self, data: bytes, context: str) -> bool:
         """Verify response is valid OPC-UA message."""
-        data = data.copy()
-        typeid = nodeid_from_binary(data)
+        data_buffer = ua.utils.Buffer(data)
+        typeid = nodeid_from_binary(data_buffer)
         if typeid == ua.FourByteNodeId(
             ua.ObjectIds.ServiceFault_Encoding_DefaultBinary
         ):
-            hdr = struct_from_binary(ua.ResponseHeader, data)
+            hdr = struct_from_binary(ua.ResponseHeader, data_buffer)
             self.logger.warning(
                 "ServiceFault (%s, diagnostics: %s) %s",
                 hdr.ServiceResult.name,
@@ -297,7 +297,7 @@ class UASocketProtocol(asyncio.Protocol):
             self._callbackmap[request_id].set_result(body)
         except KeyError as ex:
             raise ua.UaError(
-                f"No request found for id {request_id}, body was {body}"
+                f"No request found for id {request_id}, body was {body!r}"
             ) from ex
         except asyncio.InvalidStateError:
             if not self.closed:
@@ -372,9 +372,11 @@ class UASocketProtocol(asyncio.Protocol):
             ),
             self.timeout,
         )
-        _return = self._open_secure_channel_exchange.Parameters  # type: ignore[union-attr]
+        exchange = self._open_secure_channel_exchange
         self._open_secure_channel_exchange = None
-        return _return
+        if isinstance(exchange, ua.OpenSecureChannelResponse):
+            return exchange.Parameters
+        raise UaError("Secure channel open failed: missing response")
 
     async def close_secure_channel(self) -> None:
         """Close secure channel.
@@ -761,7 +763,7 @@ class UaClient:
 
     async def find_servers(
         self, params: ua.FindServersParameters
-    ) -> list[ua.ServerOnNetwork]:
+    ) -> list[ua.ApplicationDescription]:
         """Find servers on discovery server (sessionless).
 
         Args:
@@ -949,7 +951,7 @@ class UaClient:
 
     async def _send_request(
         self,
-        request: ua.BaseRequest,
+        request: Any,
         timeout: float | None = None,
         message_type: ua.MessageType = ua.MessageType.SecureMessage,
         bypass_ready_gate: bool = False,
@@ -1122,12 +1124,13 @@ class UaClient:
     def _register_session(self, session: UaSession) -> None:
         """Track newly created session."""
         self._session_id_counter += 1
-        session._client_session_id = self._session_id_counter
+        session.registry_session_id = self._session_id_counter
         self._sessions[self._session_id_counter] = session
 
     def _unregister_session(self, session: UaSession) -> None:
         """Remove closed session from registry."""
-        self._sessions.pop(session._client_session_id, None)
+        if session.registry_session_id is not None:
+            self._sessions.pop(session.registry_session_id, None)
 
     # ========== BACKWARD-COMPAT SESSION DELEGATION ==========
 

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -13,7 +13,7 @@ import copy
 import logging
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from asyncua import ua
 from asyncua.ua.uaerrors._base import UaError
@@ -36,9 +36,6 @@ from .ua_session import (
     SubscriptionStaleError,
     UaSession,
 )
-
-if TYPE_CHECKING:
-    pass
 
 __all__ = [
     "UaClient",
@@ -996,8 +993,6 @@ class UaClient:
             >>> nodes = await session.browse(...)
             >>> await session.close()
         """
-        from asyncua.client.ua_session import UaSession
-
         self.logger.info("Creating session object")
 
         await self.create_session(parameters)
@@ -1008,7 +1003,6 @@ class UaClient:
             activate_params = ua.ActivateSessionParameters()
             await self.activate_session(activate_params)
 
-            self._default_session = session
             self.logger.info("Session %s activated", session.session_id)
             return session
 
@@ -1039,7 +1033,7 @@ class UaClient:
         sessions = list(self._sessions.values())
         for session in sessions:
             try:
-                await session.close()
+                await session.close_session(delete_subscriptions)
             except Exception:
                 self.logger.exception("Error closing session %s",
                                       session.session_id)

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -1086,7 +1086,7 @@ class UaClient:
     async def history_read(self, parameters: ua.HistoryReadParameters) -> list[ua.HistoryReadResult]:
         return await self._require_default_session().history_read(parameters)
 
-    async def add_nodes(self, params: ua.AddNodesParameters) -> list[ua.AddNodesResult]:
+    async def add_nodes(self, params: ua.AddNodesParameters | list[ua.AddNodesItem]) -> list[ua.AddNodesResult]:
         return await self._require_default_session().add_nodes(params)
 
     async def add_references(self, refs: list[ua.AddReferencesItem]) -> list[ua.StatusCode]:

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -39,13 +39,13 @@ from .ua_session import (
 )
 
 __all__ = [
-    "UaClient",
-    "UASocketProtocol",
-    "UaSession",
     "SessionState",
-    "SubscriptionStaleError",
     "SubscriptionDispatchOverflowError",
     "SubscriptionDispatchOverflowPolicy",
+    "SubscriptionStaleError",
+    "UASocketProtocol",
+    "UaClient",
+    "UaSession",
 ]
 
 

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -2,18 +2,17 @@
 Low level binary client
 """
 
-from __future__ import annotations
-
 import asyncio
 import copy
 import inspect
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from enum import Enum
 
 from asyncua import ua
 from asyncua.common.session_interface import AbstractSession
-from asyncua.common.utils import Buffer
 from asyncua.ua.uaerrors._base import UaError
 
 from ..common.connection import SecureConnection, TransportLimits
@@ -22,6 +21,82 @@ from ..crypto import security_policies
 from ..ua.ua_binary import header_from_binary, nodeid_from_binary, struct_from_binary, struct_to_binary, uatcp_to_binary
 from ..ua.uaerrors import BadNoSubscription, BadSessionClosed, BadTimeout, BadUserAccessDenied, UaStructParsingError
 from ..ua.uaprotocol_auto import OpenSecureChannelResult, SubscriptionAcknowledgement
+
+
+@dataclass
+class _SubscriptionWatchdogState:
+    publishing_interval_ms: float
+    keepalive_count: int
+    last_seen_at: float
+    stale_reported: bool = False
+
+
+class SubscriptionStaleError(ConnectionError):
+    def __init__(self, subscription_ids: list[int]):
+        self.subscription_ids = subscription_ids
+        super().__init__(
+            f"Detected stale subscriptions with no Publish messages within keep-alive window: {subscription_ids}"
+        )
+
+
+class SubscriptionDispatchOverflowError(ConnectionError):
+    def __init__(self, subscription_id: int, queue_size: int):
+        self.subscription_id = subscription_id
+        self.queue_size = queue_size
+        super().__init__(
+            f"Subscription dispatch queue overflow for subscription {subscription_id} at size {queue_size}"
+        )
+
+
+class SubscriptionDispatchOverflowPolicy(str, Enum):
+    DROP_OLDEST = "drop_oldest"
+    WARN = "warn"
+    DISCONNECT = "disconnect"
+
+
+@dataclass
+class _DispatchSettings:
+    queue_maxsize: int = 1000
+    overflow_policy: SubscriptionDispatchOverflowPolicy | str = SubscriptionDispatchOverflowPolicy.DROP_OLDEST
+
+
+@dataclass
+class _SequenceRecoverySettings:
+    auto_republish_on_gap: bool = True
+    max_republish_messages_per_gap: int = 1000
+
+
+@dataclass
+class _WatchdogSettings:
+    stale_detection_enabled: bool = True
+    stale_detection_margin: float = 1.2
+
+
+@dataclass
+class _SubscriptionDispatchRuntime:
+    queue: asyncio.Queue[ua.PublishResult | None]
+    task: asyncio.Task | None = None
+
+
+def _compute_republish_window(
+    expected_sequence: int,
+    received_sequence: int,
+    max_republish: int,
+) -> tuple[int, int] | None:
+    """
+    Return an inclusive-exclusive replay window [start, end) for missing messages.
+    Returns None when no replay should be attempted.
+    """
+    if received_sequence <= expected_sequence:
+        return None
+    if max_republish <= 0:
+        return None
+
+    missing_count = received_sequence - expected_sequence
+    replay_end_exclusive = received_sequence
+    if missing_count > max_republish:
+        replay_end_exclusive = expected_sequence + max_republish
+    return expected_sequence, replay_end_exclusive
 
 
 class UASocketProtocol(asyncio.Protocol):
@@ -38,8 +113,8 @@ class UASocketProtocol(asyncio.Protocol):
         self,
         timeout: float = 1,
         security_policy: security_policies.SecurityPolicy = security_policies.SecurityPolicyNone(),
-        limits: TransportLimits | None = None,
-    ) -> None:
+        limits: TransportLimits = None,
+    ):
         """
         :param timeout: Timeout in seconds
         :param security_policy: Security policy (optional)
@@ -52,7 +127,7 @@ class UASocketProtocol(asyncio.Protocol):
         self.authentication_token = ua.NodeId()
         self._request_id = 0
         self._request_handle = 0
-        self._callbackmap: dict[int, asyncio.Future[Any]] = {}
+        self._callbackmap: dict[int, asyncio.Future] = {}
         if limits is None:
             limits = TransportLimits(65535, 65535, 0, 0)
         else:
@@ -67,11 +142,11 @@ class UASocketProtocol(asyncio.Protocol):
         # Hook for upper layer tasks before a request is sent (optional)
         self.pre_request_hook: Callable[[], Awaitable[None]] | None = None
 
-    def connection_made(self, transport: asyncio.Transport) -> None:  # type: ignore[override]
+    def connection_made(self, transport: asyncio.Transport):  # type: ignore[override]
         self.state = self.OPEN
         self.transport = transport
 
-    def connection_lost(self, exc: Exception | None) -> None:
+    def connection_lost(self, exc: Exception | None):
         self.logger.info("Socket has closed connection")
         self.state = self.CLOSED
         self.transport = None
@@ -127,7 +202,7 @@ class UASocketProtocol(asyncio.Protocol):
                 self.disconnect_socket()
                 return
 
-    def _process_received_message(self, msg: ua.Message | ua.Acknowledge | ua.ErrorMessage | None) -> None:
+    def _process_received_message(self, msg: ua.Message | ua.Acknowledge | ua.ErrorMessage):
         if msg is None:
             pass
         elif isinstance(msg, ua.Message):
@@ -143,9 +218,7 @@ class UASocketProtocol(asyncio.Protocol):
         else:
             raise ua.UaError(f"Unsupported message type: {msg}")
 
-    def _send_request(
-        self, request: Any, timeout: float = 1, message_type: ua.MessageType = ua.MessageType.SecureMessage
-    ) -> asyncio.Future[Any]:
+    def _send_request(self, request, timeout: float = 1, message_type=ua.MessageType.SecureMessage) -> asyncio.Future:
         """
         Send request to server, lower-level method.
         Timeout is the timeout written in ua header.
@@ -164,7 +237,7 @@ class UASocketProtocol(asyncio.Protocol):
             self._request_handle -= 1
             raise
         self._request_id += 1
-        future: asyncio.Future[Any] = asyncio.get_running_loop().create_future()
+        future = asyncio.get_running_loop().create_future()
         self._callbackmap[self._request_id] = future
 
         # Change to the new security token if the connection has been renewed.
@@ -176,9 +249,7 @@ class UASocketProtocol(asyncio.Protocol):
             self.transport.write(msg)
         return future
 
-    async def send_request(
-        self, request: Any, timeout: float | None = None, message_type: ua.MessageType = ua.MessageType.SecureMessage
-    ) -> Buffer:
+    async def send_request(self, request, timeout: float | None = None, message_type=ua.MessageType.SecureMessage):
         """
         Send a request to the server.
         Timeout is the timeout written in ua header.
@@ -194,6 +265,10 @@ class UASocketProtocol(asyncio.Protocol):
         except UaError as ex:
             # Recieved UA error, re-raise it to the caller
             raise ex
+        except (TimeoutError, asyncio.TimeoutError) as ex:
+            if self.state != self.OPEN:
+                raise ConnectionError("Connection is closed") from None
+            raise ConnectionError("Request timed out while waiting for OPC UA server response") from ex
         except Exception as ex:
             if self.state != self.OPEN:
                 raise ConnectionError("Connection is closed") from None
@@ -201,7 +276,7 @@ class UASocketProtocol(asyncio.Protocol):
         self.check_answer(data, f" in response to {request.__class__.__name__}")
         return data
 
-    def check_answer(self, data: Buffer, context: str) -> bool:
+    def check_answer(self, data, context):
         data = data.copy()
         typeid = nodeid_from_binary(data)
         if typeid == ua.FourByteNodeId(ua.ObjectIds.ServiceFault_Encoding_DefaultBinary):
@@ -222,7 +297,7 @@ class UASocketProtocol(asyncio.Protocol):
                 fut.set_exception(exc)
         self._callbackmap.clear()
 
-    def _call_callback(self, request_id: int, body: Buffer | ua.Acknowledge) -> None:
+    def _call_callback(self, request_id, body):
         try:
             self._callbackmap[request_id].set_result(body)
         except KeyError as ex:
@@ -236,7 +311,7 @@ class UASocketProtocol(asyncio.Protocol):
             self.logger.debug("Future for request id %s not handled due to disconnect", request_id)
         del self._callbackmap[request_id]
 
-    def _setup_request_header(self, hdr: ua.RequestHeader, timeout: float = 1) -> None:
+    def _setup_request_header(self, hdr: ua.RequestHeader, timeout=1) -> None:
         """
         :param hdr: Request header
         :param timeout: Timeout in seconds
@@ -246,25 +321,25 @@ class UASocketProtocol(asyncio.Protocol):
         hdr.RequestHandle = self._request_handle
         hdr.TimeoutHint = int(timeout * 1000)
 
-    def disconnect_socket(self) -> None:
+    def disconnect_socket(self):
         self.logger.info("Request to close socket received")
         if self.transport:
             self.transport.close()
         else:
             self.logger.warning("disconnect_socket was called but transport is None")
 
-    async def send_hello(self, url: str, max_messagesize: int = 0, max_chunkcount: int = 0) -> ua.Acknowledge:
+    async def send_hello(self, url, max_messagesize: int = 0, max_chunkcount: int = 0):
         hello = ua.Hello()
         hello.EndpointUrl = url
         hello.MaxMessageSize = max_messagesize
         hello.MaxChunkCount = max_chunkcount
-        ack: asyncio.Future[ua.Acknowledge] = asyncio.Future()
+        ack = asyncio.Future()
         self._callbackmap[0] = ack
         if self.transport is not None:
             self.transport.write(uatcp_to_binary(ua.MessageType.Hello, hello))
         return await wait_for(ack, self.timeout)
 
-    async def open_secure_channel(self, params: ua.OpenSecureChannelParameters) -> OpenSecureChannelResult:
+    async def open_secure_channel(self, params) -> OpenSecureChannelResult:
         self.logger.info("open_secure_channel")
         request = ua.OpenSecureChannelRequest()
         request.Parameters = params
@@ -275,13 +350,11 @@ class UASocketProtocol(asyncio.Protocol):
             )
         self._open_secure_channel_exchange = params
         await wait_for(self._send_request(request, message_type=ua.MessageType.SecureOpen), self.timeout)
-        assert isinstance(self._open_secure_channel_exchange, ua.OpenSecureChannelResponse)
-
-        _return = self._open_secure_channel_exchange.Parameters
+        _return = self._open_secure_channel_exchange.Parameters  # type: ignore[union-attr]
         self._open_secure_channel_exchange = None
         return _return
 
-    async def close_secure_channel(self) -> None:
+    async def close_secure_channel(self):
         """
         Close secure channel.
         It seems to trigger a shutdown of socket in most servers, so be prepared to reconnect.
@@ -308,23 +381,138 @@ class UaClient(AbstractSession):
     uaprotocol_auto.py and uaprotocol_hand.py available under asyncua.ua
     """
 
-    def __init__(self, timeout: float = 1.0) -> None:
+    class CONNECTION_STATE(Enum):
+        DISCONNECTED = 1
+        CONNECTING = 2
+        CHANNEL_READY = 3
+        SESSION_READY = 4
+        SESSION_ESTABLISHING = 5
+        DISCONNECTING = 6
+
+    def __init__(self, timeout: float = 1.0):
         """
         :param timeout: Timout in seconds
         """
         self.logger = logging.getLogger(f"{__name__}.UaClient")
-        self._subscription_callbacks: dict[int, Callable[..., Any]] = {}
+        self._subscription_callbacks = {}
+        self._subscription_dispatch_runtime: dict[int, _SubscriptionDispatchRuntime] = {}
+        self._last_publish_sequence_numbers: dict[int, int] = {}
+        self._subscription_watchdog_states: dict[int, _SubscriptionWatchdogState] = {}
+        self.dispatch_settings = _DispatchSettings()
+        self.sequence_recovery_settings = _SequenceRecoverySettings()
+        self.watchdog_settings = _WatchdogSettings()
         self._timeout = timeout
-        self.security_policy: security_policies.SecurityPolicy = security_policies.SecurityPolicyNone()
-        self.protocol: UASocketProtocol | None = None
-        self._publish_task: asyncio.Task[None] | None = None
+        self.security_policy = security_policies.SecurityPolicyNone()
+        self.protocol: UASocketProtocol = None
+        self._publish_task = None
         self._pre_request_hook: Callable[[], Awaitable[None]] | None = None
         self._closing: bool = False
+        self._connection_state: UaClient.CONNECTION_STATE = UaClient.CONNECTION_STATE.DISCONNECTED
+        self._ready_event = asyncio.Event()
+        # Nesting counter for internal operations (connect/recover/disconnect) that must bypass await_ready gating.
+        self._internal_service_call_depth = 0
 
-    def set_security(self, policy: security_policies.SecurityPolicy) -> None:
+    @property
+    def subscription_dispatch_queue_maxsize(self) -> int:
+        return self.dispatch_settings.queue_maxsize
+
+    @subscription_dispatch_queue_maxsize.setter
+    def subscription_dispatch_queue_maxsize(self, value: int) -> None:
+        self.dispatch_settings.queue_maxsize = int(value)
+
+    @property
+    def subscription_dispatch_overflow_policy(self) -> SubscriptionDispatchOverflowPolicy | str:
+        return self.dispatch_settings.overflow_policy
+
+    @subscription_dispatch_overflow_policy.setter
+    def subscription_dispatch_overflow_policy(self, value: SubscriptionDispatchOverflowPolicy | str) -> None:
+        self.dispatch_settings.overflow_policy = value
+
+    @property
+    def subscription_stale_detection_enabled(self) -> bool:
+        return self.watchdog_settings.stale_detection_enabled
+
+    @subscription_stale_detection_enabled.setter
+    def subscription_stale_detection_enabled(self, value: bool) -> None:
+        self.watchdog_settings.stale_detection_enabled = bool(value)
+
+    @property
+    def subscription_stale_detection_margin(self) -> float:
+        return self.watchdog_settings.stale_detection_margin
+
+    @subscription_stale_detection_margin.setter
+    def subscription_stale_detection_margin(self, value: float) -> None:
+        self.watchdog_settings.stale_detection_margin = float(value)
+
+    @property
+    def auto_republish_on_sequence_gap(self) -> bool:
+        return self.sequence_recovery_settings.auto_republish_on_gap
+
+    @auto_republish_on_sequence_gap.setter
+    def auto_republish_on_sequence_gap(self, value: bool) -> None:
+        self.sequence_recovery_settings.auto_republish_on_gap = bool(value)
+
+    @property
+    def max_republish_messages_per_gap(self) -> int:
+        return self.sequence_recovery_settings.max_republish_messages_per_gap
+
+    @max_republish_messages_per_gap.setter
+    def max_republish_messages_per_gap(self, value: int) -> None:
+        self.sequence_recovery_settings.max_republish_messages_per_gap = int(value)
+
+    @property
+    def connection_state(self) -> CONNECTION_STATE:
+        return self._connection_state
+
+    def _is_transition_allowed(self, state: CONNECTION_STATE) -> bool:
+        # Once disconnect starts, do not move back to session setup/ready states.
+        # This guards against reconnect/disconnect races and keeps state progression monotonic.
+        if self._connection_state == UaClient.CONNECTION_STATE.DISCONNECTING and state in (
+            UaClient.CONNECTION_STATE.SESSION_ESTABLISHING,
+            UaClient.CONNECTION_STATE.SESSION_READY,
+        ):
+            return False
+        return True
+
+    def try_set_connection_state(self, state: CONNECTION_STATE) -> bool:
+        if not self._is_transition_allowed(state):
+            self.logger.warning(
+                "Ignoring state transition %s -> %s during disconnect",
+                self._connection_state,
+                state,
+            )
+            return False
+        self.set_connection_state(state)
+        return True
+
+    def set_connection_state(self, state: CONNECTION_STATE) -> None:
+        self._connection_state = state
+        if state == UaClient.CONNECTION_STATE.SESSION_READY:
+            self._ready_event.set()
+        else:
+            self._ready_event.clear()
+
+    async def await_ready(self, timeout: float | None = None) -> None:
+        if self._connection_state == UaClient.CONNECTION_STATE.SESSION_READY:
+            return
+        wait_timeout = self._timeout if timeout is None else timeout
+        try:
+            await asyncio.wait_for(self._ready_event.wait(), wait_timeout)
+        except (TimeoutError, asyncio.TimeoutError) as ex:
+            raise ConnectionError("Client is not ready") from ex
+
+    @asynccontextmanager
+    async def internal_service_calls(self):
+        self._internal_service_call_depth += 1
+        try:
+            yield
+        finally:
+            self._internal_service_call_depth -= 1
+
+    def set_security(self, policy: security_policies.SecurityPolicy):
         self.security_policy = policy
 
-    def _make_protocol(self) -> UASocketProtocol:
+    def _make_protocol(self):
         self.protocol = UASocketProtocol(self._timeout, security_policy=self.security_policy)
         self.protocol.pre_request_hook = self._pre_request_hook
         return self.protocol
@@ -334,52 +522,71 @@ class UaClient(AbstractSession):
         return self._pre_request_hook
 
     @pre_request_hook.setter
-    def pre_request_hook(self, hook: Callable[[], Awaitable[None]] | None) -> None:
+    def pre_request_hook(self, hook: Callable[[], Awaitable[None]] | None):
         self._pre_request_hook = hook
         if self.protocol:
             self.protocol.pre_request_hook = self._pre_request_hook
 
-    async def connect_socket(self, host: str, port: int) -> None:
+    async def connect_socket(self, host: str, port: int):
         """Connect to server socket."""
         self.logger.info("opening connection")
         self._closing = False
+        self.set_connection_state(UaClient.CONNECTION_STATE.CONNECTING)
         # Timeout the connection when the server isn't available
         await asyncio.wait_for(
             asyncio.get_running_loop().create_connection(self._make_protocol, host, port), self._timeout
         )
 
-    def disconnect_socket(self) -> None:
+    def disconnect_socket(self):
+        self._cancel_subscription_dispatch_workers()
         if not self.protocol:
+            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
             return
         if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
             self.logger.warning("disconnect_socket was called but connection is closed")
+            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
             return
         self.protocol.disconnect_socket()
         self.protocol = None
+        self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
 
-    async def send_hello(self, url: str, max_messagesize: int = 0, max_chunkcount: int = 0) -> ua.Acknowledge:
-        if self.protocol is None:
-            raise ConnectionError("Connection is not open")
-        return await self.protocol.send_hello(url, max_messagesize, max_chunkcount)
+    async def _send_request(
+        self,
+        request,
+        timeout: float | None = None,
+        message_type=ua.MessageType.SecureMessage,
+        bypass_ready_gate: bool = False,
+    ):
+        if not bypass_ready_gate and self._internal_service_call_depth == 0:
+            await self.await_ready(timeout=timeout)
+        protocol = self.protocol
+        if protocol is None or protocol.state != UASocketProtocol.OPEN:
+            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+            raise ConnectionError("Connection is closed")
+        return await protocol.send_request(request, timeout=timeout, message_type=message_type)
 
-    async def open_secure_channel(self, params: ua.OpenSecureChannelParameters) -> OpenSecureChannelResult:
-        if self.protocol is None:
-            raise ConnectionError("Connection is not open")
-        return await self.protocol.open_secure_channel(params)
+    async def send_hello(self, url, max_messagesize: int = 0, max_chunkcount: int = 0):
+        await self.protocol.send_hello(url, max_messagesize, max_chunkcount)
 
-    async def close_secure_channel(self) -> None:
+    async def open_secure_channel(self, params):
+        result = await self.protocol.open_secure_channel(params)
+        if self._connection_state != UaClient.CONNECTION_STATE.SESSION_READY:
+            self.set_connection_state(UaClient.CONNECTION_STATE.CHANNEL_READY)
+        return result
+
+    async def close_secure_channel(self):
         """
         close secure channel. It seems to trigger a shutdown of socket
         in most servers, so be prepared to reconnect
         """
         if not self.protocol or self.protocol.state == UASocketProtocol.CLOSED:
             self.logger.warning("close_secure_channel was called but connection is closed")
+            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
             return None
+        self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTING)
         return await self.protocol.close_secure_channel()
 
-    async def create_session(self, parameters: ua.CreateSessionParameters) -> ua.CreateSessionResult:
-        if self.protocol is None:
-            raise ConnectionError("Connection is not open")
+    async def create_session(self, parameters):
         self.logger.info("create_session")
         self._closing = False
         # FIXME: setting a value on an object to set it its state is suspicious,
@@ -387,38 +594,29 @@ class UaClient(AbstractSession):
         self.protocol.closed = False
         request = ua.CreateSessionRequest()
         request.Parameters = parameters
-        data = await self._send_request(request)
+        data = await self._send_request(request, bypass_ready_gate=True)
         response = struct_from_binary(ua.CreateSessionResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
         self.protocol.authentication_token = response.Parameters.AuthenticationToken
         return response.Parameters
 
-    async def activate_session(self, parameters: ua.ActivateSessionParameters) -> ua.ActivateSessionResult:
+    async def activate_session(self, parameters):
         self.logger.info("activate_session")
         request = ua.ActivateSessionRequest()
         request.Parameters = parameters
-        data = await self._send_request(request)
+        data = await self._send_request(request, bypass_ready_gate=True)
         response = struct_from_binary(ua.ActivateSessionResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
+        self.set_connection_state(UaClient.CONNECTION_STATE.SESSION_READY)
         return response.Parameters
 
-    async def close_session(self, delete_subscriptions: bool) -> None:
+    async def close_session(self, delete_subscriptions):
         self.logger.info("close_session")
-        if not self.protocol:
-            self.logger.warning("close_session but connection wasn't established")
+        if not self._prepare_close_session():
             return
-        self.protocol.closed = True
-        self._closing = True
-        if self._publish_task and not self._publish_task.done():
-            self._publish_task.cancel()
-        if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
-            self.logger.warning("close_session was called but connection is closed")
-            return
-        request = ua.CloseSessionRequest()
-        request.DeleteSubscriptions = delete_subscriptions
-        data = await self._send_request(request)
+        data = await self._send_close_session_request(delete_subscriptions)
         response = struct_from_binary(ua.CloseSessionResponse, data)
         try:
             response.ResponseHeader.ServiceResult.check()
@@ -432,7 +630,27 @@ class UaClient(AbstractSession):
             # Problem: older versions of asyncua didn't allow closing non-activated sessions. just ignore it.
             pass
 
-    async def browse(self, parameters: ua.BrowseParameters) -> list[ua.BrowseResult]:
+    def _prepare_close_session(self) -> bool:
+        self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTING)
+        self._closing = True
+        if self._publish_task and not self._publish_task.done():
+            self._publish_task.cancel()
+        self._cancel_subscription_dispatch_workers()
+        if not self.protocol:
+            self.logger.warning("close_session but connection wasn't established")
+            return False
+        self.protocol.closed = True
+        if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
+            self.logger.warning("close_session was called but connection is closed")
+            return False
+        return True
+
+    async def _send_close_session_request(self, delete_subscriptions):
+        request = ua.CloseSessionRequest()
+        request.DeleteSubscriptions = delete_subscriptions
+        return await self._send_request(request, bypass_ready_gate=True)
+
+    async def browse(self, parameters):
         self.logger.info("browse")
         request = ua.BrowseRequest()
         request.Parameters = parameters
@@ -442,14 +660,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def _send_request(
-        self, request: Any, timeout: float = 1, message_type: ua.MessageType = ua.MessageType.SecureMessage
-    ) -> Buffer:
-        if self.protocol is None:
-            raise ConnectionError("Connection is not open")
-        return await self.protocol.send_request(request, timeout, message_type)
-
-    async def browse_next(self, parameters: ua.BrowseNextParameters) -> list[ua.BrowseResult]:
+    async def browse_next(self, parameters):
         self.logger.debug("browse next")
         request = ua.BrowseNextRequest()
         request.Parameters = parameters
@@ -459,7 +670,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Parameters.Results
 
-    async def read(self, parameters: ua.ReadParameters) -> list[ua.DataValue]:
+    async def read(self, parameters):
         self.logger.debug("read")
         request = ua.ReadRequest()
         request.Parameters = parameters
@@ -469,7 +680,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def write(self, params: ua.WriteParameters) -> list[ua.StatusCode]:
+    async def write(self, params):
         self.logger.debug("write")
         request = ua.WriteRequest()
         request.Parameters = params
@@ -479,77 +690,77 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def get_endpoints(self, params: ua.GetEndpointsParameters) -> list[ua.EndpointDescription]:
+    async def get_endpoints(self, params):
         self.logger.debug("get_endpoint")
         request = ua.GetEndpointsRequest()
         request.Parameters = params
-        data = await self._send_request(request)
+        data = await self._send_request(request, bypass_ready_gate=True)
         response = struct_from_binary(ua.GetEndpointsResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
         return response.Endpoints
 
-    async def find_servers(self, params: ua.FindServersParameters) -> list[ua.ApplicationDescription]:
+    async def find_servers(self, params):
         self.logger.debug("find_servers")
         request = ua.FindServersRequest()
         request.Parameters = params
-        data = await self._send_request(request)
+        data = await self._send_request(request, bypass_ready_gate=True)
         response = struct_from_binary(ua.FindServersResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
         return response.Servers
 
-    async def find_servers_on_network(self, params: ua.FindServersOnNetworkParameters) -> ua.FindServersOnNetworkResult:
+    async def find_servers_on_network(self, params):
         self.logger.debug("find_servers_on_network")
         request = ua.FindServersOnNetworkRequest()
         request.Parameters = params
-        data = await self._send_request(request)
+        data = await self._send_request(request, bypass_ready_gate=True)
         response = struct_from_binary(ua.FindServersOnNetworkResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
         return response.Parameters
 
-    async def register_server(self, registered_server: ua.RegisteredServer) -> None:
+    async def register_server(self, registered_server):
         self.logger.debug("register_server")
         request = ua.RegisterServerRequest()
         request.Server = registered_server
-        data = await self._send_request(request)
+        data = await self._send_request(request, bypass_ready_gate=True)
         response = struct_from_binary(ua.RegisterServerResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
         # nothing to return for this service
 
-    async def unregister_server(self, registered_server: ua.RegisteredServer) -> None:
+    async def unregister_server(self, registered_server):
         self.logger.debug("unregister_server")
         request = ua.RegisterServerRequest()
         request.Server = registered_server
-        data = await self._send_request(request)
+        data = await self._send_request(request, bypass_ready_gate=True)
         response = struct_from_binary(ua.RegisterServerResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
         # nothing to return for this service
 
-    async def register_server2(self, params: ua.RegisterServer2Parameters) -> list[ua.StatusCode]:
+    async def register_server2(self, params):
         self.logger.debug("register_server2")
         request = ua.RegisterServer2Request()
         request.Parameters = params
-        data = await self._send_request(request)
+        data = await self._send_request(request, bypass_ready_gate=True)
         response = struct_from_binary(ua.RegisterServer2Response, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
         return response.ConfigurationResults
 
-    async def unregister_server2(self, params: ua.RegisterServer2Parameters) -> list[ua.StatusCode]:
+    async def unregister_server2(self, params):
         self.logger.debug("unregister_server2")
         request = ua.RegisterServer2Request()
         request.Parameters = params
-        data = await self._send_request(request)
+        data = await self._send_request(request, bypass_ready_gate=True)
         response = struct_from_binary(ua.RegisterServer2Response, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
         return response.ConfigurationResults
 
-    async def translate_browsepaths_to_nodeids(self, browse_paths: list[ua.BrowsePath]) -> list[ua.BrowsePathResult]:
+    async def translate_browsepaths_to_nodeids(self, browse_paths):
         self.logger.debug("translate_browsepath_to_nodeid")
         request = ua.TranslateBrowsePathsToNodeIdsRequest()
         request.Parameters.BrowsePaths = browse_paths
@@ -560,7 +771,7 @@ class UaClient(AbstractSession):
         return response.Results
 
     async def create_subscription(  # type: ignore[override]
-        self, params: ua.CreateSubscriptionParameters, callback: Callable[..., Any]
+        self, params: ua.CreateSubscriptionParameters, callback
     ) -> ua.CreateSubscriptionResult:
         self.logger.debug("create_subscription")
         request = ua.CreateSubscriptionRequest()
@@ -568,8 +779,17 @@ class UaClient(AbstractSession):
         data = await self._send_request(request)
         response = struct_from_binary(ua.CreateSubscriptionResponse, data)
         response.ResponseHeader.ServiceResult.check()
-        self._subscription_callbacks[response.Parameters.SubscriptionId] = callback
-        self.logger.info("create_subscription success SubscriptionId %s", response.Parameters.SubscriptionId)
+        subscription_id = response.Parameters.SubscriptionId
+        self._subscription_callbacks[subscription_id] = callback
+        self._ensure_subscription_dispatch_worker(subscription_id)
+        publishing_interval_ms = float(
+            getattr(response.Parameters, "RevisedPublishingInterval", params.RequestedPublishingInterval or 0.0) or 0.0
+        )
+        keepalive_count = int(
+            getattr(response.Parameters, "RevisedMaxKeepAliveCount", params.RequestedMaxKeepAliveCount or 1) or 1
+        )
+        self._register_subscription_watchdog(subscription_id, publishing_interval_ms, keepalive_count)
+        self.logger.info("create_subscription success SubscriptionId %s", subscription_id)
         if not self._publish_task or self._publish_task.done():
             # Start the publishing loop if it is not yet running
             # The current strategy is to have only one open publish request per UaClient. This might not be enough
@@ -578,7 +798,7 @@ class UaClient(AbstractSession):
             self._publish_task = asyncio.create_task(self._publish_loop())
         return response.Parameters
 
-    async def inform_subscriptions(self, status: ua.StatusCode) -> None:
+    async def inform_subscriptions(self, status: ua.StatusCode):
         """
         Inform all current subscriptions with a status code. This calls the handler's status_change_notification
         """
@@ -587,10 +807,7 @@ class UaClient(AbstractSession):
         for subid, callback in self._subscription_callbacks.items():
             try:
                 parameters = ua.PublishResult(subid, NotificationMessage=notification_message)
-                if inspect.iscoroutinefunction(callback):
-                    await callback(parameters)
-                else:
-                    callback(parameters)
+                await self._invoke_subscription_callback(callback, parameters)
             except Exception:  # we call user code, catch everything!
                 self.logger.exception("Exception while calling user callback: %s")
 
@@ -600,12 +817,17 @@ class UaClient(AbstractSession):
         data = await self._send_request(request)
         response = struct_from_binary(ua.ModifySubscriptionResponse, data)
         response.ResponseHeader.ServiceResult.check()
+        self._register_subscription_watchdog(
+            int(params.SubscriptionId),
+            float(getattr(response.Parameters, "RevisedPublishingInterval", params.RequestedPublishingInterval or 0.0) or 0.0),
+            int(getattr(response.Parameters, "RevisedMaxKeepAliveCount", params.RequestedMaxKeepAliveCount or 1) or 1),
+        )
         self.logger.info("update_subscription success SubscriptionId %s", params.SubscriptionId)
         return response.Parameters
 
     modify_subscription = update_subscription  # legacy support
 
-    async def delete_subscriptions(self, subscription_ids: list[int]) -> list[ua.StatusCode]:  # type: ignore[override]
+    async def delete_subscriptions(self, subscription_ids):
         self.logger.debug("delete_subscriptions %r", subscription_ids)
         request = ua.DeleteSubscriptionsRequest()
         request.Parameters.SubscriptionIds = subscription_ids
@@ -615,7 +837,360 @@ class UaClient(AbstractSession):
         self.logger.info("remove subscription callbacks for %r", subscription_ids)
         for sid in subscription_ids:
             self._subscription_callbacks.pop(sid)
+            self._stop_subscription_dispatch_worker(sid)
+            self._last_publish_sequence_numbers.pop(sid, None)
+            self._subscription_watchdog_states.pop(sid, None)
         return response.Results
+
+    def _ensure_subscription_dispatch_worker(self, subscription_id: int) -> None:
+        runtime = self._subscription_dispatch_runtime.get(subscription_id)
+        if runtime is None:
+            maxsize = max(int(self.subscription_dispatch_queue_maxsize), 0)
+            runtime = _SubscriptionDispatchRuntime(queue=asyncio.Queue(maxsize=maxsize))
+            self._subscription_dispatch_runtime[subscription_id] = runtime
+        if runtime.task is None or runtime.task.done():
+            runtime.task = asyncio.create_task(self._subscription_dispatch_worker(subscription_id))
+
+    def _stop_subscription_dispatch_worker(self, subscription_id: int) -> None:
+        runtime = self._subscription_dispatch_runtime.pop(subscription_id, None)
+        if runtime is None:
+            return
+        queue = runtime.queue
+        if queue is not None:
+            try:
+                queue.put_nowait(None)
+            except asyncio.QueueFull:
+                pass
+        task = runtime.task
+        if task is not None and not task.done():
+            task.cancel()
+
+    def _cancel_subscription_dispatch_workers(self) -> None:
+        subscription_ids = list(self._subscription_dispatch_runtime.keys())
+        for subscription_id in subscription_ids:
+            self._stop_subscription_dispatch_worker(subscription_id)
+
+    async def flush_subscription_dispatch(
+        self,
+        subscription_ids: list[int] | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        if subscription_ids is None:
+            queues = [runtime.queue for runtime in self._subscription_dispatch_runtime.values()]
+        else:
+            queues = [
+                self._subscription_dispatch_runtime[subscription_id].queue
+                for subscription_id in subscription_ids
+                if subscription_id in self._subscription_dispatch_runtime
+            ]
+        if not queues:
+            return
+        awaitable = asyncio.gather(*(queue.join() for queue in queues))
+        if timeout is None:
+            await awaitable
+        else:
+            await asyncio.wait_for(awaitable, timeout)
+
+    async def _subscription_dispatch_worker(self, subscription_id: int) -> None:
+        runtime = self._subscription_dispatch_runtime.get(subscription_id)
+        if runtime is None:
+            return
+        queue = runtime.queue
+        while True:
+            publish_result = await queue.get()
+            try:
+                if publish_result is None:
+                    return
+                callback = self._subscription_callbacks.get(subscription_id)
+                if callback is None:
+                    self.logger.warning(
+                        "Received queued publish result for unknown subscription %s active are %s",
+                        subscription_id,
+                        self._subscription_callbacks.keys(),
+                    )
+                    continue
+                await self._invoke_subscription_callback(callback, publish_result)
+            except Exception:
+                self.logger.exception("Exception while calling user callback: %s")
+            finally:
+                queue.task_done()
+
+    async def _invoke_subscription_callback(self, callback, publish_result: ua.PublishResult) -> None:
+        result = callback(publish_result)
+        if inspect.isawaitable(result):
+            await result
+
+    def _get_dispatch_queue(self, subscription_id: int) -> asyncio.Queue[ua.PublishResult | None] | None:
+        self._ensure_subscription_dispatch_worker(subscription_id)
+        runtime = self._subscription_dispatch_runtime.get(subscription_id)
+        if runtime is None:
+            return None
+        return runtime.queue
+
+    def _enqueue_with_drop_oldest(
+        self,
+        queue: asyncio.Queue[ua.PublishResult | None],
+        subscription_id: int,
+        publish_result: ua.PublishResult,
+    ) -> bool:
+        dropped = False
+        try:
+            oldest = queue.get_nowait()
+            queue.task_done()
+            dropped = True
+            if oldest is None:
+                queue.put_nowait(None)
+        except asyncio.QueueEmpty:
+            pass
+        try:
+            queue.put_nowait(publish_result)
+        except asyncio.QueueFull:
+            self.logger.warning(
+                "Subscription %s dispatch queue still full after drop_oldest; dropping newest notification",
+                subscription_id,
+            )
+            return False
+        if dropped:
+            self.logger.warning(
+                "Subscription %s dispatch queue overflow; dropped oldest queued notification",
+                subscription_id,
+            )
+        return True
+
+    def _enqueue_with_disconnect_policy(
+        self,
+        queue: asyncio.Queue[ua.PublishResult | None],
+        subscription_id: int,
+    ) -> bool:
+        overflow_error = SubscriptionDispatchOverflowError(subscription_id, queue.qsize())
+        self.logger.error("%s", overflow_error)
+        self._fail_all_dispatch_workers(overflow_error)
+        self._closing = True
+        return False
+
+    def _enqueue_with_warn_policy(self, subscription_id: int) -> bool:
+        self.logger.warning(
+            "Subscription %s dispatch queue overflow; dropping newest notification",
+            subscription_id,
+        )
+        return False
+
+    def _enqueue_when_full(
+        self,
+        queue: asyncio.Queue[ua.PublishResult | None],
+        subscription_id: int,
+        publish_result: ua.PublishResult,
+    ) -> bool:
+        policy = self._resolve_overflow_policy()
+        if policy == SubscriptionDispatchOverflowPolicy.DROP_OLDEST:
+            return self._enqueue_with_drop_oldest(queue, subscription_id, publish_result)
+        if policy == SubscriptionDispatchOverflowPolicy.DISCONNECT:
+            return self._enqueue_with_disconnect_policy(queue, subscription_id)
+        if policy == SubscriptionDispatchOverflowPolicy.WARN:
+            return self._enqueue_with_warn_policy(subscription_id)
+        return self._enqueue_with_warn_policy(subscription_id)
+
+    def _resolve_overflow_policy(self) -> SubscriptionDispatchOverflowPolicy:
+        policy = self.subscription_dispatch_overflow_policy
+        if isinstance(policy, SubscriptionDispatchOverflowPolicy):
+            return policy
+        if isinstance(policy, str):
+            normalized = policy.strip().lower()
+            for candidate in SubscriptionDispatchOverflowPolicy:
+                if candidate.value == normalized:
+                    self.subscription_dispatch_overflow_policy = candidate
+                    return candidate
+            self.logger.warning(
+                "Unknown subscription dispatch overflow policy '%s'; falling back to '%s'",
+                policy,
+                SubscriptionDispatchOverflowPolicy.WARN.value,
+            )
+            self.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.WARN
+            return SubscriptionDispatchOverflowPolicy.WARN
+        self.logger.warning(
+            "Unsupported subscription dispatch overflow policy type '%s'; falling back to '%s'",
+            type(policy).__name__,
+            SubscriptionDispatchOverflowPolicy.WARN.value,
+        )
+        self.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.WARN
+        return SubscriptionDispatchOverflowPolicy.WARN
+
+    def _enqueue_publish_result(self, subscription_id: int, publish_result: ua.PublishResult) -> bool:
+        callback = self._subscription_callbacks.get(subscription_id)
+        if callback is None:
+            self.logger.warning(
+                "Received publish result for unknown subscription %s active are %s",
+                subscription_id,
+                self._subscription_callbacks.keys(),
+            )
+            return False
+        queue = self._get_dispatch_queue(subscription_id)
+        if queue is None:
+            return False
+        if not queue.full():
+            queue.put_nowait(publish_result)
+            return True
+        return self._enqueue_when_full(queue, subscription_id, publish_result)
+
+    def _fail_all_dispatch_workers(self, exc: Exception) -> None:
+        for runtime in self._subscription_dispatch_runtime.values():
+            task = runtime.task
+            if task is not None and not task.done():
+                task.cancel()
+        self._subscription_dispatch_runtime.clear()
+
+    def get_subscription_ids(self) -> list[int]:
+        return list(self._subscription_callbacks.keys())
+
+    def _register_subscription_watchdog(self, subscription_id: int, publishing_interval_ms: float, keepalive_count: int) -> None:
+        if publishing_interval_ms <= 0:
+            self._subscription_watchdog_states.pop(subscription_id, None)
+            return
+        self._subscription_watchdog_states[subscription_id] = _SubscriptionWatchdogState(
+            publishing_interval_ms=publishing_interval_ms,
+            keepalive_count=max(int(keepalive_count), 1),
+            last_seen_at=asyncio.get_running_loop().time(),
+        )
+
+    def _mark_subscription_watchdog_activity(self, subscription_id: int) -> None:
+        state = self._subscription_watchdog_states.get(subscription_id)
+        if state is None:
+            return
+        state.last_seen_at = asyncio.get_running_loop().time()
+        state.stale_reported = False
+
+    def _get_stale_subscription_ids(self, now: float) -> list[int]:
+        if not self.watchdog_settings.stale_detection_enabled:
+            return []
+        stale_subscription_ids: list[int] = []
+        margin = max(self.watchdog_settings.stale_detection_margin, 1.0)
+        stale_state_ids_to_prune: list[int] = []
+        for subscription_id, state in self._subscription_watchdog_states.items():
+            if subscription_id not in self._subscription_callbacks:
+                stale_state_ids_to_prune.append(subscription_id)
+                continue
+            timeout = (state.publishing_interval_ms / 1000.0) * state.keepalive_count * margin
+            if timeout <= 0:
+                continue
+            if (now - state.last_seen_at) <= timeout:
+                continue
+            if state.stale_reported:
+                continue
+            state.stale_reported = True
+            stale_subscription_ids.append(subscription_id)
+        for stale_state_id in stale_state_ids_to_prune:
+            self._subscription_watchdog_states.pop(stale_state_id, None)
+        return stale_subscription_ids
+
+    def get_next_sequence_number(self, subscription_id: int) -> int:
+        last_sequence = self._last_publish_sequence_numbers.get(subscription_id, 0)
+        return last_sequence + 1
+
+    def _record_notification_sequence_number(
+        self,
+        subscription_id: int,
+        notification_message: ua.NotificationMessage,
+        source: str = "publish",
+    ) -> None:
+        # Keep-alive messages contain the next sequence number and do not represent
+        # a delivered NotificationMessage. Track only messages that include
+        # NotificationData so reconnect republish starts from the correct sequence.
+        if not notification_message.NotificationData:
+            return
+
+        received = int(notification_message.SequenceNumber)
+        if subscription_id in self._last_publish_sequence_numbers:
+            expected = self.get_next_sequence_number(subscription_id)
+            if received != expected:
+                self.logger.warning(
+                    "Detected notification sequence mismatch on subscription %s (%s): expected %s but received %s",
+                    subscription_id,
+                    source,
+                    expected,
+                    received,
+                )
+
+        self._last_publish_sequence_numbers[subscription_id] = received
+
+    async def dispatch_notification_message(self, subscription_id: int, notification_message: ua.NotificationMessage) -> None:
+        self._record_notification_sequence_number(subscription_id, notification_message, source="republish")
+        result = ua.PublishResult(subscription_id, NotificationMessage=notification_message)
+        self._enqueue_publish_result(subscription_id, result)
+
+    def ensure_publish_loop_running(self) -> None:
+        if self._subscription_callbacks and (not self._publish_task or self._publish_task.done()):
+            self._publish_task = asyncio.create_task(self._publish_loop())
+
+    async def restart_publish_loop(self) -> None:
+        if self._publish_task is not None and not self._publish_task.done():
+            self._publish_task.cancel()
+            try:
+                await self._publish_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._publish_task = None
+        self.ensure_publish_loop_running()
+
+    async def republish(self, subscription_id: int, retransmit_sequence_number: int) -> ua.NotificationMessage:
+        request = ua.RepublishRequest()
+        request.Parameters.SubscriptionId = subscription_id
+        request.Parameters.RetransmitSequenceNumber = retransmit_sequence_number
+        data = await self._send_request(request)
+        response = struct_from_binary(ua.RepublishResponse, data)
+        response.ResponseHeader.ServiceResult.check()
+        return response.NotificationMessage
+
+    async def _recover_sequence_gap(self, subscription_id: int, expected_sequence: int, received_sequence: int) -> None:
+        max_republish = max(int(self.max_republish_messages_per_gap), 0)
+        replay_window = _compute_republish_window(expected_sequence, received_sequence, max_republish)
+        if replay_window is None:
+            return
+        replay_start, replay_end_exclusive = replay_window
+        missing_count = received_sequence - expected_sequence
+
+        if (replay_end_exclusive - replay_start) < missing_count:
+            self.logger.warning(
+                "Sequence gap on subscription %s is %s messages; replay capped to %s messages",
+                subscription_id,
+                missing_count,
+                max_republish,
+            )
+
+        self.logger.warning(
+            "Detected notification sequence gap on subscription %s: expected %s but received %s. Attempting republish",
+            subscription_id,
+            expected_sequence,
+            received_sequence,
+        )
+
+        for sequence_number in range(replay_start, replay_end_exclusive):
+            try:
+                notification_message = await self.republish(subscription_id, sequence_number)
+            except ua.UaStatusCodeError as err:
+                if err.code == ua.StatusCodes.BadMessageNotAvailable:
+                    self.logger.warning(
+                        "Republish missing sequence %s for subscription %s is not available on server",
+                        sequence_number,
+                        subscription_id,
+                    )
+                    break
+                if err.code == ua.StatusCodes.BadSubscriptionIdInvalid:
+                    self.logger.warning(
+                        "Republish failed for subscription %s because subscription is invalid",
+                        subscription_id,
+                    )
+                    break
+                raise
+            republished_sequence = int(notification_message.SequenceNumber)
+            if republished_sequence != sequence_number:
+                self.logger.warning(
+                    "Republish returned unexpected sequence for subscription %s: requested %s but got %s",
+                    subscription_id,
+                    sequence_number,
+                    republished_sequence,
+                )
+                break
+            await self.dispatch_notification_message(subscription_id, notification_message)
 
     async def publish(self, acks: list[ua.SubscriptionAcknowledgement]) -> ua.PublishResponse:
         """
@@ -625,8 +1200,10 @@ class UaClient(AbstractSession):
         request = ua.PublishRequest()
         request.Parameters.SubscriptionAcknowledgements = acks if acks else []
         data = await self._send_request(request, timeout=0)
-        assert self.protocol is not None
-        self.protocol.check_answer(data, "while waiting for publish response")
+        protocol = self.protocol
+        if protocol is None:
+            raise ConnectionError("Connection is closed")
+        protocol.check_answer(data, "while waiting for publish response")
         try:
             response = struct_from_binary(ua.PublishResponse, data)
         except Exception as ex:
@@ -634,7 +1211,74 @@ class UaClient(AbstractSession):
             raise UaStructParsingError from ex
         return response
 
-    async def _publish_loop(self) -> None:
+    async def _read_publish_response(
+        self,
+        ack: SubscriptionAcknowledgement | None,
+    ) -> ua.PublishResponse | None:
+        try:
+            return await self.publish([ack] if ack else [])
+        except BadTimeout:  # See Spec. Part 4, 7.28
+            # Repeat without acknowledgement
+            return None
+        except BadNoSubscription:  # See Spec. Part 5, 13.8.1
+            # BadNoSubscription is expected to be received after deleting the last subscription.
+            # We use this as a signal to exit this task and stop sending PublishRequests.
+            self.logger.info("BadNoSubscription received, ignoring because it's probably valid.")
+            raise
+        except UaStructParsingError:
+            # Keep loop alive, parse problems can happen with broken payloads.
+            return None
+
+    async def _maybe_recover_gap(
+        self,
+        subscription_id: int,
+        notification_message: ua.NotificationMessage,
+    ) -> None:
+        if (
+            not self.sequence_recovery_settings.auto_republish_on_gap
+            or not notification_message.NotificationData
+            or subscription_id not in self._last_publish_sequence_numbers
+        ):
+            return
+        expected_sequence = self.get_next_sequence_number(subscription_id)
+        received_sequence = int(notification_message.SequenceNumber)
+        if received_sequence > expected_sequence:
+            await self._recover_sequence_gap(subscription_id, expected_sequence, received_sequence)
+
+    def _build_publish_ack(
+        self,
+        subscription_id: int,
+        notification_message: ua.NotificationMessage,
+    ) -> SubscriptionAcknowledgement | None:
+        if not notification_message.NotificationData:
+            return None
+        ack = ua.SubscriptionAcknowledgement()
+        ack.SubscriptionId = subscription_id
+        ack.SequenceNumber = notification_message.SequenceNumber
+        return ack
+
+    async def _handle_publish_response(self, response: ua.PublishResponse) -> SubscriptionAcknowledgement | None:
+        subscription_id = response.Parameters.SubscriptionId
+        if not subscription_id:
+            # The value 0 indicates there were no subscriptions for which a response could be sent.
+            raise BadNoSubscription()
+
+        self._mark_subscription_watchdog_activity(subscription_id)
+        stale_subscription_ids = self._get_stale_subscription_ids(asyncio.get_running_loop().time())
+        if stale_subscription_ids:
+            raise SubscriptionStaleError(stale_subscription_ids)
+
+        notification_message = response.Parameters.NotificationMessage
+        await self._maybe_recover_gap(subscription_id, notification_message)
+        self._enqueue_publish_result(subscription_id, response.Parameters)
+        self._record_notification_sequence_number(
+            subscription_id,
+            notification_message,
+            source="publish",
+        )
+        return self._build_publish_ack(subscription_id, notification_message)
+
+    async def _publish_loop(self):
         """
         Start a loop that sends a publish requests and waits for the publish responses.
         Forward the `PublishResult` to the matching `Subscription` by callback.
@@ -642,63 +1286,21 @@ class UaClient(AbstractSession):
         ack: SubscriptionAcknowledgement | None = None
         while not self._closing:
             try:
-                response = await self.publish([ack] if ack else [])
-            except BadTimeout:  # See Spec. Part 4, 7.28
-                # Repeat without acknowledgement
-                ack = None
-                continue
-            except BadNoSubscription:  # See Spec. Part 5, 13.8.1
-                # BadNoSubscription is expected to be received after deleting the last subscription.
-                # We use this as a signal to exit this task and stop sending PublishRequests. This is easier than
-                # checking if there are no more subscriptions registered in this client (). A Publish response
-                # could still arrive before the DeleteSubscription response.
-                #
-                # We could remove the callback already when sending the DeleteSubscription request,
-                # but there are some legitimate reasons to keep them around, such as when the server
-                # responds with "BadTimeout" and we should try again later instead of just removing
-                # the subscription client-side.
-                #
-                # There are a variety of ways to act correctly, but the most practical solution seems
-                # to be to just silently ignore any BadNoSubscription responses.
-                self.logger.info("BadNoSubscription received, ignoring because it's probably valid.")
-                # End task
+                response = await self._read_publish_response(ack)
+                if response is None:
+                    ack = None
+                    continue
+                ack = await self._handle_publish_response(response)
+            except BadNoSubscription:
                 return
-            except UaStructParsingError:
+            except SubscriptionStaleError:
+                raise
+            except Exception:
+                # Keep publish flow alive after unexpected callback or parsing edge cases.
                 ack = None
-                continue
-            subscription_id = response.Parameters.SubscriptionId
-            if not subscription_id:
-                # The value 0 is used to indicate that there were no Subscriptions defined for which a
-                # response could be sent. See Spec. Part 4 - Section 5.13.5 "Publish"
-                # End task
-                return
-            try:
-                callback = self._subscription_callbacks[subscription_id]
-            except KeyError:
-                self.logger.warning(
-                    "Received data for unknown subscription %s active are %s",
-                    subscription_id,
-                    self._subscription_callbacks.keys(),
-                )
-            else:
-                try:
-                    if inspect.iscoroutinefunction(callback):
-                        await callback(response.Parameters)
-                    else:
-                        callback(response.Parameters)
-                except Exception:  # we call user code, catch everything!
-                    self.logger.exception("Exception while calling user callback: %s")
-            # Repeat with acknowledgement
-            if response.Parameters.NotificationMessage.NotificationData:
-                ack = ua.SubscriptionAcknowledgement()
-                ack.SubscriptionId = subscription_id
-                ack.SequenceNumber = response.Parameters.NotificationMessage.SequenceNumber
-            else:
-                ack = None
+                self.logger.exception("Unexpected error in publish loop")
 
-    async def create_monitored_items(
-        self, params: ua.CreateMonitoredItemsParameters
-    ) -> list[ua.MonitoredItemCreateResult]:
+    async def create_monitored_items(self, params):
         self.logger.info("create_monitored_items")
         request = ua.CreateMonitoredItemsRequest()
         request.Parameters = params
@@ -708,7 +1310,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def delete_monitored_items(self, params: ua.DeleteMonitoredItemsParameters) -> list[ua.StatusCode]:
+    async def delete_monitored_items(self, params):
         self.logger.info("delete_monitored_items")
         request = ua.DeleteMonitoredItemsRequest()
         request.Parameters = params
@@ -718,7 +1320,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def add_nodes(self, nodestoadd: list[ua.AddNodesItem]) -> list[ua.AddNodesResult]:
+    async def add_nodes(self, nodestoadd):
         self.logger.info("add_nodes")
         request = ua.AddNodesRequest()
         request.Parameters.NodesToAdd = nodestoadd
@@ -728,7 +1330,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def add_references(self, refs: list[ua.AddReferencesItem]) -> list[ua.StatusCode]:
+    async def add_references(self, refs):
         self.logger.info("add_references")
         request = ua.AddReferencesRequest()
         request.Parameters.ReferencesToAdd = refs
@@ -738,7 +1340,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def delete_references(self, refs: list[ua.DeleteReferencesItem]) -> list[ua.StatusCode]:
+    async def delete_references(self, refs):
         self.logger.info("delete")
         request = ua.DeleteReferencesRequest()
         request.Parameters.ReferencesToDelete = refs
@@ -748,7 +1350,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Parameters.Results
 
-    async def delete_nodes(self, params: ua.DeleteNodesParameters) -> list[ua.StatusCode]:
+    async def delete_nodes(self, params):
         self.logger.info("delete_nodes")
         request = ua.DeleteNodesRequest()
         request.Parameters = params
@@ -758,7 +1360,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def call(self, methodstocall: list[ua.CallMethodRequest]) -> list[ua.CallMethodResult]:
+    async def call(self, methodstocall):
         request = ua.CallRequest()
         request.Parameters.MethodsToCall = methodstocall
         data = await self._send_request(request)
@@ -767,7 +1369,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def history_read(self, params: ua.HistoryReadParameters) -> list[ua.HistoryReadResult]:
+    async def history_read(self, params):
         self.logger.info("history_read")
         request = ua.HistoryReadRequest()
         request.Parameters = params
@@ -777,9 +1379,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def modify_monitored_items(
-        self, params: ua.ModifyMonitoredItemsParameters
-    ) -> list[ua.MonitoredItemModifyResult]:
+    async def modify_monitored_items(self, params):
         self.logger.info("modify_monitored_items")
         request = ua.ModifyMonitoredItemsRequest()
         request.Parameters = params
@@ -789,7 +1389,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def register_nodes(self, nodes: list[ua.NodeId]) -> list[ua.NodeId]:
+    async def register_nodes(self, nodes):
         self.logger.info("register_nodes")
         request = ua.RegisterNodesRequest()
         request.Parameters.NodesToRegister = nodes
@@ -799,7 +1399,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Parameters.RegisteredNodeIds
 
-    async def unregister_nodes(self, nodes: list[ua.NodeId]) -> None:
+    async def unregister_nodes(self, nodes):
         self.logger.info("unregister_nodes")
         request = ua.UnregisterNodesRequest()
         request.Parameters.NodesToUnregister = nodes
@@ -809,7 +1409,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         # nothing to return for this service
 
-    async def read_attributes(self, nodeids: list[ua.NodeId], attr: ua.AttributeIds) -> list[ua.DataValue]:
+    async def read_attributes(self, nodeids, attr):
         self.logger.info("read_attributes of several nodes")
         request = ua.ReadRequest()
         for nodeid in nodeids:
@@ -822,12 +1422,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def write_attributes(
-        self,
-        nodeids: list[ua.NodeId],
-        datavalues: list[ua.DataValue],
-        attributeid: ua.AttributeIds = ua.AttributeIds.Value,
-    ) -> list[ua.StatusCode]:
+    async def write_attributes(self, nodeids, datavalues, attributeid=ua.AttributeIds.Value):
         """
         Set an attribute of multiple nodes
         datavalue is a ua.DataValue object
@@ -845,7 +1440,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def set_monitoring_mode(self, params: ua.SetMonitoringModeParameters) -> list[ua.uatypes.StatusCode]:
+    async def set_monitoring_mode(self, params) -> list[ua.uatypes.StatusCode]:
         """
         Update the subscription monitoring mode
         """
@@ -858,7 +1453,7 @@ class UaClient(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Parameters.Results
 
-    async def set_publishing_mode(self, params: ua.SetPublishingModeParameters) -> list[ua.uatypes.StatusCode]:
+    async def set_publishing_mode(self, params) -> list[ua.uatypes.StatusCode]:
         """
         Update the subscription publishing mode
         """
@@ -874,4 +1469,9 @@ class UaClient(AbstractSession):
     async def transfer_subscriptions(self, params: ua.TransferSubscriptionsParameters) -> list[ua.TransferResult]:
         # Subscriptions aren't bound to a Session and can be transferred!
         # https://reference.opcfoundation.org/Core/Part4/v104/5.13.7/
-        raise NotImplementedError
+        request = ua.TransferSubscriptionsRequest()
+        request.Parameters = params
+        data = await self._send_request(request)
+        response = struct_from_binary(ua.TransferSubscriptionsResponse, data)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Parameters.Results

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import copy
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any
 
@@ -945,7 +945,7 @@ class UaClient:
             raise ConnectionError("Client is not ready") from ex
 
     @asynccontextmanager
-    async def internal_service_calls(self):
+    async def internal_service_calls(self) -> AsyncIterator[None]:
         """Context manager for internal operations bypassing ready gate."""
         self._internal_service_call_depth += 1
         try:

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -1291,6 +1291,9 @@ class UaClient(AbstractSession):
                     ack = None
                     continue
                 ack = await self._handle_publish_response(response)
+                # Yield once per successful publish cycle so notification-dispatch
+                # workers can run even when publish() returns immediately.
+                await asyncio.sleep(0)
             except BadNoSubscription:
                 return
             except SubscriptionStaleError:

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -676,7 +676,7 @@ class UaClient:
 
         if self._default_session is not None:
             try:
-                await self._default_session.close_session(delete_subscriptions)
+                await self._default_session.close()
             finally:
                 self._unregister_session(self._default_session)
                 self._default_session = None
@@ -1040,7 +1040,7 @@ class UaClient:
         sessions = list(self._sessions.values())
         for session in sessions:
             try:
-                await session.close_session(delete_subscriptions)
+                await session.close()
             except Exception:
                 self.logger.exception("Error closing session %s",
                                       session.session_id)

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -1190,8 +1190,8 @@ class UaClient:
     async def register_nodes(self, nodes: list[ua.NodeId]) -> list[ua.NodeId]:
         return await self._require_default_session().register_nodes(nodes)
 
-    async def unregister_nodes(self, nodes: list[ua.NodeId]) -> list[ua.NodeId]:
-        return await self._require_default_session().unregister_nodes(nodes)
+    async def unregister_nodes(self, nodes: list[ua.NodeId]) -> None:
+        await self._require_default_session().unregister_nodes(nodes)
 
     async def create_subscription(
         self, params: ua.CreateSubscriptionParameters, callback: Callable[[ua.PublishResult], Any]

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -99,6 +99,24 @@ def _compute_republish_window(
     return expected_sequence, replay_end_exclusive
 
 
+def _build_publish_ack(
+    subscription_id: int,
+    notification_message: ua.NotificationMessage,
+) -> SubscriptionAcknowledgement | None:
+    if not notification_message.NotificationData:
+        return None
+    ack = ua.SubscriptionAcknowledgement()
+    ack.SubscriptionId = subscription_id
+    ack.SequenceNumber = notification_message.SequenceNumber
+    return ack
+
+
+async def _invoke_subscription_callback(callback, publish_result: ua.PublishResult) -> None:
+    result = callback(publish_result)
+    if inspect.isawaitable(result):
+        await result
+
+
 class UASocketProtocol(asyncio.Protocol):
     """
     Handle socket connection and send ua messages.
@@ -807,7 +825,7 @@ class UaClient(AbstractSession):
         for subid, callback in self._subscription_callbacks.items():
             try:
                 parameters = ua.PublishResult(subid, NotificationMessage=notification_message)
-                await self._invoke_subscription_callback(callback, parameters)
+                await _invoke_subscription_callback(callback, parameters)
             except Exception:  # we call user code, catch everything!
                 self.logger.exception("Exception while calling user callback: %s")
 
@@ -909,16 +927,11 @@ class UaClient(AbstractSession):
                         self._subscription_callbacks.keys(),
                     )
                     continue
-                await self._invoke_subscription_callback(callback, publish_result)
+                await _invoke_subscription_callback(callback, publish_result)
             except Exception:
                 self.logger.exception("Exception while calling user callback: %s")
             finally:
                 queue.task_done()
-
-    async def _invoke_subscription_callback(self, callback, publish_result: ua.PublishResult) -> None:
-        result = callback(publish_result)
-        if inspect.isawaitable(result):
-            await result
 
     def _get_dispatch_queue(self, subscription_id: int) -> asyncio.Queue[ua.PublishResult | None] | None:
         self._ensure_subscription_dispatch_worker(subscription_id)
@@ -1245,18 +1258,6 @@ class UaClient(AbstractSession):
         if received_sequence > expected_sequence:
             await self._recover_sequence_gap(subscription_id, expected_sequence, received_sequence)
 
-    def _build_publish_ack(
-        self,
-        subscription_id: int,
-        notification_message: ua.NotificationMessage,
-    ) -> SubscriptionAcknowledgement | None:
-        if not notification_message.NotificationData:
-            return None
-        ack = ua.SubscriptionAcknowledgement()
-        ack.SubscriptionId = subscription_id
-        ack.SequenceNumber = notification_message.SequenceNumber
-        return ack
-
     async def _handle_publish_response(self, response: ua.PublishResponse) -> SubscriptionAcknowledgement | None:
         subscription_id = response.Parameters.SubscriptionId
         if not subscription_id:
@@ -1276,7 +1277,7 @@ class UaClient(AbstractSession):
             notification_message,
             source="publish",
         )
-        return self._build_publish_ack(subscription_id, notification_message)
+        return _build_publish_ack(subscription_id, notification_message)
 
     async def _publish_loop(self):
         """

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -31,6 +31,7 @@ from ..ua.ua_binary import (
 from ..ua.uaerrors import BadSessionClosed, BadUserAccessDenied
 from ..ua.uaprotocol_auto import OpenSecureChannelResult
 from .ua_session import (
+    SessionState,
     SubscriptionDispatchOverflowError,
     SubscriptionDispatchOverflowPolicy,
     SubscriptionStaleError,
@@ -41,6 +42,7 @@ __all__ = [
     "UaClient",
     "UASocketProtocol",
     "UaSession",
+    "SessionState",
     "SubscriptionStaleError",
     "SubscriptionDispatchOverflowError",
     "SubscriptionDispatchOverflowPolicy",
@@ -388,9 +390,7 @@ class UaClient:
         DISCONNECTED = 1
         CONNECTING = 2
         CHANNEL_READY = 3
-        SESSION_READY = 4
-        SESSION_ESTABLISHING = 5
-        DISCONNECTING = 6
+        DISCONNECTING = 4
 
     def __init__(self, timeout: float = 1.0) -> None:
         """Initialize sessionless client.
@@ -477,11 +477,15 @@ class UaClient:
         if self.protocol.state == UASocketProtocol.CLOSED:
             self.logger.warning("Socket already closed")
             self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+            for session in self._sessions.values():
+                session.on_transport_lost()
             return
 
         self.protocol.disconnect_socket()
         self.protocol = None
         self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+        for session in self._sessions.values():
+            session.on_transport_lost()
 
     # ========== SECURE CHANNEL ==========
 
@@ -536,9 +540,12 @@ class UaClient:
 
         if (
             self._connection_state
-            != UaClient.CONNECTION_STATE.SESSION_READY
+            != UaClient.CONNECTION_STATE.CHANNEL_READY
         ):
             self.set_connection_state(UaClient.CONNECTION_STATE.CHANNEL_READY)
+        for session in self._sessions.values():
+            if session.state == SessionState.SUSPENDED:
+                session.on_transport_restored()
 
         return result
 
@@ -552,6 +559,8 @@ class UaClient:
             return
 
         self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTING)
+        for session in self._sessions.values():
+            session.on_transport_lost()
         await self.protocol.close_secure_channel()
 
     # ========== SESSION LIFECYCLE ==========
@@ -597,12 +606,14 @@ class UaClient:
                 response.Parameters.SessionId,
                 response.Parameters.AuthenticationToken,
             )
+            self._default_session._set_state(SessionState.ESTABLISHING)
             self._register_session(self._default_session)
         else:
             self._default_session.session_id = response.Parameters.SessionId
             self._default_session.authentication_token = (
                 response.Parameters.AuthenticationToken
             )
+            self._default_session._set_state(SessionState.ESTABLISHING)
 
         return response.Parameters
 
@@ -610,8 +621,6 @@ class UaClient:
         self, parameters: ua.ActivateSessionParameters
     ) -> ua.ActivateSessionResult:
         """Activate (authenticate) existing session.
-
-        Transitions state to SESSION_READY.
 
         Args:
             parameters: ActivateSessionParameters with credentials, etc.
@@ -633,7 +642,11 @@ class UaClient:
         self.logger.debug("ActivateSessionResponse: %s", response)
         response.ResponseHeader.ServiceResult.check()
 
-        self.set_connection_state(UaClient.CONNECTION_STATE.SESSION_READY)
+        if self._default_session is not None:
+            self._default_session._set_state(SessionState.READY)
+        for session in self._sessions.values():
+            if session is not self._default_session and session.state == SessionState.RECOVERING:
+                session._set_state(SessionState.READY)
         return response.Parameters
 
     async def close_session(
@@ -833,21 +846,14 @@ class UaClient:
     def set_connection_state(self, state: int) -> None:
         """Update connection state and signal ready event."""
         self._connection_state = state
-        if state == UaClient.CONNECTION_STATE.SESSION_READY:
+        if state == UaClient.CONNECTION_STATE.CHANNEL_READY:
             self._ready_event.set()
         else:
             self._ready_event.clear()
 
     def try_set_connection_state(self, state: int) -> bool:
         """Attempt guarded state transition (prevents backward states)."""
-        if (
-            self._connection_state == UaClient.CONNECTION_STATE.DISCONNECTING
-            and state
-            in (
-                UaClient.CONNECTION_STATE.SESSION_ESTABLISHING,
-                UaClient.CONNECTION_STATE.SESSION_READY,
-            )
-        ):
+        if self._connection_state == UaClient.CONNECTION_STATE.DISCONNECTING and state == UaClient.CONNECTION_STATE.CHANNEL_READY:
             self.logger.warning(
                 "Ignoring state transition %s -> %s during disconnect",
                 self._connection_state,
@@ -858,7 +864,7 @@ class UaClient:
         return True
 
     async def await_ready(self, timeout: float | None = None) -> None:
-        """Block until SESSION_READY state.
+        """Block until CHANNEL_READY state.
 
         Args:
             timeout: Seconds to wait (default: client timeout)
@@ -868,7 +874,7 @@ class UaClient:
         """
         if (
             self._connection_state
-            == UaClient.CONNECTION_STATE.SESSION_READY
+            == UaClient.CONNECTION_STATE.CHANNEL_READY
         ):
             return
 
@@ -902,7 +908,7 @@ class UaClient:
             request: OPC-UA request structure
             timeout: Override default timeout
             message_type: Message type (SecureMessage, SecureOpen, etc.)
-            bypass_ready_gate: Skip SESSION_READY check if True
+            bypass_ready_gate: Skip CHANNEL_READY check if True
 
         Returns:
             Response body (usually parsed by caller)
@@ -1003,6 +1009,7 @@ class UaClient:
             activate_params = ua.ActivateSessionParameters()
             await self.activate_session(activate_params)
 
+            self.set_connection_state(UaClient.CONNECTION_STATE.CHANNEL_READY)
             self.logger.info("Session %s activated", session.session_id)
             return session
 
@@ -1057,6 +1064,12 @@ class UaClient:
                 "No active session. Call create_session/activate_session first."
             )
         return self._default_session
+
+    @property
+    def _publish_task(self) -> asyncio.Task[None] | None:
+        if self._default_session is None:
+            return None
+        return self._default_session._publish_task
 
     async def browse(self, parameters: ua.BrowseParameters) -> list[ua.BrowseResult]:
         return await self._require_default_session().browse(parameters)

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -266,9 +266,13 @@ class UASocketProtocol(asyncio.Protocol):
         self.check_answer(data, f" in response to {request.__class__.__name__}")
         return data
 
-    def check_answer(self, data: bytes, context: str) -> bool:
+    def check_answer(self, data: Any, context: str) -> bool:
         """Verify response is valid OPC-UA message."""
-        data_buffer = ua.utils.Buffer(data)
+        if hasattr(data, "copy"):
+            data_buffer = data.copy()
+        else:
+            data_buffer = ua.utils.Buffer(bytes(data))
+
         typeid = nodeid_from_binary(data_buffer)
         if typeid == ua.FourByteNodeId(
             ua.ObjectIds.ServiceFault_Encoding_DefaultBinary

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -1194,6 +1194,10 @@ class UaClient:
     async def modify_subscription(self, params: ua.ModifySubscriptionParameters) -> ua.ModifySubscriptionResult:
         return await self._require_default_session().modify_subscription(params)
 
+    async def update_subscription(self, params: ua.ModifySubscriptionParameters) -> ua.ModifySubscriptionResult:
+        """Backward-compatible alias for modify_subscription."""
+        return await self.modify_subscription(params)
+
     async def delete_subscriptions(
         self, params: ua.DeleteSubscriptionsParameters | list[int]
     ) -> list[ua.StatusCode]:

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -196,9 +196,14 @@ class UASocketProtocol(asyncio.Protocol):
         request: ua.BaseRequest,
         timeout: float = 1,
         message_type: ua.MessageType = ua.MessageType.SecureMessage,
+        authentication_token: ua.NodeId | None = None,
     ) -> asyncio.Future:
         """Send OPC-UA request, return future for response."""
-        self._setup_request_header(request.RequestHeader, timeout)
+        self._setup_request_header(
+            request.RequestHeader,
+            timeout,
+            authentication_token=authentication_token,
+        )
         self.logger.debug("Sending: %s", request)
 
         try:
@@ -226,6 +231,7 @@ class UASocketProtocol(asyncio.Protocol):
         request: ua.BaseRequest,
         timeout: float | None = None,
         message_type: ua.MessageType = ua.MessageType.SecureMessage,
+        authentication_token: ua.NodeId | None = None,
     ) -> bytes:
         """Send request and wait for response."""
         timeout = self.timeout if timeout is None else timeout
@@ -234,7 +240,12 @@ class UASocketProtocol(asyncio.Protocol):
 
         try:
             data = await wait_for(
-                self._send_request(request, timeout, message_type),
+                self._send_request(
+                    request,
+                    timeout,
+                    message_type,
+                    authentication_token=authentication_token,
+                ),
                 timeout if timeout else None,
             )
         except UaError as ex:
@@ -301,10 +312,17 @@ class UASocketProtocol(asyncio.Protocol):
         del self._callbackmap[request_id]
 
     def _setup_request_header(
-        self, hdr: ua.RequestHeader, timeout: float = 1
+        self,
+        hdr: ua.RequestHeader,
+        timeout: float = 1,
+        authentication_token: ua.NodeId | None = None,
     ) -> None:
         """Prepare request header with token and timeouts."""
-        hdr.AuthenticationToken = self.authentication_token
+        hdr.AuthenticationToken = (
+            self.authentication_token
+            if authentication_token is None
+            else authentication_token
+        )
         self._request_handle += 1
         hdr.RequestHandle = self._request_handle
         hdr.TimeoutHint = int(timeout * 1000)
@@ -595,11 +613,6 @@ class UaClient:
         self.logger.debug("CreateSessionResponse: %s", response)
         response.ResponseHeader.ServiceResult.check()
 
-        if self.protocol:
-            self.protocol.authentication_token = (
-                response.Parameters.AuthenticationToken
-            )
-
         if self._default_session is None:
             self._default_session = UaSession(
                 self,
@@ -618,7 +631,9 @@ class UaClient:
         return response.Parameters
 
     async def activate_session(
-        self, parameters: ua.ActivateSessionParameters
+        self,
+        parameters: ua.ActivateSessionParameters,
+        session: UaSession | None = None,
     ) -> ua.ActivateSessionResult:
         """Activate (authenticate) existing session.
 
@@ -637,20 +652,36 @@ class UaClient:
         request = ua.ActivateSessionRequest()
         request.Parameters = parameters
 
-        data = await self._send_request(request, bypass_ready_gate=True)
+        target_session = session if session is not None else self._default_session
+        if target_session is None:
+            raise UaError(
+                "No target session for activate_session. "
+                "Pass session=... or create a default session first."
+            )
+
+        data = await self._send_request(
+            request,
+            bypass_ready_gate=True,
+            authentication_token=target_session.authentication_token,
+        )
         response = struct_from_binary(ua.ActivateSessionResponse, data)
         self.logger.debug("ActivateSessionResponse: %s", response)
         response.ResponseHeader.ServiceResult.check()
 
-        if self._default_session is not None:
-            self._default_session._set_state(SessionState.READY)
-        for session in self._sessions.values():
-            if session is not self._default_session and session.state == SessionState.RECOVERING:
-                session._set_state(SessionState.READY)
+        if target_session is not None:
+            target_session._set_state(SessionState.READY)
+        for registered_session in self._sessions.values():
+            if (
+                registered_session is not target_session
+                and registered_session.state == SessionState.RECOVERING
+            ):
+                registered_session._set_state(SessionState.READY)
         return response.Parameters
 
     async def close_session(
-        self, delete_subscriptions: bool = True
+        self,
+        delete_subscriptions: bool = True,
+        session: UaSession | None = None,
     ) -> None:
         """Close session on server.
 
@@ -661,25 +692,46 @@ class UaClient:
             Ignores BadSessionClosed and BadUserAccessDenied (expected
             for some edge cases or older server versions)
         """
-        self.logger.info("Closing session")
-
-        if not self._prepare_close_session():
+        target_session = session if session is not None else self._default_session
+        if target_session is None:
+            self.logger.debug("close_session called with no active session")
             return
 
-        data = await self._send_close_session_request(delete_subscriptions)
-        response = struct_from_binary(ua.CloseSessionResponse, data)
+        self.logger.info("Closing session %s", target_session.session_id)
+
+        protocol = self.protocol
+        can_send_close = protocol is not None and protocol.state != UASocketProtocol.CLOSED
+        if can_send_close:
+            try:
+                data = await self._send_close_session_request(
+                    delete_subscriptions,
+                    authentication_token=target_session.authentication_token,
+                )
+                response = struct_from_binary(ua.CloseSessionResponse, data)
+
+                try:
+                    response.ResponseHeader.ServiceResult.check()
+                except (BadSessionClosed, BadUserAccessDenied):
+                    self.logger.debug("Ignored close_session error (expected)")
+            except ConnectionError:
+                self.logger.debug(
+                    "Skipping CloseSessionRequest for %s because connection is closed",
+                    target_session.session_id,
+                )
+        else:
+            self.logger.debug(
+                "Skipping CloseSessionRequest for %s because protocol is not open",
+                target_session.session_id,
+            )
 
         try:
-            response.ResponseHeader.ServiceResult.check()
-        except (BadSessionClosed, BadUserAccessDenied):
-            self.logger.debug("Ignored close_session error (expected)")
-
-        if self._default_session is not None:
-            try:
-                await self._default_session.close()
-            finally:
-                self._unregister_session(self._default_session)
+            await target_session._close_local()
+        finally:
+            self._unregister_session(target_session)
+            if self._default_session is target_session:
                 self._default_session = None
+            if self._default_session is None and self._sessions:
+                self._default_session = next(iter(self._sessions.values()))
 
     # ========== SESSIONLESS DISCOVERY SERVICES ==========
 
@@ -901,6 +953,7 @@ class UaClient:
         timeout: float | None = None,
         message_type: ua.MessageType = ua.MessageType.SecureMessage,
         bypass_ready_gate: bool = False,
+        authentication_token: ua.NodeId | None = None,
     ) -> bytes:
         """Send OPC-UA request and wait for response.
 
@@ -928,35 +981,25 @@ class UaClient:
             raise ConnectionError("Connection is closed")
 
         return await protocol.send_request(
-            request, timeout=timeout, message_type=message_type
+            request,
+            timeout=timeout,
+            message_type=message_type,
+            authentication_token=authentication_token,
         )
 
-    def _prepare_close_session(self) -> bool:
-        """Prepare for session closure."""
-        self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTING)
-        self._closing = True
-
-        if not self.protocol:
-            self.logger.warning(
-                "close_session but connection not established"
-            )
-            return False
-
-        self.protocol.closed = True
-
-        if self.protocol.state == UASocketProtocol.CLOSED:
-            self.logger.warning("Connection already closed")
-            return False
-
-        return True
-
     async def _send_close_session_request(
-        self, delete_subscriptions: bool
+        self,
+        delete_subscriptions: bool,
+        authentication_token: ua.NodeId | None = None,
     ) -> bytes:
         """Send CloseSessionRequest to server."""
         request = ua.CloseSessionRequest()
         request.DeleteSubscriptions = delete_subscriptions
-        return await self._send_request(request, bypass_ready_gate=True)
+        return await self._send_request(
+            request,
+            bypass_ready_gate=True,
+            authentication_token=authentication_token,
+        )
 
     def set_security(
         self, policy: security_policies.SecurityPolicy
@@ -975,6 +1018,8 @@ class UaClient:
     async def create_session_object(
         self,
         parameters: ua.CreateSessionParameters,
+        make_default: bool = True,
+        activate_parameters: ua.ActivateSessionParameters | None = None,
     ) -> UaSession:
         """Create and activate a new UaSession object.
 
@@ -983,6 +1028,11 @@ class UaClient:
 
         Args:
             parameters: CreateSessionParameters (description, timeout, etc.)
+            make_default: If True, creates/reuses the default session slot.
+                If False, creates an additional non-default session.
+            activate_parameters: Optional ActivateSessionParameters used to
+                authenticate this specific session (for example per-session
+                user identity tokens). If omitted, anonymous activation is used.
 
         Returns:
             Ready-to-use UaSession object
@@ -1001,13 +1051,34 @@ class UaClient:
         """
         self.logger.info("Creating session object")
 
-        await self.create_session(parameters)
-        session = self._require_default_session()
+        if make_default:
+            await self.create_session(parameters)
+            session = self._require_default_session()
+        else:
+            request = ua.CreateSessionRequest()
+            request.Parameters = parameters
+
+            data = await self._send_request(request, bypass_ready_gate=True)
+            response = struct_from_binary(ua.CreateSessionResponse, data)
+            self.logger.debug("CreateSessionResponse (additional): %s", response)
+            response.ResponseHeader.ServiceResult.check()
+
+            session = UaSession(
+                self,
+                response.Parameters.SessionId,
+                response.Parameters.AuthenticationToken,
+            )
+            session._set_state(SessionState.ESTABLISHING)
+            self._register_session(session)
 
         try:
             # Activate the session
-            activate_params = ua.ActivateSessionParameters()
-            await self.activate_session(activate_params)
+            activate_params = (
+                activate_parameters
+                if activate_parameters is not None
+                else ua.ActivateSessionParameters()
+            )
+            await self.activate_session(activate_params, session=session)
 
             self.set_connection_state(UaClient.CONNECTION_STATE.CHANNEL_READY)
             self.logger.info("Session %s activated", session.session_id)
@@ -1016,7 +1087,10 @@ class UaClient:
         except Exception as ex:
             # Cleanup on failure
             try:
-                await self.close_session(delete_subscriptions=True)
+                await self.close_session(
+                    delete_subscriptions=True,
+                    session=session,
+                )
             except Exception:
                 pass
             raise ex
@@ -1040,7 +1114,7 @@ class UaClient:
         sessions = list(self._sessions.values())
         for session in sessions:
             try:
-                await session.close()
+                await session.close(delete_subscriptions=delete_subscriptions)
             except Exception:
                 self.logger.exception("Error closing session %s",
                                       session.session_id)

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -1,127 +1,57 @@
 """
-Low level binary client
+Low-level OPC-UA client for connection, secure channel, and discovery services.
+
+This module provides the sessionless foundation for OPC-UA operations.
+Session-specific operations (browse, read, write, subscriptions) are
+handled by UaSession instances created via create_session_object().
 """
+
+from __future__ import annotations
 
 import asyncio
 import copy
-import inspect
 import logging
 from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
-from dataclasses import dataclass
-from enum import Enum
+from typing import TYPE_CHECKING, Any
 
 from asyncua import ua
-from asyncua.common.session_interface import AbstractSession
 from asyncua.ua.uaerrors._base import UaError
 
 from ..common.connection import SecureConnection, TransportLimits
 from ..common.utils import wait_for
 from ..crypto import security_policies
-from ..ua.ua_binary import header_from_binary, nodeid_from_binary, struct_from_binary, struct_to_binary, uatcp_to_binary
-from ..ua.uaerrors import BadNoSubscription, BadSessionClosed, BadTimeout, BadUserAccessDenied, UaStructParsingError
-from ..ua.uaprotocol_auto import OpenSecureChannelResult, SubscriptionAcknowledgement
+from ..ua.ua_binary import (
+    header_from_binary,
+    nodeid_from_binary,
+    struct_from_binary,
+    struct_to_binary,
+    uatcp_to_binary,
+)
+from ..ua.uaerrors import BadSessionClosed, BadUserAccessDenied
+from ..ua.uaprotocol_auto import OpenSecureChannelResult
+from .ua_session import (
+    SubscriptionDispatchOverflowError,
+    SubscriptionDispatchOverflowPolicy,
+    SubscriptionStaleError,
+    UaSession,
+)
 
+if TYPE_CHECKING:
+    pass
 
-@dataclass
-class _SubscriptionWatchdogState:
-    publishing_interval_ms: float
-    keepalive_count: int
-    last_seen_at: float
-    stale_reported: bool = False
-
-
-class SubscriptionStaleError(ConnectionError):
-    def __init__(self, subscription_ids: list[int]):
-        self.subscription_ids = subscription_ids
-        super().__init__(
-            f"Detected stale subscriptions with no Publish messages within keep-alive window: {subscription_ids}"
-        )
-
-
-class SubscriptionDispatchOverflowError(ConnectionError):
-    def __init__(self, subscription_id: int, queue_size: int):
-        self.subscription_id = subscription_id
-        self.queue_size = queue_size
-        super().__init__(
-            f"Subscription dispatch queue overflow for subscription {subscription_id} at size {queue_size}"
-        )
-
-
-class SubscriptionDispatchOverflowPolicy(str, Enum):
-    DROP_OLDEST = "drop_oldest"
-    WARN = "warn"
-    DISCONNECT = "disconnect"
-
-
-@dataclass
-class _DispatchSettings:
-    queue_maxsize: int = 1000
-    overflow_policy: SubscriptionDispatchOverflowPolicy | str = SubscriptionDispatchOverflowPolicy.DROP_OLDEST
-
-
-@dataclass
-class _SequenceRecoverySettings:
-    auto_republish_on_gap: bool = True
-    max_republish_messages_per_gap: int = 1000
-
-
-@dataclass
-class _WatchdogSettings:
-    stale_detection_enabled: bool = True
-    stale_detection_margin: float = 1.2
-
-
-@dataclass
-class _SubscriptionDispatchRuntime:
-    queue: asyncio.Queue[ua.PublishResult | None]
-    task: asyncio.Task | None = None
-
-
-def _compute_republish_window(
-    expected_sequence: int,
-    received_sequence: int,
-    max_republish: int,
-) -> tuple[int, int] | None:
-    """
-    Return an inclusive-exclusive replay window [start, end) for missing messages.
-    Returns None when no replay should be attempted.
-    """
-    if received_sequence <= expected_sequence:
-        return None
-    if max_republish <= 0:
-        return None
-
-    missing_count = received_sequence - expected_sequence
-    replay_end_exclusive = received_sequence
-    if missing_count > max_republish:
-        replay_end_exclusive = expected_sequence + max_republish
-    return expected_sequence, replay_end_exclusive
-
-
-def _build_publish_ack(
-    subscription_id: int,
-    notification_message: ua.NotificationMessage,
-) -> SubscriptionAcknowledgement | None:
-    if not notification_message.NotificationData:
-        return None
-    ack = ua.SubscriptionAcknowledgement()
-    ack.SubscriptionId = subscription_id
-    ack.SequenceNumber = notification_message.SequenceNumber
-    return ack
-
-
-async def _invoke_subscription_callback(callback, publish_result: ua.PublishResult) -> None:
-    result = callback(publish_result)
-    if inspect.isawaitable(result):
-        await result
+__all__ = [
+    "UaClient",
+    "UASocketProtocol",
+    "UaSession",
+    "SubscriptionStaleError",
+    "SubscriptionDispatchOverflowError",
+    "SubscriptionDispatchOverflowPolicy",
+]
 
 
 class UASocketProtocol(asyncio.Protocol):
-    """
-    Handle socket connection and send ua messages.
-    Timeout is the timeout used while waiting for an ua answer from server.
-    """
+    """Handle socket connection and send OPC-UA messages."""
 
     INITIALIZED = "initialized"
     OPEN = "open"
@@ -130,12 +60,15 @@ class UASocketProtocol(asyncio.Protocol):
     def __init__(
         self,
         timeout: float = 1,
-        security_policy: security_policies.SecurityPolicy = security_policies.SecurityPolicyNone(),
-        limits: TransportLimits = None,
-    ):
-        """
-        :param timeout: Timeout in seconds
-        :param security_policy: Security policy (optional)
+        security_policy: security_policies.SecurityPolicy | None = None,
+        limits: TransportLimits | None = None,
+    ) -> None:
+        """Initialize protocol handler.
+
+        Args:
+            timeout: Request timeout in seconds
+            security_policy: Security policy for encryption/signing
+            limits: Transport limits (max message size, chunk count, etc.)
         """
         self.logger = logging.getLogger(f"{__name__}.UASocketProtocol")
         self.transport: asyncio.Transport | None = None
@@ -146,81 +79,105 @@ class UASocketProtocol(asyncio.Protocol):
         self._request_id = 0
         self._request_handle = 0
         self._callbackmap: dict[int, asyncio.Future] = {}
+
         if limits is None:
             limits = TransportLimits(65535, 65535, 0, 0)
         else:
-            limits = copy.deepcopy(limits)  # Make a copy because the limits can change in the session
-        self._connection = SecureConnection(security_policy, limits)
+            limits = copy.deepcopy(limits)
 
+        if security_policy is None:
+            security_policy = security_policies.SecurityPolicyNone()
+
+        self._connection = SecureConnection(security_policy, limits)
         self.state = self.INITIALIZED
         self.closed: bool = False
-        # needed to pass params from asynchronous request to synchronous data receive callback, as well as
-        # passing back the processed response to the request so that it can return it.
-        self._open_secure_channel_exchange: ua.OpenSecureChannelResponse | ua.OpenSecureChannelParameters | None = None
-        # Hook for upper layer tasks before a request is sent (optional)
+        self._open_secure_channel_exchange: (
+            ua.OpenSecureChannelResponse
+            | ua.OpenSecureChannelParameters
+            | None
+        ) = None
         self.pre_request_hook: Callable[[], Awaitable[None]] | None = None
 
-    def connection_made(self, transport: asyncio.Transport):  # type: ignore[override]
+    def connection_made(self, transport: asyncio.Transport) -> None:  # type: ignore[override]
+        """Called when connection is established."""
         self.state = self.OPEN
         self.transport = transport
 
-    def connection_lost(self, exc: Exception | None):
-        self.logger.info("Socket has closed connection")
+    def connection_lost(self, exc: Exception | None) -> None:
+        """Called when connection is lost."""
+        self.logger.info("Socket connection closed")
         self.state = self.CLOSED
         self.transport = None
 
     def data_received(self, data: bytes) -> None:
+        """Process received data."""
         if self.receive_buffer:
             data = self.receive_buffer + data
             self.receive_buffer = None
         self._process_received_data(data)
 
     def _process_received_data(self, data: bytes) -> None:
-        """
-        Try to parse received data as asyncua message. Data may be chunked but will be in correct order.
-        See: https://docs.python.org/3/library/asyncio-protocol.html#asyncio.Protocol.data_received
-        Reassembly is done by filling up a buffer until it verifies as a valid message (or a MessageChunk).
-        """
+        """Parse OPC-UA messages from received data."""
         buf = ua.utils.Buffer(data)
         while True:
             try:
                 try:
                     header = header_from_binary(buf)
                 except ua.utils.NotEnoughData:
-                    self.logger.debug("Not enough data while parsing header from server, waiting for more")
-                    self.receive_buffer = data
-                    return
-                if len(buf) < header.body_size:
                     self.logger.debug(
-                        "We did not receive enough data from server. Need %s got %s", header.body_size, len(buf)
+                        "Incomplete header, waiting for more data"
                     )
                     self.receive_buffer = data
                     return
-                msg = self._connection.receive_from_header_and_body(header, buf)
+
+                if len(buf) < header.body_size:
+                    self.logger.debug(
+                        "Incomplete message body, waiting for more data"
+                    )
+                    self.receive_buffer = data
+                    return
+
+                msg = self._connection.receive_from_header_and_body(
+                    header, buf
+                )
                 self._process_received_message(msg)
+
                 if header.MessageType == ua.MessageType.SecureOpen:
-                    params: ua.OpenSecureChannelParameters = self._open_secure_channel_exchange
-                    response: ua.OpenSecureChannelResponse = struct_from_binary(
-                        ua.OpenSecureChannelResponse, msg.body()
+                    params: ua.OpenSecureChannelParameters = (
+                        self._open_secure_channel_exchange
+                    )
+                    response: ua.OpenSecureChannelResponse = (
+                        struct_from_binary(
+                            ua.OpenSecureChannelResponse, msg.body()
+                        )
                     )
                     response.ResponseHeader.ServiceResult.check()
                     self._open_secure_channel_exchange = response
-                    self._connection.set_channel(response.Parameters, params.RequestType, params.ClientNonce)
+                    self._connection.set_channel(
+                        response.Parameters,
+                        params.RequestType,
+                        params.ClientNonce,
+                    )
+
                 if not buf:
                     return
-                # Buffer still has bytes left, try to process again
                 data = bytes(buf)
             except ua.UaStatusCodeError as e:
-                self.logger.error("Got error status from server: %s", e)
+                self.logger.error("OPC-UA status error: %s", e)
                 self._fail_all_pending(e)
                 self.disconnect_socket()
                 return
             except Exception:
-                self.logger.exception("Exception raised while parsing message from server")
+                self.logger.exception(
+                    "Unexpected error parsing message from server"
+                )
                 self.disconnect_socket()
                 return
 
-    def _process_received_message(self, msg: ua.Message | ua.Acknowledge | ua.ErrorMessage):
+    def _process_received_message(
+        self, msg: ua.Message | ua.Acknowledge | ua.ErrorMessage
+    ) -> None:
+        """Process parsed OPC-UA message."""
         if msg is None:
             pass
         elif isinstance(msg, ua.Message):
@@ -228,79 +185,87 @@ class UASocketProtocol(asyncio.Protocol):
         elif isinstance(msg, ua.Acknowledge):
             self._call_callback(0, msg)
         elif isinstance(msg, ua.ErrorMessage):
-            self.logger.fatal("Received an error: %r", msg)
+            self.logger.fatal("Received error message: %r", msg)
             self.disconnect_socket()
             if msg.Error is not None:
-                # Automatically print human-readable error text.
                 msg.Error.check()
         else:
             raise ua.UaError(f"Unsupported message type: {msg}")
 
-    def _send_request(self, request, timeout: float = 1, message_type=ua.MessageType.SecureMessage) -> asyncio.Future:
-        """
-        Send request to server, lower-level method.
-        Timeout is the timeout written in ua header.
-        :param request: Request
-        :param timeout: Timeout in seconds
-        :param message_type: UA Message Type (optional)
-        :return: Future that resolves with the Response
-        """
+    def _send_request(
+        self,
+        request: ua.BaseRequest,
+        timeout: float = 1,
+        message_type: ua.MessageType = ua.MessageType.SecureMessage,
+    ) -> asyncio.Future:
+        """Send OPC-UA request, return future for response."""
         self._setup_request_header(request.RequestHeader, timeout)
         self.logger.debug("Sending: %s", request)
+
         try:
             binreq = struct_to_binary(request)
         except Exception:
-            # reset request handle if any error
-            # see self._setup_request_header
             self._request_handle -= 1
             raise
+
         self._request_id += 1
-        future = asyncio.get_running_loop().create_future()
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
         self._callbackmap[self._request_id] = future
 
-        # Change to the new security token if the connection has been renewed.
         if self._connection.next_security_token.TokenId != 0:
             self._connection.revolve_tokens()
 
-        msg = self._connection.message_to_binary(binreq, message_type=message_type, request_id=self._request_id)
+        msg = self._connection.message_to_binary(
+            binreq, message_type=message_type, request_id=self._request_id
+        )
         if self.transport is not None:
             self.transport.write(msg)
         return future
 
-    async def send_request(self, request, timeout: float | None = None, message_type=ua.MessageType.SecureMessage):
-        """
-        Send a request to the server.
-        Timeout is the timeout written in ua header.
-        Returns response object if no callback is provided.
-        """
+    async def send_request(
+        self,
+        request: ua.BaseRequest,
+        timeout: float | None = None,
+        message_type: ua.MessageType = ua.MessageType.SecureMessage,
+    ) -> bytes:
+        """Send request and wait for response."""
         timeout = self.timeout if timeout is None else timeout
         if self.pre_request_hook:
-            # This will propagate exceptions from background tasks to the library user before calling a request which will
-            # time out then.
             await self.pre_request_hook()
+
         try:
-            data = await wait_for(self._send_request(request, timeout, message_type), timeout if timeout else None)
+            data = await wait_for(
+                self._send_request(request, timeout, message_type),
+                timeout if timeout else None,
+            )
         except UaError as ex:
-            # Recieved UA error, re-raise it to the caller
             raise ex
         except (TimeoutError, asyncio.TimeoutError) as ex:
             if self.state != self.OPEN:
                 raise ConnectionError("Connection is closed") from None
-            raise ConnectionError("Request timed out while waiting for OPC UA server response") from ex
+            raise ConnectionError(
+                "Request timed out waiting for server response"
+            ) from ex
         except Exception as ex:
             if self.state != self.OPEN:
                 raise ConnectionError("Connection is closed") from None
-            raise Exception("Unhandled exception while sending request to OPC UA server") from ex
+            raise Exception(
+                "Error sending request to OPC-UA server"
+            ) from ex
+
         self.check_answer(data, f" in response to {request.__class__.__name__}")
         return data
 
-    def check_answer(self, data, context):
+    def check_answer(self, data: bytes, context: str) -> bool:
+        """Verify response is valid OPC-UA message."""
         data = data.copy()
         typeid = nodeid_from_binary(data)
-        if typeid == ua.FourByteNodeId(ua.ObjectIds.ServiceFault_Encoding_DefaultBinary):
+        if typeid == ua.FourByteNodeId(
+            ua.ObjectIds.ServiceFault_Encoding_DefaultBinary
+        ):
             hdr = struct_from_binary(ua.ResponseHeader, data)
             self.logger.warning(
-                "ServiceFault (%s, diagnostics: %s) from server received %s",
+                "ServiceFault (%s, diagnostics: %s) %s",
                 hdr.ServiceResult.name,
                 hdr.ServiceDiagnostics,
                 context,
@@ -310,96 +275,119 @@ class UASocketProtocol(asyncio.Protocol):
         return True
 
     def _fail_all_pending(self, exc: Exception) -> None:
+        """Signal all pending requests of error."""
         for fut in self._callbackmap.values():
             if not fut.done():
                 fut.set_exception(exc)
         self._callbackmap.clear()
 
-    def _call_callback(self, request_id, body):
+    def _call_callback(self, request_id: int, body: bytes) -> None:
+        """Call response callback for request."""
         try:
             self._callbackmap[request_id].set_result(body)
         except KeyError as ex:
             raise ua.UaError(
-                f"No request found for request id: {request_id}, pending are {self._callbackmap.keys()}, body was {body}"
+                f"No request found for id {request_id}, body was {body}"
             ) from ex
         except asyncio.InvalidStateError:
             if not self.closed:
-                self.logger.warning("Future for request id %s is already done", request_id)
+                self.logger.warning(
+                    "Future for request id %s already done", request_id
+                )
                 return
-            self.logger.debug("Future for request id %s not handled due to disconnect", request_id)
+            self.logger.debug(
+                "Future for request id %s not handled due to disconnect",
+                request_id,
+            )
         del self._callbackmap[request_id]
 
-    def _setup_request_header(self, hdr: ua.RequestHeader, timeout=1) -> None:
-        """
-        :param hdr: Request header
-        :param timeout: Timeout in seconds
-        """
+    def _setup_request_header(
+        self, hdr: ua.RequestHeader, timeout: float = 1
+    ) -> None:
+        """Prepare request header with token and timeouts."""
         hdr.AuthenticationToken = self.authentication_token
         self._request_handle += 1
         hdr.RequestHandle = self._request_handle
         hdr.TimeoutHint = int(timeout * 1000)
 
-    def disconnect_socket(self):
-        self.logger.info("Request to close socket received")
+    def disconnect_socket(self) -> None:
+        """Close socket connection."""
+        self.logger.info("Closing socket")
         if self.transport:
             self.transport.close()
         else:
-            self.logger.warning("disconnect_socket was called but transport is None")
+            self.logger.warning("disconnect_socket but transport is None")
 
-    async def send_hello(self, url, max_messagesize: int = 0, max_chunkcount: int = 0):
+    async def send_hello(
+        self,
+        url: str,
+        max_messagesize: int = 0,
+        max_chunkcount: int = 0,
+    ) -> ua.Acknowledge:
+        """Send HELLO message for protocol handshake."""
         hello = ua.Hello()
         hello.EndpointUrl = url
         hello.MaxMessageSize = max_messagesize
         hello.MaxChunkCount = max_chunkcount
-        ack = asyncio.Future()
+        ack: asyncio.Future = asyncio.Future()
         self._callbackmap[0] = ack
         if self.transport is not None:
             self.transport.write(uatcp_to_binary(ua.MessageType.Hello, hello))
         return await wait_for(ack, self.timeout)
 
-    async def open_secure_channel(self, params) -> OpenSecureChannelResult:
-        self.logger.info("open_secure_channel")
+    async def open_secure_channel(
+        self, params: ua.OpenSecureChannelParameters
+    ) -> OpenSecureChannelResult:
+        """Open secure channel with server."""
+        self.logger.info("Opening secure channel")
         request = ua.OpenSecureChannelRequest()
         request.Parameters = params
+
         if self._open_secure_channel_exchange is not None:
             raise UaError(
-                "Two Open Secure Channel requests can not happen too close to each other. "
-                "The response must be processed and returned before the next request can be sent."
+                "Secure channel request already in progress"
             )
+
         self._open_secure_channel_exchange = params
-        await wait_for(self._send_request(request, message_type=ua.MessageType.SecureOpen), self.timeout)
+        await wait_for(
+            self._send_request(
+                request, message_type=ua.MessageType.SecureOpen
+            ),
+            self.timeout,
+        )
         _return = self._open_secure_channel_exchange.Parameters  # type: ignore[union-attr]
         self._open_secure_channel_exchange = None
         return _return
 
-    async def close_secure_channel(self):
+    async def close_secure_channel(self) -> None:
+        """Close secure channel.
+
+        Note: Most servers close the socket after this per OPC-UA spec.
         """
-        Close secure channel.
-        It seems to trigger a shutdown of socket in most servers, so be prepared to reconnect.
-        OPC UA specs Part 6, 7.1.4 say that Server does not send a CloseSecureChannel response
-        and should just close socket.
-        """
-        self.logger.info("close_secure_channel")
+        self.logger.info("Closing secure channel")
         request = ua.CloseSecureChannelRequest()
-        future = self._send_request(request, message_type=ua.MessageType.SecureClose)
-        # don't expect any more answers
+        future = self._send_request(
+            request, message_type=ua.MessageType.SecureClose
+        )
         future.cancel()
         self._callbackmap.clear()
-        # some servers send a response here, most do not ... so we ignore
 
 
-class UaClient(AbstractSession):
+class UaClient:
     """
-    low level OPC-UA client.
+    Sessionless OPC-UA client for discovery and session management.
 
-    It implements (almost) all methods defined in asyncua spec
-    taking in argument the structures defined in asyncua spec.
+    Handles connection establishment, secure channel negotiation, and
+    session creation/activation. Session-dependent operations are delegated
+    to UaSession instances.
 
-    In this Python implementation  most of the structures are defined in
-    uaprotocol_auto.py and uaprotocol_hand.py available under asyncua.ua
+    For session-specific operations (browse, read, write, subscriptions),
+    use create_session_object() to get a UaSession instance.
     """
 
-    class CONNECTION_STATE(Enum):
+    class CONNECTION_STATE:
+        """Connection state enumeration."""
+
         DISCONNECTED = 1
         CONNECTING = 2
         CHANNEL_READY = 3
@@ -407,93 +395,462 @@ class UaClient(AbstractSession):
         SESSION_ESTABLISHING = 5
         DISCONNECTING = 6
 
-    def __init__(self, timeout: float = 1.0):
-        """
-        :param timeout: Timout in seconds
+    def __init__(self, timeout: float = 1.0) -> None:
+        """Initialize sessionless client.
+
+        Args:
+            timeout: Default request timeout in seconds
         """
         self.logger = logging.getLogger(f"{__name__}.UaClient")
-        self._subscription_callbacks = {}
-        self._subscription_dispatch_runtime: dict[int, _SubscriptionDispatchRuntime] = {}
-        self._last_publish_sequence_numbers: dict[int, int] = {}
-        self._subscription_watchdog_states: dict[int, _SubscriptionWatchdogState] = {}
-        self.dispatch_settings = _DispatchSettings()
-        self.sequence_recovery_settings = _SequenceRecoverySettings()
-        self.watchdog_settings = _WatchdogSettings()
         self._timeout = timeout
+        self.protocol: UASocketProtocol | None = None
         self.security_policy = security_policies.SecurityPolicyNone()
-        self.protocol: UASocketProtocol = None
-        self._publish_task = None
-        self._pre_request_hook: Callable[[], Awaitable[None]] | None = None
-        self._closing: bool = False
-        self._connection_state: UaClient.CONNECTION_STATE = UaClient.CONNECTION_STATE.DISCONNECTED
+
+        # State management
+        self._connection_state = UaClient.CONNECTION_STATE.DISCONNECTED
         self._ready_event = asyncio.Event()
-        # Nesting counter for internal operations (connect/recover/disconnect) that must bypass await_ready gating.
+        self._closing = False
         self._internal_service_call_depth = 0
 
-    @property
-    def subscription_dispatch_queue_maxsize(self) -> int:
-        return self.dispatch_settings.queue_maxsize
+        # Session registry
+        self._sessions: dict[int, UaSession] = {}
+        self._session_id_counter = 0
+        self._default_session: UaSession | None = None
 
-    @subscription_dispatch_queue_maxsize.setter
-    def subscription_dispatch_queue_maxsize(self, value: int) -> None:
-        self.dispatch_settings.queue_maxsize = int(value)
-
-    @property
-    def subscription_dispatch_overflow_policy(self) -> SubscriptionDispatchOverflowPolicy | str:
-        return self.dispatch_settings.overflow_policy
-
-    @subscription_dispatch_overflow_policy.setter
-    def subscription_dispatch_overflow_policy(self, value: SubscriptionDispatchOverflowPolicy | str) -> None:
-        self.dispatch_settings.overflow_policy = value
+        # Pre-request hook for diagnostics
+        self._pre_request_hook: Callable[[], Awaitable[None]] | None = None
 
     @property
-    def subscription_stale_detection_enabled(self) -> bool:
-        return self.watchdog_settings.stale_detection_enabled
-
-    @subscription_stale_detection_enabled.setter
-    def subscription_stale_detection_enabled(self, value: bool) -> None:
-        self.watchdog_settings.stale_detection_enabled = bool(value)
-
-    @property
-    def subscription_stale_detection_margin(self) -> float:
-        return self.watchdog_settings.stale_detection_margin
-
-    @subscription_stale_detection_margin.setter
-    def subscription_stale_detection_margin(self, value: float) -> None:
-        self.watchdog_settings.stale_detection_margin = float(value)
-
-    @property
-    def auto_republish_on_sequence_gap(self) -> bool:
-        return self.sequence_recovery_settings.auto_republish_on_gap
-
-    @auto_republish_on_sequence_gap.setter
-    def auto_republish_on_sequence_gap(self, value: bool) -> None:
-        self.sequence_recovery_settings.auto_republish_on_gap = bool(value)
-
-    @property
-    def max_republish_messages_per_gap(self) -> int:
-        return self.sequence_recovery_settings.max_republish_messages_per_gap
-
-    @max_republish_messages_per_gap.setter
-    def max_republish_messages_per_gap(self, value: int) -> None:
-        self.sequence_recovery_settings.max_republish_messages_per_gap = int(value)
-
-    @property
-    def connection_state(self) -> CONNECTION_STATE:
+    def connection_state(self) -> int:
+        """Get current connection state."""
         return self._connection_state
 
-    def _is_transition_allowed(self, state: CONNECTION_STATE) -> bool:
-        # Once disconnect starts, do not move back to session setup/ready states.
-        # This guards against reconnect/disconnect races and keeps state progression monotonic.
-        if self._connection_state == UaClient.CONNECTION_STATE.DISCONNECTING and state in (
-            UaClient.CONNECTION_STATE.SESSION_ESTABLISHING,
-            UaClient.CONNECTION_STATE.SESSION_READY,
-        ):
-            return False
-        return True
+    @property
+    def pre_request_hook(self) -> Callable[[], Awaitable[None]] | None:
+        """Get pre-request hook."""
+        return self._pre_request_hook
 
-    def try_set_connection_state(self, state: CONNECTION_STATE) -> bool:
-        if not self._is_transition_allowed(state):
+    @pre_request_hook.setter
+    def pre_request_hook(
+        self, hook: Callable[[], Awaitable[None]] | None
+    ) -> None:
+        """Set pre-request hook."""
+        self._pre_request_hook = hook
+        if self.protocol:
+            self.protocol.pre_request_hook = hook
+
+    # ========== CONNECTION MANAGEMENT ==========
+
+    async def connect_socket(self, host: str, port: int) -> None:
+        """Establish TCP connection to OPC-UA server.
+
+        Args:
+            host: Server hostname or IP address
+            port: Server port number
+
+        Raises:
+            TimeoutError: If connection cannot be established within timeout
+            ConnectionError: If socket creation fails
+        """
+        self.logger.info("Opening connection to %s:%d", host, port)
+        self._closing = False
+        self.set_connection_state(UaClient.CONNECTION_STATE.CONNECTING)
+
+        try:
+            await asyncio.wait_for(
+                asyncio.get_running_loop().create_connection(
+                    self._make_protocol, host, port
+                ),
+                self._timeout,
+            )
+        except (TimeoutError, asyncio.TimeoutError) as ex:
+            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+            raise ConnectionError(
+                f"Failed to connect to {host}:{port}"
+            ) from ex
+
+    def disconnect_socket(self) -> None:
+        """Close socket and cleanup."""
+        self.logger.info("Disconnecting socket")
+
+        if not self.protocol:
+            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+            return
+
+        if self.protocol.state == UASocketProtocol.CLOSED:
+            self.logger.warning("Socket already closed")
+            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+            return
+
+        self.protocol.disconnect_socket()
+        self.protocol = None
+        self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+
+    # ========== SECURE CHANNEL ==========
+
+    async def send_hello(
+        self,
+        url: str,
+        max_messagesize: int = 0,
+        max_chunkcount: int = 0,
+    ) -> ua.Acknowledge:
+        """Send HELLO message to establish protocol version.
+
+        Args:
+            url: Server endpoint URL
+            max_messagesize: Maximum message size (0 = use default)
+            max_chunkcount: Maximum chunk count (0 = use default)
+
+        Returns:
+            Server's acknowledgement message
+
+        Raises:
+            ConnectionError: If socket not connected
+        """
+        if not self.protocol:
+            raise ConnectionError("Socket not connected")
+        return await self.protocol.send_hello(
+            url, max_messagesize, max_chunkcount
+        )
+
+    async def open_secure_channel(
+        self, params: ua.OpenSecureChannelParameters
+    ) -> OpenSecureChannelResult:
+        """Open secure channel with server.
+
+        Transitions state from CONNECTING to CHANNEL_READY.
+
+        Args:
+            params: OpenSecureChannelParameters with token, nonce, etc.
+
+        Returns:
+            Server's channel response
+
+        Raises:
+            UaError: If channel establishment fails
+            ConnectionError: If socket not connected
+        """
+        self.logger.info("Opening secure channel")
+
+        if not self.protocol:
+            raise ConnectionError("Socket not connected")
+
+        result = await self.protocol.open_secure_channel(params)
+
+        if (
+            self._connection_state
+            != UaClient.CONNECTION_STATE.SESSION_READY
+        ):
+            self.set_connection_state(UaClient.CONNECTION_STATE.CHANNEL_READY)
+
+        return result
+
+    async def close_secure_channel(self) -> None:
+        """Close secure channel (may close socket per OPC-UA spec)."""
+        self.logger.info("Closing secure channel")
+
+        if not self.protocol or self.protocol.state == UASocketProtocol.CLOSED:
+            self.logger.warning("Channel already closed")
+            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
+            return
+
+        self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTING)
+        await self.protocol.close_secure_channel()
+
+    # ========== SESSION LIFECYCLE ==========
+
+    async def create_session(
+        self, parameters: ua.CreateSessionParameters
+    ) -> ua.CreateSessionResult:
+        """Create session on server (low-level operation).
+
+        Prefer create_session_object() for high-level usage.
+
+        Args:
+            parameters: CreateSessionParameters with description, timeout, etc.
+
+        Returns:
+            Session parameters including session ID, authentication token
+
+        Raises:
+            BadUserAccessDenied: If authentication fails
+            ConnectionError: If secure channel not open
+        """
+        self.logger.info("Creating session")
+        self._closing = False
+        if self.protocol:
+            self.protocol.closed = False
+
+        request = ua.CreateSessionRequest()
+        request.Parameters = parameters
+
+        data = await self._send_request(request, bypass_ready_gate=True)
+        response = struct_from_binary(ua.CreateSessionResponse, data)
+        self.logger.debug("CreateSessionResponse: %s", response)
+        response.ResponseHeader.ServiceResult.check()
+
+        if self.protocol:
+            self.protocol.authentication_token = (
+                response.Parameters.AuthenticationToken
+            )
+
+        if self._default_session is None:
+            self._default_session = UaSession(
+                self,
+                response.Parameters.SessionId,
+                response.Parameters.AuthenticationToken,
+            )
+            self._register_session(self._default_session)
+        else:
+            self._default_session.session_id = response.Parameters.SessionId
+            self._default_session.authentication_token = (
+                response.Parameters.AuthenticationToken
+            )
+
+        return response.Parameters
+
+    async def activate_session(
+        self, parameters: ua.ActivateSessionParameters
+    ) -> ua.ActivateSessionResult:
+        """Activate (authenticate) existing session.
+
+        Transitions state to SESSION_READY.
+
+        Args:
+            parameters: ActivateSessionParameters with credentials, etc.
+
+        Returns:
+            ActivateSessionResult with new session cookie
+
+        Raises:
+            BadUserAccessDenied: If credentials invalid
+            ConnectionError: If secure channel closed
+        """
+        self.logger.info("Activating session")
+
+        request = ua.ActivateSessionRequest()
+        request.Parameters = parameters
+
+        data = await self._send_request(request, bypass_ready_gate=True)
+        response = struct_from_binary(ua.ActivateSessionResponse, data)
+        self.logger.debug("ActivateSessionResponse: %s", response)
+        response.ResponseHeader.ServiceResult.check()
+
+        self.set_connection_state(UaClient.CONNECTION_STATE.SESSION_READY)
+        return response.Parameters
+
+    async def close_session(
+        self, delete_subscriptions: bool = True
+    ) -> None:
+        """Close session on server.
+
+        Args:
+            delete_subscriptions: If True, delete all subscriptions
+
+        Note:
+            Ignores BadSessionClosed and BadUserAccessDenied (expected
+            for some edge cases or older server versions)
+        """
+        self.logger.info("Closing session")
+
+        if not self._prepare_close_session():
+            return
+
+        data = await self._send_close_session_request(delete_subscriptions)
+        response = struct_from_binary(ua.CloseSessionResponse, data)
+
+        try:
+            response.ResponseHeader.ServiceResult.check()
+        except (BadSessionClosed, BadUserAccessDenied):
+            self.logger.debug("Ignored close_session error (expected)")
+
+        if self._default_session is not None:
+            try:
+                await self._default_session.close_session(delete_subscriptions)
+            finally:
+                self._unregister_session(self._default_session)
+                self._default_session = None
+
+    # ========== SESSIONLESS DISCOVERY SERVICES ==========
+
+    async def get_endpoints(
+        self, params: ua.GetEndpointsParameters
+    ) -> list[ua.EndpointDescription]:
+        """Query available server endpoints (sessionless).
+
+        Args:
+            params: GetEndpointsParameters with URL, locale, profiles
+
+        Returns:
+            List of available endpoints
+        """
+        self.logger.debug("get_endpoints")
+
+        request = ua.GetEndpointsRequest()
+        request.Parameters = params
+
+        data = await self._send_request(request, bypass_ready_gate=True)
+        response = struct_from_binary(ua.GetEndpointsResponse, data)
+        self.logger.debug("GetEndpointsResponse: %d endpoints",
+                          len(response.Endpoints))
+        response.ResponseHeader.ServiceResult.check()
+
+        return response.Endpoints
+
+    async def find_servers(
+        self, params: ua.FindServersParameters
+    ) -> list[ua.ServerOnNetwork]:
+        """Find servers on discovery server (sessionless).
+
+        Args:
+            params: FindServersParameters
+
+        Returns:
+            List of available servers
+        """
+        self.logger.debug("find_servers")
+
+        request = ua.FindServersRequest()
+        request.Parameters = params
+
+        data = await self._send_request(request, bypass_ready_gate=True)
+        response = struct_from_binary(ua.FindServersResponse, data)
+        response.ResponseHeader.ServiceResult.check()
+
+        return response.Servers
+
+    async def find_servers_on_network(
+        self, params: ua.FindServersOnNetworkParameters
+    ) -> ua.FindServersOnNetworkResult:
+        """Find servers on local network via mDNS (sessionless).
+
+        Args:
+            params: FindServersOnNetworkParameters
+
+        Returns:
+            Discovery result
+        """
+        self.logger.debug("find_servers_on_network")
+
+        request = ua.FindServersOnNetworkRequest()
+        request.Parameters = params
+
+        data = await self._send_request(request, bypass_ready_gate=True)
+        response = struct_from_binary(ua.FindServersOnNetworkResponse, data)
+        response.ResponseHeader.ServiceResult.check()
+
+        return response.Parameters
+
+    async def register_server(
+        self, registered_server: ua.RegisteredServer
+    ) -> None:
+        """Register server with discovery server (sessionless).
+
+        Args:
+            registered_server: Server registration details
+        """
+        self.logger.debug("register_server")
+
+        request = ua.RegisterServerRequest()
+        request.Server = registered_server
+
+        data = await self._send_request(request, bypass_ready_gate=True)
+        response = struct_from_binary(ua.RegisterServerResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+
+    async def unregister_server(
+        self, registered_server: ua.RegisteredServer
+    ) -> None:
+        """Unregister server from discovery server (sessionless).
+
+        Args:
+            registered_server: Server to unregister
+        """
+        self.logger.debug("unregister_server")
+
+        request = ua.RegisterServerRequest()
+        request.Server = registered_server
+
+        data = await self._send_request(request, bypass_ready_gate=True)
+        response = struct_from_binary(ua.RegisterServerResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+
+    async def register_server2(
+        self, params: ua.RegisterServer2Parameters
+    ) -> list[ua.StatusCode]:
+        """Register server with extended parameters (sessionless).
+
+        Args:
+            params: RegisterServer2Parameters
+
+        Returns:
+            List of configuration result status codes
+        """
+        self.logger.debug("register_server2")
+
+        request = ua.RegisterServer2Request()
+        request.Parameters = params
+
+        data = await self._send_request(request, bypass_ready_gate=True)
+        response = struct_from_binary(ua.RegisterServer2Response, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+
+        return response.ConfigurationResults
+
+    async def unregister_server2(
+        self, params: ua.RegisterServer2Parameters
+    ) -> list[ua.StatusCode]:
+        """Unregister server with extended parameters (sessionless).
+
+        Args:
+            params: RegisterServer2Parameters
+
+        Returns:
+            List of configuration result status codes
+        """
+        self.logger.debug("unregister_server2")
+
+        request = ua.RegisterServer2Request()
+        request.Parameters = params
+
+        data = await self._send_request(request, bypass_ready_gate=True)
+        response = struct_from_binary(ua.RegisterServer2Response, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+
+        return response.ConfigurationResults
+
+    # ========== INTERNAL & UTILITIES ==========
+
+    def _make_protocol(self) -> UASocketProtocol:
+        """Create new socket protocol handler."""
+        self.protocol = UASocketProtocol(
+            self._timeout, security_policy=self.security_policy
+        )
+        self.protocol.pre_request_hook = self._pre_request_hook
+        return self.protocol
+
+    def set_connection_state(self, state: int) -> None:
+        """Update connection state and signal ready event."""
+        self._connection_state = state
+        if state == UaClient.CONNECTION_STATE.SESSION_READY:
+            self._ready_event.set()
+        else:
+            self._ready_event.clear()
+
+    def try_set_connection_state(self, state: int) -> bool:
+        """Attempt guarded state transition (prevents backward states)."""
+        if (
+            self._connection_state == UaClient.CONNECTION_STATE.DISCONNECTING
+            and state
+            in (
+                UaClient.CONNECTION_STATE.SESSION_ESTABLISHING,
+                UaClient.CONNECTION_STATE.SESSION_READY,
+            )
+        ):
             self.logger.warning(
                 "Ignoring state transition %s -> %s during disconnect",
                 self._connection_state,
@@ -503,979 +860,350 @@ class UaClient(AbstractSession):
         self.set_connection_state(state)
         return True
 
-    def set_connection_state(self, state: CONNECTION_STATE) -> None:
-        self._connection_state = state
-        if state == UaClient.CONNECTION_STATE.SESSION_READY:
-            self._ready_event.set()
-        else:
-            self._ready_event.clear()
-
     async def await_ready(self, timeout: float | None = None) -> None:
-        if self._connection_state == UaClient.CONNECTION_STATE.SESSION_READY:
+        """Block until SESSION_READY state.
+
+        Args:
+            timeout: Seconds to wait (default: client timeout)
+
+        Raises:
+            ConnectionError: If timeout expires before ready
+        """
+        if (
+            self._connection_state
+            == UaClient.CONNECTION_STATE.SESSION_READY
+        ):
             return
+
         wait_timeout = self._timeout if timeout is None else timeout
         try:
-            await asyncio.wait_for(self._ready_event.wait(), wait_timeout)
+            await asyncio.wait_for(
+                self._ready_event.wait(), wait_timeout
+            )
         except (TimeoutError, asyncio.TimeoutError) as ex:
             raise ConnectionError("Client is not ready") from ex
 
     @asynccontextmanager
     async def internal_service_calls(self):
+        """Context manager for internal operations bypassing ready gate."""
         self._internal_service_call_depth += 1
         try:
             yield
         finally:
             self._internal_service_call_depth -= 1
 
-    def set_security(self, policy: security_policies.SecurityPolicy):
-        self.security_policy = policy
-
-    def _make_protocol(self):
-        self.protocol = UASocketProtocol(self._timeout, security_policy=self.security_policy)
-        self.protocol.pre_request_hook = self._pre_request_hook
-        return self.protocol
-
-    @property
-    def pre_request_hook(self) -> Callable[[], Awaitable[None]] | None:
-        return self._pre_request_hook
-
-    @pre_request_hook.setter
-    def pre_request_hook(self, hook: Callable[[], Awaitable[None]] | None):
-        self._pre_request_hook = hook
-        if self.protocol:
-            self.protocol.pre_request_hook = self._pre_request_hook
-
-    async def connect_socket(self, host: str, port: int):
-        """Connect to server socket."""
-        self.logger.info("opening connection")
-        self._closing = False
-        self.set_connection_state(UaClient.CONNECTION_STATE.CONNECTING)
-        # Timeout the connection when the server isn't available
-        await asyncio.wait_for(
-            asyncio.get_running_loop().create_connection(self._make_protocol, host, port), self._timeout
-        )
-
-    def disconnect_socket(self):
-        self._cancel_subscription_dispatch_workers()
-        if not self.protocol:
-            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
-            return
-        if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
-            self.logger.warning("disconnect_socket was called but connection is closed")
-            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
-            return
-        self.protocol.disconnect_socket()
-        self.protocol = None
-        self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
-
     async def _send_request(
         self,
-        request,
+        request: ua.BaseRequest,
         timeout: float | None = None,
-        message_type=ua.MessageType.SecureMessage,
+        message_type: ua.MessageType = ua.MessageType.SecureMessage,
         bypass_ready_gate: bool = False,
-    ):
-        if not bypass_ready_gate and self._internal_service_call_depth == 0:
+    ) -> bytes:
+        """Send OPC-UA request and wait for response.
+
+        Args:
+            request: OPC-UA request structure
+            timeout: Override default timeout
+            message_type: Message type (SecureMessage, SecureOpen, etc.)
+            bypass_ready_gate: Skip SESSION_READY check if True
+
+        Returns:
+            Response body (usually parsed by caller)
+
+        Raises:
+            ConnectionError: If channel not open or request times out
+        """
+        if (
+            not bypass_ready_gate
+            and self._internal_service_call_depth == 0
+        ):
             await self.await_ready(timeout=timeout)
+
         protocol = self.protocol
-        if protocol is None or protocol.state != UASocketProtocol.OPEN:
+        if not protocol or protocol.state != UASocketProtocol.OPEN:
             self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
             raise ConnectionError("Connection is closed")
-        return await protocol.send_request(request, timeout=timeout, message_type=message_type)
 
-    async def send_hello(self, url, max_messagesize: int = 0, max_chunkcount: int = 0):
-        await self.protocol.send_hello(url, max_messagesize, max_chunkcount)
-
-    async def open_secure_channel(self, params):
-        result = await self.protocol.open_secure_channel(params)
-        if self._connection_state != UaClient.CONNECTION_STATE.SESSION_READY:
-            self.set_connection_state(UaClient.CONNECTION_STATE.CHANNEL_READY)
-        return result
-
-    async def close_secure_channel(self):
-        """
-        close secure channel. It seems to trigger a shutdown of socket
-        in most servers, so be prepared to reconnect
-        """
-        if not self.protocol or self.protocol.state == UASocketProtocol.CLOSED:
-            self.logger.warning("close_secure_channel was called but connection is closed")
-            self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTED)
-            return None
-        self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTING)
-        return await self.protocol.close_secure_channel()
-
-    async def create_session(self, parameters):
-        self.logger.info("create_session")
-        self._closing = False
-        # FIXME: setting a value on an object to set it its state is suspicious,
-        # especially when that object has its own state
-        self.protocol.closed = False
-        request = ua.CreateSessionRequest()
-        request.Parameters = parameters
-        data = await self._send_request(request, bypass_ready_gate=True)
-        response = struct_from_binary(ua.CreateSessionResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        self.protocol.authentication_token = response.Parameters.AuthenticationToken
-        return response.Parameters
-
-    async def activate_session(self, parameters):
-        self.logger.info("activate_session")
-        request = ua.ActivateSessionRequest()
-        request.Parameters = parameters
-        data = await self._send_request(request, bypass_ready_gate=True)
-        response = struct_from_binary(ua.ActivateSessionResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        self.set_connection_state(UaClient.CONNECTION_STATE.SESSION_READY)
-        return response.Parameters
-
-    async def close_session(self, delete_subscriptions):
-        self.logger.info("close_session")
-        if not self._prepare_close_session():
-            return
-        data = await self._send_close_session_request(delete_subscriptions)
-        response = struct_from_binary(ua.CloseSessionResponse, data)
-        try:
-            response.ResponseHeader.ServiceResult.check()
-        except BadSessionClosed:
-            # Problem: closing the session with open publish requests leads to BadSessionClosed responses
-            #          we can just ignore it therefore.
-            #          Alternatively we could make sure that there are no publish requests in flight when
-            #          closing the session.
-            pass
-        except BadUserAccessDenied:
-            # Problem: older versions of asyncua didn't allow closing non-activated sessions. just ignore it.
-            pass
+        return await protocol.send_request(
+            request, timeout=timeout, message_type=message_type
+        )
 
     def _prepare_close_session(self) -> bool:
+        """Prepare for session closure."""
         self.set_connection_state(UaClient.CONNECTION_STATE.DISCONNECTING)
         self._closing = True
-        if self._publish_task and not self._publish_task.done():
-            self._publish_task.cancel()
-        self._cancel_subscription_dispatch_workers()
+
         if not self.protocol:
-            self.logger.warning("close_session but connection wasn't established")
+            self.logger.warning(
+                "close_session but connection not established"
+            )
             return False
+
         self.protocol.closed = True
-        if self.protocol and self.protocol.state == UASocketProtocol.CLOSED:
-            self.logger.warning("close_session was called but connection is closed")
+
+        if self.protocol.state == UASocketProtocol.CLOSED:
+            self.logger.warning("Connection already closed")
             return False
+
         return True
 
-    async def _send_close_session_request(self, delete_subscriptions):
+    async def _send_close_session_request(
+        self, delete_subscriptions: bool
+    ) -> bytes:
+        """Send CloseSessionRequest to server."""
         request = ua.CloseSessionRequest()
         request.DeleteSubscriptions = delete_subscriptions
         return await self._send_request(request, bypass_ready_gate=True)
 
-    async def browse(self, parameters):
-        self.logger.info("browse")
-        request = ua.BrowseRequest()
-        request.Parameters = parameters
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.BrowseResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def browse_next(self, parameters):
-        self.logger.debug("browse next")
-        request = ua.BrowseNextRequest()
-        request.Parameters = parameters
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.BrowseNextResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Parameters.Results
-
-    async def read(self, parameters):
-        self.logger.debug("read")
-        request = ua.ReadRequest()
-        request.Parameters = parameters
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.ReadResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def write(self, params):
-        self.logger.debug("write")
-        request = ua.WriteRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.WriteResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def get_endpoints(self, params):
-        self.logger.debug("get_endpoint")
-        request = ua.GetEndpointsRequest()
-        request.Parameters = params
-        data = await self._send_request(request, bypass_ready_gate=True)
-        response = struct_from_binary(ua.GetEndpointsResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Endpoints
-
-    async def find_servers(self, params):
-        self.logger.debug("find_servers")
-        request = ua.FindServersRequest()
-        request.Parameters = params
-        data = await self._send_request(request, bypass_ready_gate=True)
-        response = struct_from_binary(ua.FindServersResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Servers
-
-    async def find_servers_on_network(self, params):
-        self.logger.debug("find_servers_on_network")
-        request = ua.FindServersOnNetworkRequest()
-        request.Parameters = params
-        data = await self._send_request(request, bypass_ready_gate=True)
-        response = struct_from_binary(ua.FindServersOnNetworkResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Parameters
-
-    async def register_server(self, registered_server):
-        self.logger.debug("register_server")
-        request = ua.RegisterServerRequest()
-        request.Server = registered_server
-        data = await self._send_request(request, bypass_ready_gate=True)
-        response = struct_from_binary(ua.RegisterServerResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        # nothing to return for this service
-
-    async def unregister_server(self, registered_server):
-        self.logger.debug("unregister_server")
-        request = ua.RegisterServerRequest()
-        request.Server = registered_server
-        data = await self._send_request(request, bypass_ready_gate=True)
-        response = struct_from_binary(ua.RegisterServerResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        # nothing to return for this service
-
-    async def register_server2(self, params):
-        self.logger.debug("register_server2")
-        request = ua.RegisterServer2Request()
-        request.Parameters = params
-        data = await self._send_request(request, bypass_ready_gate=True)
-        response = struct_from_binary(ua.RegisterServer2Response, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.ConfigurationResults
-
-    async def unregister_server2(self, params):
-        self.logger.debug("unregister_server2")
-        request = ua.RegisterServer2Request()
-        request.Parameters = params
-        data = await self._send_request(request, bypass_ready_gate=True)
-        response = struct_from_binary(ua.RegisterServer2Response, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.ConfigurationResults
-
-    async def translate_browsepaths_to_nodeids(self, browse_paths):
-        self.logger.debug("translate_browsepath_to_nodeid")
-        request = ua.TranslateBrowsePathsToNodeIdsRequest()
-        request.Parameters.BrowsePaths = browse_paths
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.TranslateBrowsePathsToNodeIdsResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def create_subscription(  # type: ignore[override]
-        self, params: ua.CreateSubscriptionParameters, callback
-    ) -> ua.CreateSubscriptionResult:
-        self.logger.debug("create_subscription")
-        request = ua.CreateSubscriptionRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.CreateSubscriptionResponse, data)
-        response.ResponseHeader.ServiceResult.check()
-        subscription_id = response.Parameters.SubscriptionId
-        self._subscription_callbacks[subscription_id] = callback
-        self._ensure_subscription_dispatch_worker(subscription_id)
-        publishing_interval_ms = float(
-            getattr(response.Parameters, "RevisedPublishingInterval", params.RequestedPublishingInterval or 0.0) or 0.0
-        )
-        keepalive_count = int(
-            getattr(response.Parameters, "RevisedMaxKeepAliveCount", params.RequestedMaxKeepAliveCount or 1) or 1
-        )
-        self._register_subscription_watchdog(subscription_id, publishing_interval_ms, keepalive_count)
-        self.logger.info("create_subscription success SubscriptionId %s", subscription_id)
-        if not self._publish_task or self._publish_task.done():
-            # Start the publishing loop if it is not yet running
-            # The current strategy is to have only one open publish request per UaClient. This might not be enough
-            # in high latency networks or in case many subscriptions are created. A Set of Tasks of `_publish_loop`
-            # could be used if necessary.
-            self._publish_task = asyncio.create_task(self._publish_loop())
-        return response.Parameters
-
-    async def inform_subscriptions(self, status: ua.StatusCode):
-        """
-        Inform all current subscriptions with a status code. This calls the handler's status_change_notification
-        """
-        status_message = ua.StatusChangeNotification(Status=status)
-        notification_message = ua.NotificationMessage(NotificationData=[status_message])  # type: ignore[list-item]
-        for subid, callback in self._subscription_callbacks.items():
-            try:
-                parameters = ua.PublishResult(subid, NotificationMessage=notification_message)
-                await _invoke_subscription_callback(callback, parameters)
-            except Exception:  # we call user code, catch everything!
-                self.logger.exception("Exception while calling user callback: %s")
-
-    async def update_subscription(self, params: ua.ModifySubscriptionParameters) -> ua.ModifySubscriptionResult:
-        request = ua.ModifySubscriptionRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.ModifySubscriptionResponse, data)
-        response.ResponseHeader.ServiceResult.check()
-        self._register_subscription_watchdog(
-            int(params.SubscriptionId),
-            float(getattr(response.Parameters, "RevisedPublishingInterval", params.RequestedPublishingInterval or 0.0) or 0.0),
-            int(getattr(response.Parameters, "RevisedMaxKeepAliveCount", params.RequestedMaxKeepAliveCount or 1) or 1),
-        )
-        self.logger.info("update_subscription success SubscriptionId %s", params.SubscriptionId)
-        return response.Parameters
-
-    modify_subscription = update_subscription  # legacy support
-
-    async def delete_subscriptions(self, subscription_ids):
-        self.logger.debug("delete_subscriptions %r", subscription_ids)
-        request = ua.DeleteSubscriptionsRequest()
-        request.Parameters.SubscriptionIds = subscription_ids
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.DeleteSubscriptionsResponse, data)
-        response.ResponseHeader.ServiceResult.check()
-        self.logger.info("remove subscription callbacks for %r", subscription_ids)
-        for sid in subscription_ids:
-            self._subscription_callbacks.pop(sid)
-            self._stop_subscription_dispatch_worker(sid)
-            self._last_publish_sequence_numbers.pop(sid, None)
-            self._subscription_watchdog_states.pop(sid, None)
-        return response.Results
-
-    def _ensure_subscription_dispatch_worker(self, subscription_id: int) -> None:
-        runtime = self._subscription_dispatch_runtime.get(subscription_id)
-        if runtime is None:
-            maxsize = max(int(self.subscription_dispatch_queue_maxsize), 0)
-            runtime = _SubscriptionDispatchRuntime(queue=asyncio.Queue(maxsize=maxsize))
-            self._subscription_dispatch_runtime[subscription_id] = runtime
-        if runtime.task is None or runtime.task.done():
-            runtime.task = asyncio.create_task(self._subscription_dispatch_worker(subscription_id))
-
-    def _stop_subscription_dispatch_worker(self, subscription_id: int) -> None:
-        runtime = self._subscription_dispatch_runtime.pop(subscription_id, None)
-        if runtime is None:
-            return
-        queue = runtime.queue
-        if queue is not None:
-            try:
-                queue.put_nowait(None)
-            except asyncio.QueueFull:
-                pass
-        task = runtime.task
-        if task is not None and not task.done():
-            task.cancel()
-
-    def _cancel_subscription_dispatch_workers(self) -> None:
-        subscription_ids = list(self._subscription_dispatch_runtime.keys())
-        for subscription_id in subscription_ids:
-            self._stop_subscription_dispatch_worker(subscription_id)
-
-    async def flush_subscription_dispatch(
-        self,
-        subscription_ids: list[int] | None = None,
-        timeout: float | None = None,
+    def set_security(
+        self, policy: security_policies.SecurityPolicy
     ) -> None:
-        if subscription_ids is None:
-            queues = [runtime.queue for runtime in self._subscription_dispatch_runtime.values()]
-        else:
-            queues = [
-                self._subscription_dispatch_runtime[subscription_id].queue
-                for subscription_id in subscription_ids
-                if subscription_id in self._subscription_dispatch_runtime
-            ]
-        if not queues:
-            return
-        awaitable = asyncio.gather(*(queue.join() for queue in queues))
-        if timeout is None:
-            await awaitable
-        else:
-            await asyncio.wait_for(awaitable, timeout)
+        """Configure security policy before connecting.
 
-    async def _subscription_dispatch_worker(self, subscription_id: int) -> None:
-        runtime = self._subscription_dispatch_runtime.get(subscription_id)
-        if runtime is None:
-            return
-        queue = runtime.queue
-        while True:
-            publish_result = await queue.get()
+        Must be called before connect_socket().
+
+        Args:
+            policy: SecurityPolicy to apply
+        """
+        self.security_policy = policy
+
+    # ========== SESSION MANAGEMENT ==========
+
+    async def create_session_object(
+        self,
+        parameters: ua.CreateSessionParameters,
+    ) -> UaSession:
+        """Create and activate a new UaSession object.
+
+        This is the recommended way to create sessions. It handles creation,
+        activation, and wrapping in a UaSession for high-level operations.
+
+        Args:
+            parameters: CreateSessionParameters (description, timeout, etc.)
+
+        Returns:
+            Ready-to-use UaSession object
+
+        Raises:
+            BadUserAccessDenied: If activation fails
+            ConnectionError: If secure channel not open
+
+        Example:
+            >>> client = UaClient()
+            >>> await client.connect_socket("localhost", 4840)
+            >>> params = ua.CreateSessionParameters()
+            >>> session = await client.create_session_object(params)
+            >>> nodes = await session.browse(...)
+            >>> await session.close()
+        """
+        from asyncua.client.ua_session import UaSession
+
+        self.logger.info("Creating session object")
+
+        await self.create_session(parameters)
+        session = self._require_default_session()
+
+        try:
+            # Activate the session
+            activate_params = ua.ActivateSessionParameters()
+            await self.activate_session(activate_params)
+
+            self._default_session = session
+            self.logger.info("Session %s activated", session.session_id)
+            return session
+
+        except Exception as ex:
+            # Cleanup on failure
             try:
-                if publish_result is None:
-                    return
-                callback = self._subscription_callbacks.get(subscription_id)
-                if callback is None:
-                    self.logger.warning(
-                        "Received queued publish result for unknown subscription %s active are %s",
-                        subscription_id,
-                        self._subscription_callbacks.keys(),
-                    )
-                    continue
-                await _invoke_subscription_callback(callback, publish_result)
+                await self.close_session(delete_subscriptions=True)
             except Exception:
-                self.logger.exception("Exception while calling user callback: %s")
-            finally:
-                queue.task_done()
+                pass
+            raise ex
 
-    def _get_dispatch_queue(self, subscription_id: int) -> asyncio.Queue[ua.PublishResult | None] | None:
-        self._ensure_subscription_dispatch_worker(subscription_id)
-        runtime = self._subscription_dispatch_runtime.get(subscription_id)
-        if runtime is None:
-            return None
-        return runtime.queue
+    def get_sessions(self) -> list[UaSession]:
+        """Get list of active sessions.
 
-    def _enqueue_with_drop_oldest(
-        self,
-        queue: asyncio.Queue[ua.PublishResult | None],
-        subscription_id: int,
-        publish_result: ua.PublishResult,
-    ) -> bool:
-        dropped = False
-        try:
-            oldest = queue.get_nowait()
-            queue.task_done()
-            dropped = True
-            if oldest is None:
-                queue.put_nowait(None)
-        except asyncio.QueueEmpty:
-            pass
-        try:
-            queue.put_nowait(publish_result)
-        except asyncio.QueueFull:
-            self.logger.warning(
-                "Subscription %s dispatch queue still full after drop_oldest; dropping newest notification",
-                subscription_id,
-            )
-            return False
-        if dropped:
-            self.logger.warning(
-                "Subscription %s dispatch queue overflow; dropped oldest queued notification",
-                subscription_id,
-            )
-        return True
+        Returns:
+            Copy of active session list
+        """
+        return list(self._sessions.values())
 
-    def _enqueue_with_disconnect_policy(
-        self,
-        queue: asyncio.Queue[ua.PublishResult | None],
-        subscription_id: int,
-    ) -> bool:
-        overflow_error = SubscriptionDispatchOverflowError(subscription_id, queue.qsize())
-        self.logger.error("%s", overflow_error)
-        self._fail_all_dispatch_workers(overflow_error)
-        self._closing = True
-        return False
-
-    def _enqueue_with_warn_policy(self, subscription_id: int) -> bool:
-        self.logger.warning(
-            "Subscription %s dispatch queue overflow; dropping newest notification",
-            subscription_id,
-        )
-        return False
-
-    def _enqueue_when_full(
-        self,
-        queue: asyncio.Queue[ua.PublishResult | None],
-        subscription_id: int,
-        publish_result: ua.PublishResult,
-    ) -> bool:
-        policy = self._resolve_overflow_policy()
-        if policy == SubscriptionDispatchOverflowPolicy.DROP_OLDEST:
-            return self._enqueue_with_drop_oldest(queue, subscription_id, publish_result)
-        if policy == SubscriptionDispatchOverflowPolicy.DISCONNECT:
-            return self._enqueue_with_disconnect_policy(queue, subscription_id)
-        if policy == SubscriptionDispatchOverflowPolicy.WARN:
-            return self._enqueue_with_warn_policy(subscription_id)
-        return self._enqueue_with_warn_policy(subscription_id)
-
-    def _resolve_overflow_policy(self) -> SubscriptionDispatchOverflowPolicy:
-        policy = self.subscription_dispatch_overflow_policy
-        if isinstance(policy, SubscriptionDispatchOverflowPolicy):
-            return policy
-        if isinstance(policy, str):
-            normalized = policy.strip().lower()
-            for candidate in SubscriptionDispatchOverflowPolicy:
-                if candidate.value == normalized:
-                    self.subscription_dispatch_overflow_policy = candidate
-                    return candidate
-            self.logger.warning(
-                "Unknown subscription dispatch overflow policy '%s'; falling back to '%s'",
-                policy,
-                SubscriptionDispatchOverflowPolicy.WARN.value,
-            )
-            self.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.WARN
-            return SubscriptionDispatchOverflowPolicy.WARN
-        self.logger.warning(
-            "Unsupported subscription dispatch overflow policy type '%s'; falling back to '%s'",
-            type(policy).__name__,
-            SubscriptionDispatchOverflowPolicy.WARN.value,
-        )
-        self.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.WARN
-        return SubscriptionDispatchOverflowPolicy.WARN
-
-    def _enqueue_publish_result(self, subscription_id: int, publish_result: ua.PublishResult) -> bool:
-        callback = self._subscription_callbacks.get(subscription_id)
-        if callback is None:
-            self.logger.warning(
-                "Received publish result for unknown subscription %s active are %s",
-                subscription_id,
-                self._subscription_callbacks.keys(),
-            )
-            return False
-        queue = self._get_dispatch_queue(subscription_id)
-        if queue is None:
-            return False
-        if not queue.full():
-            queue.put_nowait(publish_result)
-            return True
-        return self._enqueue_when_full(queue, subscription_id, publish_result)
-
-    def _fail_all_dispatch_workers(self, exc: Exception) -> None:
-        for runtime in self._subscription_dispatch_runtime.values():
-            task = runtime.task
-            if task is not None and not task.done():
-                task.cancel()
-        self._subscription_dispatch_runtime.clear()
-
-    def get_subscription_ids(self) -> list[int]:
-        return list(self._subscription_callbacks.keys())
-
-    def _register_subscription_watchdog(self, subscription_id: int, publishing_interval_ms: float, keepalive_count: int) -> None:
-        if publishing_interval_ms <= 0:
-            self._subscription_watchdog_states.pop(subscription_id, None)
-            return
-        self._subscription_watchdog_states[subscription_id] = _SubscriptionWatchdogState(
-            publishing_interval_ms=publishing_interval_ms,
-            keepalive_count=max(int(keepalive_count), 1),
-            last_seen_at=asyncio.get_running_loop().time(),
-        )
-
-    def _mark_subscription_watchdog_activity(self, subscription_id: int) -> None:
-        state = self._subscription_watchdog_states.get(subscription_id)
-        if state is None:
-            return
-        state.last_seen_at = asyncio.get_running_loop().time()
-        state.stale_reported = False
-
-    def _get_stale_subscription_ids(self, now: float) -> list[int]:
-        if not self.watchdog_settings.stale_detection_enabled:
-            return []
-        stale_subscription_ids: list[int] = []
-        margin = max(self.watchdog_settings.stale_detection_margin, 1.0)
-        stale_state_ids_to_prune: list[int] = []
-        for subscription_id, state in self._subscription_watchdog_states.items():
-            if subscription_id not in self._subscription_callbacks:
-                stale_state_ids_to_prune.append(subscription_id)
-                continue
-            timeout = (state.publishing_interval_ms / 1000.0) * state.keepalive_count * margin
-            if timeout <= 0:
-                continue
-            if (now - state.last_seen_at) <= timeout:
-                continue
-            if state.stale_reported:
-                continue
-            state.stale_reported = True
-            stale_subscription_ids.append(subscription_id)
-        for stale_state_id in stale_state_ids_to_prune:
-            self._subscription_watchdog_states.pop(stale_state_id, None)
-        return stale_subscription_ids
-
-    def get_next_sequence_number(self, subscription_id: int) -> int:
-        last_sequence = self._last_publish_sequence_numbers.get(subscription_id, 0)
-        return last_sequence + 1
-
-    def _record_notification_sequence_number(
-        self,
-        subscription_id: int,
-        notification_message: ua.NotificationMessage,
-        source: str = "publish",
+    async def close_all_sessions(
+        self, delete_subscriptions: bool = True
     ) -> None:
-        # Keep-alive messages contain the next sequence number and do not represent
-        # a delivered NotificationMessage. Track only messages that include
-        # NotificationData so reconnect republish starts from the correct sequence.
-        if not notification_message.NotificationData:
-            return
+        """Close all active sessions.
 
-        received = int(notification_message.SequenceNumber)
-        if subscription_id in self._last_publish_sequence_numbers:
-            expected = self.get_next_sequence_number(subscription_id)
-            if received != expected:
-                self.logger.warning(
-                    "Detected notification sequence mismatch on subscription %s (%s): expected %s but received %s",
-                    subscription_id,
-                    source,
-                    expected,
-                    received,
-                )
+        Args:
+            delete_subscriptions: If True, delete subscriptions on server
+        """
+        sessions = list(self._sessions.values())
+        for session in sessions:
+            try:
+                await session.close()
+            except Exception:
+                self.logger.exception("Error closing session %s",
+                                      session.session_id)
 
-        self._last_publish_sequence_numbers[subscription_id] = received
+    def _register_session(self, session: UaSession) -> None:
+        """Track newly created session."""
+        self._session_id_counter += 1
+        session._client_session_id = self._session_id_counter
+        self._sessions[self._session_id_counter] = session
 
-    async def dispatch_notification_message(self, subscription_id: int, notification_message: ua.NotificationMessage) -> None:
-        self._record_notification_sequence_number(subscription_id, notification_message, source="republish")
-        result = ua.PublishResult(subscription_id, NotificationMessage=notification_message)
-        self._enqueue_publish_result(subscription_id, result)
+    def _unregister_session(self, session: UaSession) -> None:
+        """Remove closed session from registry."""
+        self._sessions.pop(session._client_session_id, None)
 
-    def ensure_publish_loop_running(self) -> None:
-        if self._subscription_callbacks and (not self._publish_task or self._publish_task.done()):
-            self._publish_task = asyncio.create_task(self._publish_loop())
+    # ========== BACKWARD-COMPAT SESSION DELEGATION ==========
+
+    def _require_default_session(self) -> UaSession:
+        """Return the default active session used by legacy UaClient APIs."""
+        if self._default_session is None:
+            raise UaError(
+                "No active session. Call create_session/activate_session first."
+            )
+        return self._default_session
+
+    async def browse(self, parameters: ua.BrowseParameters) -> list[ua.BrowseResult]:
+        return await self._require_default_session().browse(parameters)
+
+    async def browse_next(self, parameters: ua.BrowseNextParameters) -> list[ua.BrowseResult]:
+        return await self._require_default_session().browse_next(parameters)
+
+    async def read(self, parameters: ua.ReadParameters) -> list[ua.DataValue]:
+        return await self._require_default_session().read(parameters)
+
+    async def write(self, parameters: ua.WriteParameters) -> list[ua.StatusCode]:
+        return await self._require_default_session().write(parameters)
+
+    async def history_read(self, parameters: ua.HistoryReadParameters) -> list[ua.HistoryReadResult]:
+        return await self._require_default_session().history_read(parameters)
+
+    async def add_nodes(self, params: ua.AddNodesParameters) -> list[ua.AddNodesResult]:
+        return await self._require_default_session().add_nodes(params)
+
+    async def add_references(self, refs: list[ua.AddReferencesItem]) -> list[ua.StatusCode]:
+        return await self._require_default_session().add_references(refs)
+
+    async def delete_nodes(self, params: ua.DeleteNodesParameters) -> list[ua.StatusCode]:
+        return await self._require_default_session().delete_nodes(params)
+
+    async def delete_references(self, refs: list[ua.DeleteReferencesItem]) -> list[ua.StatusCode]:
+        return await self._require_default_session().delete_references(refs)
+
+    async def call(self, methodstocall: list[ua.CallMethodRequest]) -> list[ua.CallMethodResult]:
+        return await self._require_default_session().call(methodstocall)
+
+    async def translate_browsepaths_to_nodeids(
+        self, browse_paths: list[ua.BrowsePath]
+    ) -> list[ua.BrowsePathResult]:
+        return await self._require_default_session().translate_browsepaths_to_nodeids(browse_paths)
+
+    async def register_nodes(self, nodes: list[ua.NodeId]) -> list[ua.NodeId]:
+        return await self._require_default_session().register_nodes(nodes)
+
+    async def unregister_nodes(self, nodes: list[ua.NodeId]) -> list[ua.NodeId]:
+        return await self._require_default_session().unregister_nodes(nodes)
+
+    async def create_subscription(
+        self, params: ua.CreateSubscriptionParameters, callback: Callable[[ua.PublishResult], Any]
+    ) -> ua.CreateSubscriptionResult:
+        return await self._require_default_session().create_subscription(params, callback)
+
+    async def modify_subscription(self, params: ua.ModifySubscriptionParameters) -> ua.ModifySubscriptionResult:
+        return await self._require_default_session().modify_subscription(params)
+
+    async def delete_subscriptions(
+        self, params: ua.DeleteSubscriptionsParameters | list[int]
+    ) -> list[ua.StatusCode]:
+        actual_params = params
+        if isinstance(params, list):
+            actual_params = ua.DeleteSubscriptionsParameters()
+            actual_params.SubscriptionIds = params
+        return await self._require_default_session().delete_subscriptions(actual_params)
+
+    async def create_monitored_items(
+        self, params: ua.CreateMonitoredItemsParameters
+    ) -> list[ua.MonitoredItemCreateResult]:
+        return await self._require_default_session().create_monitored_items(params)
+
+    async def modify_monitored_items(
+        self, params: ua.ModifyMonitoredItemsParameters
+    ) -> list[ua.MonitoredItemModifyResult]:
+        return await self._require_default_session().modify_monitored_items(params)
+
+    async def delete_monitored_items(
+        self, params: ua.DeleteMonitoredItemsParameters
+    ) -> list[ua.StatusCode]:
+        return await self._require_default_session().delete_monitored_items(params)
+
+    async def transfer_subscriptions(
+        self, params: ua.TransferSubscriptionsParameters
+    ) -> list[ua.TransferResult]:
+        return await self._require_default_session().transfer_subscriptions(params)
+
+    async def set_monitoring_mode(
+        self, params: ua.SetMonitoringModeParameters
+    ) -> list[ua.StatusCode]:
+        return await self._require_default_session().set_monitoring_mode(params)
+
+    async def set_publishing_mode(
+        self, params: ua.SetPublishingModeParameters
+    ) -> list[ua.StatusCode]:
+        return await self._require_default_session().set_publishing_mode(params)
+
+    async def republish(
+        self, subscription_id: int, retransmit_sequence_number: int
+    ) -> ua.NotificationMessage:
+        return await self._require_default_session().republish(
+            subscription_id, retransmit_sequence_number
+        )
+
+    async def dispatch_notification_message(
+        self, subscription_id: int, notification_message: ua.NotificationMessage
+    ) -> None:
+        await self._require_default_session().dispatch_notification_message(
+            subscription_id, notification_message
+        )
 
     async def restart_publish_loop(self) -> None:
-        if self._publish_task is not None and not self._publish_task.done():
-            self._publish_task.cancel()
-            try:
-                await self._publish_task
-            except (asyncio.CancelledError, Exception):
-                pass
-        self._publish_task = None
-        self.ensure_publish_loop_running()
+        await self._require_default_session().restart_publish_loop()
 
-    async def republish(self, subscription_id: int, retransmit_sequence_number: int) -> ua.NotificationMessage:
-        request = ua.RepublishRequest()
-        request.Parameters.SubscriptionId = subscription_id
-        request.Parameters.RetransmitSequenceNumber = retransmit_sequence_number
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.RepublishResponse, data)
-        response.ResponseHeader.ServiceResult.check()
-        return response.NotificationMessage
+    async def inform_subscriptions(self, status: ua.StatusCode) -> None:
+        await self._require_default_session().inform_subscriptions(status)
 
-    async def _recover_sequence_gap(self, subscription_id: int, expected_sequence: int, received_sequence: int) -> None:
-        max_republish = max(int(self.max_republish_messages_per_gap), 0)
-        replay_window = _compute_republish_window(expected_sequence, received_sequence, max_republish)
-        if replay_window is None:
-            return
-        replay_start, replay_end_exclusive = replay_window
-        missing_count = received_sequence - expected_sequence
+    def get_subscription_ids(self) -> list[int]:
+        return self._require_default_session().get_subscription_ids()
 
-        if (replay_end_exclusive - replay_start) < missing_count:
-            self.logger.warning(
-                "Sequence gap on subscription %s is %s messages; replay capped to %s messages",
-                subscription_id,
-                missing_count,
-                max_republish,
-            )
+    def get_next_sequence_number(self, subscription_id: int) -> int:
+        return self._require_default_session().get_next_sequence_number(subscription_id)
 
-        self.logger.warning(
-            "Detected notification sequence gap on subscription %s: expected %s but received %s. Attempting republish",
-            subscription_id,
-            expected_sequence,
-            received_sequence,
-        )
-
-        for sequence_number in range(replay_start, replay_end_exclusive):
-            try:
-                notification_message = await self.republish(subscription_id, sequence_number)
-            except ua.UaStatusCodeError as err:
-                if err.code == ua.StatusCodes.BadMessageNotAvailable:
-                    self.logger.warning(
-                        "Republish missing sequence %s for subscription %s is not available on server",
-                        sequence_number,
-                        subscription_id,
-                    )
-                    break
-                if err.code == ua.StatusCodes.BadSubscriptionIdInvalid:
-                    self.logger.warning(
-                        "Republish failed for subscription %s because subscription is invalid",
-                        subscription_id,
-                    )
-                    break
-                raise
-            republished_sequence = int(notification_message.SequenceNumber)
-            if republished_sequence != sequence_number:
-                self.logger.warning(
-                    "Republish returned unexpected sequence for subscription %s: requested %s but got %s",
-                    subscription_id,
-                    sequence_number,
-                    republished_sequence,
-                )
-                break
-            await self.dispatch_notification_message(subscription_id, notification_message)
-
-    async def publish(self, acks: list[ua.SubscriptionAcknowledgement]) -> ua.PublishResponse:
-        """
-        Send a PublishRequest to the server.
-        """
-        self.logger.debug("publish %r", acks)
-        request = ua.PublishRequest()
-        request.Parameters.SubscriptionAcknowledgements = acks if acks else []
-        data = await self._send_request(request, timeout=0)
-        protocol = self.protocol
-        if protocol is None:
-            raise ConnectionError("Connection is closed")
-        protocol.check_answer(data, "while waiting for publish response")
-        try:
-            response = struct_from_binary(ua.PublishResponse, data)
-        except Exception as ex:
-            self.logger.exception("Error parsing notification from server")
-            raise UaStructParsingError from ex
-        return response
-
-    async def _read_publish_response(
-        self,
-        ack: SubscriptionAcknowledgement | None,
-    ) -> ua.PublishResponse | None:
-        try:
-            return await self.publish([ack] if ack else [])
-        except BadTimeout:  # See Spec. Part 4, 7.28
-            # Repeat without acknowledgement
-            return None
-        except BadNoSubscription:  # See Spec. Part 5, 13.8.1
-            # BadNoSubscription is expected to be received after deleting the last subscription.
-            # We use this as a signal to exit this task and stop sending PublishRequests.
-            self.logger.info("BadNoSubscription received, ignoring because it's probably valid.")
-            raise
-        except UaStructParsingError:
-            # Keep loop alive, parse problems can happen with broken payloads.
-            return None
-
-    async def _maybe_recover_gap(
-        self,
-        subscription_id: int,
-        notification_message: ua.NotificationMessage,
-    ) -> None:
-        if (
-            not self.sequence_recovery_settings.auto_republish_on_gap
-            or not notification_message.NotificationData
-            or subscription_id not in self._last_publish_sequence_numbers
-        ):
-            return
-        expected_sequence = self.get_next_sequence_number(subscription_id)
-        received_sequence = int(notification_message.SequenceNumber)
-        if received_sequence > expected_sequence:
-            await self._recover_sequence_gap(subscription_id, expected_sequence, received_sequence)
-
-    async def _handle_publish_response(self, response: ua.PublishResponse) -> SubscriptionAcknowledgement | None:
-        subscription_id = response.Parameters.SubscriptionId
-        if not subscription_id:
-            # The value 0 indicates there were no subscriptions for which a response could be sent.
-            raise BadNoSubscription()
-
-        self._mark_subscription_watchdog_activity(subscription_id)
-        stale_subscription_ids = self._get_stale_subscription_ids(asyncio.get_running_loop().time())
-        if stale_subscription_ids:
-            raise SubscriptionStaleError(stale_subscription_ids)
-
-        notification_message = response.Parameters.NotificationMessage
-        await self._maybe_recover_gap(subscription_id, notification_message)
-        self._enqueue_publish_result(subscription_id, response.Parameters)
-        self._record_notification_sequence_number(
-            subscription_id,
-            notification_message,
-            source="publish",
-        )
-        return _build_publish_ack(subscription_id, notification_message)
-
-    async def _publish_loop(self):
-        """
-        Start a loop that sends a publish requests and waits for the publish responses.
-        Forward the `PublishResult` to the matching `Subscription` by callback.
-        """
-        ack: SubscriptionAcknowledgement | None = None
-        while not self._closing:
-            try:
-                response = await self._read_publish_response(ack)
-                if response is None:
-                    ack = None
-                    continue
-                ack = await self._handle_publish_response(response)
-                # Yield once per successful publish cycle so notification-dispatch
-                # workers can run even when publish() returns immediately.
-                await asyncio.sleep(0)
-            except BadNoSubscription:
-                return
-            except SubscriptionStaleError:
-                raise
-            except Exception:
-                # Keep publish flow alive after unexpected callback or parsing edge cases.
-                ack = None
-                self.logger.exception("Unexpected error in publish loop")
-
-    async def create_monitored_items(self, params):
-        self.logger.info("create_monitored_items")
-        request = ua.CreateMonitoredItemsRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.CreateMonitoredItemsResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def delete_monitored_items(self, params):
-        self.logger.info("delete_monitored_items")
-        request = ua.DeleteMonitoredItemsRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.DeleteMonitoredItemsResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def add_nodes(self, nodestoadd):
-        self.logger.info("add_nodes")
-        request = ua.AddNodesRequest()
-        request.Parameters.NodesToAdd = nodestoadd
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.AddNodesResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def add_references(self, refs):
-        self.logger.info("add_references")
-        request = ua.AddReferencesRequest()
-        request.Parameters.ReferencesToAdd = refs
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.AddReferencesResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def delete_references(self, refs):
-        self.logger.info("delete")
-        request = ua.DeleteReferencesRequest()
-        request.Parameters.ReferencesToDelete = refs
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.DeleteReferencesResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Parameters.Results
-
-    async def delete_nodes(self, params):
-        self.logger.info("delete_nodes")
-        request = ua.DeleteNodesRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.DeleteNodesResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def call(self, methodstocall):
-        request = ua.CallRequest()
-        request.Parameters.MethodsToCall = methodstocall
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.CallResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def history_read(self, params):
-        self.logger.info("history_read")
-        request = ua.HistoryReadRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.HistoryReadResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def modify_monitored_items(self, params):
-        self.logger.info("modify_monitored_items")
-        request = ua.ModifyMonitoredItemsRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.ModifyMonitoredItemsResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def register_nodes(self, nodes):
-        self.logger.info("register_nodes")
-        request = ua.RegisterNodesRequest()
-        request.Parameters.NodesToRegister = nodes
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.RegisterNodesResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Parameters.RegisteredNodeIds
-
-    async def unregister_nodes(self, nodes):
-        self.logger.info("unregister_nodes")
-        request = ua.UnregisterNodesRequest()
-        request.Parameters.NodesToUnregister = nodes
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.UnregisterNodesResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        # nothing to return for this service
-
-    async def read_attributes(self, nodeids, attr):
-        self.logger.info("read_attributes of several nodes")
-        request = ua.ReadRequest()
+    async def read_attributes(
+        self, nodeids: list[ua.NodeId], attr: ua.AttributeIds = ua.AttributeIds.Value
+    ) -> list[ua.DataValue]:
+        params = ua.ReadParameters()
+        params.NodesToRead = []
         for nodeid in nodeids:
-            rv = ua.ReadValueId()
-            rv.NodeId = nodeid
-            rv.AttributeId = attr
-            request.Parameters.NodesToRead.append(rv)
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.ReadResponse, data)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
+            read_value = ua.ReadValueId()
+            read_value.NodeId = nodeid
+            read_value.AttributeId = attr
+            params.NodesToRead.append(read_value)
+        return await self.read(params)
 
-    async def write_attributes(self, nodeids, datavalues, attributeid=ua.AttributeIds.Value):
-        """
-        Set an attribute of multiple nodes
-        datavalue is a ua.DataValue object
-        """
-        self.logger.info("write_attributes of several nodes")
-        request = ua.WriteRequest()
-        for idx, nodeid in enumerate(nodeids):
-            attr = ua.WriteValue()
-            attr.NodeId = nodeid
-            attr.AttributeId = attributeid
-            attr.Value = datavalues[idx]
-            request.Parameters.NodesToWrite.append(attr)
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.WriteResponse, data)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Results
-
-    async def set_monitoring_mode(self, params) -> list[ua.uatypes.StatusCode]:
-        """
-        Update the subscription monitoring mode
-        """
-        self.logger.info("set_monitoring_mode")
-        request = ua.SetMonitoringModeRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.SetMonitoringModeResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Parameters.Results
-
-    async def set_publishing_mode(self, params) -> list[ua.uatypes.StatusCode]:
-        """
-        Update the subscription publishing mode
-        """
-        self.logger.info("set_publishing_mode")
-        request = ua.SetPublishingModeRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.SetPublishingModeResponse, data)
-        self.logger.debug(response)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Parameters.Results
-
-    async def transfer_subscriptions(self, params: ua.TransferSubscriptionsParameters) -> list[ua.TransferResult]:
-        # Subscriptions aren't bound to a Session and can be transferred!
-        # https://reference.opcfoundation.org/Core/Part4/v104/5.13.7/
-        request = ua.TransferSubscriptionsRequest()
-        request.Parameters = params
-        data = await self._send_request(request)
-        response = struct_from_binary(ua.TransferSubscriptionsResponse, data)
-        response.ResponseHeader.ServiceResult.check()
-        return response.Parameters.Results
+    async def write_attributes(
+        self,
+        nodeids: list[ua.NodeId],
+        datavalues: list[ua.DataValue],
+        attributeid: ua.AttributeIds = ua.AttributeIds.Value,
+    ) -> list[ua.StatusCode]:
+        if len(nodeids) != len(datavalues):
+            raise ValueError("nodeids and datavalues must have the same length")
+        params = ua.WriteParameters()
+        params.NodesToWrite = []
+        for nodeid, datavalue in zip(nodeids, datavalues):
+            write_value = ua.WriteValue()
+            write_value.NodeId = nodeid
+            write_value.AttributeId = attributeid
+            write_value.Value = datavalue
+            params.NodesToWrite.append(write_value)
+        return await self.write(params)

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -141,10 +141,12 @@ class UaSession(AbstractSession):
     OPC-UA Session managing session-specific operations and subscriptions.
 
     Handles:
-    - Session creation, activation, closure
+    - Session-scoped services and session closure handling
     - Subscriptions and monitored items
     - Publish/subscription loop with gap recovery
     - Watchdog monitoring for subscription staleness
+
+    Session creation and activation are handled by UaClient.
     """
 
     def __init__(

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -938,7 +938,12 @@ class UaSession(AbstractSession):
         response = struct_from_binary(ua.RepublishResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
-        return response.Parameters.NotificationMessage
+        # RepublishResponse can expose NotificationMessage directly (spec-compliant)
+        # or behind a Parameters object in older generated protocol code.
+        params = getattr(response, "Parameters", None)
+        if params is not None:
+            return params.NotificationMessage
+        return response.NotificationMessage
 
     async def publish(
         self, acks: list[ua.SubscriptionAcknowledgement]

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -464,7 +464,7 @@ class UaSession(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Parameters.RegisteredNodeIds
 
-    async def unregister_nodes(self, nodes: list[ua.NodeId]) -> list[ua.NodeId]:
+    async def unregister_nodes(self, nodes: list[ua.NodeId]) -> None:
         """Unregister nodes."""
         self.logger.debug("unregister_nodes")
         request = ua.UnregisterNodesRequest()
@@ -473,7 +473,7 @@ class UaSession(AbstractSession):
         response = struct_from_binary(ua.UnregisterNodesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
-        return nodes
+        return None
 
     # Subscription Service Set methods
 

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING, Any, Callable
 from asyncua import ua
 from asyncua.common.session_interface import AbstractSession
 from asyncua.ua.ua_binary import struct_from_binary
-from asyncua.ua.uaerrors import BadSessionClosed
 from asyncua.ua.uaprotocol_auto import SubscriptionAcknowledgement
 
 if TYPE_CHECKING:
@@ -49,6 +48,17 @@ class SubscriptionDispatchOverflowPolicy(str, Enum):
     DROP_OLDEST = "drop_oldest"
     WARN = "warn"
     DISCONNECT = "disconnect"
+
+
+class SessionState(str, Enum):
+    IDLE = "idle"
+    ESTABLISHING = "establishing"
+    READY = "ready"
+    SUSPENDED = "suspended"
+    RECOVERING = "recovering"
+    CLOSING = "closing"
+    CLOSED = "closed"
+    FAILED = "failed"
 
 
 @dataclass
@@ -186,6 +196,52 @@ class UaSession(AbstractSession):
         self._publish_task: asyncio.Task[None] | None = None
         self._closing = False
         self._disconnect_event = asyncio.Event()
+        self._ready_event = asyncio.Event()
+        self._state: SessionState = SessionState.IDLE
+
+    @property
+    def state(self) -> SessionState:
+        return self._state
+
+    def _set_state(self, state: SessionState) -> None:
+        self._state = state
+        if state == SessionState.READY:
+            self._ready_event.set()
+            return
+        self._ready_event.clear()
+
+    async def await_ready(self, timeout: float | None = None) -> None:
+        if self._state == SessionState.READY:
+            return
+        wait_timeout = self.client._timeout if timeout is None else timeout
+        try:
+            await asyncio.wait_for(self._ready_event.wait(), wait_timeout)
+        except (TimeoutError, asyncio.TimeoutError) as ex:
+            raise ConnectionError("Session is not ready") from ex
+
+    def on_transport_lost(self) -> None:
+        if self._state in (SessionState.CLOSING, SessionState.CLOSED):
+            return
+        self._set_state(SessionState.SUSPENDED)
+
+    def on_transport_restored(self) -> None:
+        if self._state in (SessionState.CLOSING, SessionState.CLOSED):
+            return
+        self._set_state(SessionState.RECOVERING)
+
+    async def _send_session_request(
+        self,
+        request: ua.BaseRequest,
+        timeout: float | None = None,
+        bypass_ready_gate: bool = False,
+    ) -> bytes:
+        if not bypass_ready_gate:
+            await self.await_ready(timeout=timeout)
+        return await self.client._send_request(
+            request,
+            timeout=timeout,
+            bypass_ready_gate=bypass_ready_gate,
+        )
 
     @property
     def subscription_dispatch_queue_maxsize(self) -> int:
@@ -258,7 +314,7 @@ class UaSession(AbstractSession):
         self.logger.debug("browse")
         request = ua.BrowseRequest()
         request.Parameters = parameters
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.BrowseResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -271,7 +327,7 @@ class UaSession(AbstractSession):
         self.logger.debug("browse_next")
         request = ua.BrowseNextRequest()
         request.Parameters = parameters
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.BrowseNextResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -282,7 +338,7 @@ class UaSession(AbstractSession):
         self.logger.debug("read")
         request = ua.ReadRequest()
         request.Parameters = parameters
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.ReadResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -293,7 +349,7 @@ class UaSession(AbstractSession):
         self.logger.debug("write")
         request = ua.WriteRequest()
         request.Parameters = parameters
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.WriteResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -306,7 +362,7 @@ class UaSession(AbstractSession):
         self.logger.debug("history_read")
         request = ua.HistoryReadRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.HistoryReadResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -317,7 +373,7 @@ class UaSession(AbstractSession):
         self.logger.debug("add_nodes")
         request = ua.AddNodesRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.AddNodesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -330,7 +386,7 @@ class UaSession(AbstractSession):
         self.logger.debug("add_references")
         request = ua.AddReferencesRequest()
         request.Parameters.ReferencesToAdd = refs
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.AddReferencesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -343,7 +399,7 @@ class UaSession(AbstractSession):
         self.logger.debug("delete_nodes")
         request = ua.DeleteNodesRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.DeleteNodesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -356,7 +412,7 @@ class UaSession(AbstractSession):
         self.logger.debug("delete_references")
         request = ua.DeleteReferencesRequest()
         request.Parameters.ReferencesToDelete = refs
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.DeleteReferencesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -369,7 +425,7 @@ class UaSession(AbstractSession):
         self.logger.debug("call")
         request = ua.CallRequest()
         request.Parameters.MethodsToCall = methodstocall
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.CallResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -382,7 +438,7 @@ class UaSession(AbstractSession):
         self.logger.debug("translate_browsepath_to_nodeid")
         request = ua.TranslateBrowsePathsToNodeIdsRequest()
         request.Parameters.BrowsePaths = browse_paths
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.TranslateBrowsePathsToNodeIdsResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -393,7 +449,7 @@ class UaSession(AbstractSession):
         self.logger.debug("register_nodes")
         request = ua.RegisterNodesRequest()
         request.Parameters.NodesToRegister = nodes
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.RegisterNodesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -404,7 +460,7 @@ class UaSession(AbstractSession):
         self.logger.debug("unregister_nodes")
         request = ua.UnregisterNodesRequest()
         request.Parameters.NodesToUnregister = nodes
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.UnregisterNodesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -419,7 +475,7 @@ class UaSession(AbstractSession):
         self.logger.debug("create_subscription")
         request = ua.CreateSubscriptionRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.CreateSubscriptionResponse, data)
         response.ResponseHeader.ServiceResult.check()
         subscription_id = response.Parameters.SubscriptionId
@@ -459,7 +515,7 @@ class UaSession(AbstractSession):
         self.logger.debug("modify_subscription")
         request = ua.ModifySubscriptionRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.ModifySubscriptionResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -472,7 +528,7 @@ class UaSession(AbstractSession):
         self.logger.debug("delete_subscriptions")
         request = ua.DeleteSubscriptionsRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.DeleteSubscriptionsResponse, data)
         response.ResponseHeader.ServiceResult.check()
         for subscription_id in params.SubscriptionIds:
@@ -489,7 +545,7 @@ class UaSession(AbstractSession):
         self.logger.debug("create_monitored_items")
         request = ua.CreateMonitoredItemsRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.CreateMonitoredItemsResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -502,7 +558,7 @@ class UaSession(AbstractSession):
         self.logger.debug("modify_monitored_items")
         request = ua.ModifyMonitoredItemsRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.ModifyMonitoredItemsResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -515,7 +571,7 @@ class UaSession(AbstractSession):
         self.logger.debug("delete_monitored_items")
         request = ua.DeleteMonitoredItemsRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.DeleteMonitoredItemsResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -528,7 +584,7 @@ class UaSession(AbstractSession):
         self.logger.debug("transfer_subscriptions")
         request = ua.TransferSubscriptionsRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.TransferSubscriptionsResponse, data)
         response.ResponseHeader.ServiceResult.check()
         return response.Parameters.Results
@@ -540,7 +596,7 @@ class UaSession(AbstractSession):
         self.logger.debug("set_monitoring_mode")
         request = ua.SetMonitoringModeRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.SetMonitoringModeResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -872,7 +928,7 @@ class UaSession(AbstractSession):
         request = ua.RepublishRequest()
         request.Parameters.SubscriptionId = subscription_id
         request.Parameters.RetransmitSequenceNumber = retransmit_sequence_number
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.RepublishResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -885,6 +941,7 @@ class UaSession(AbstractSession):
         self.logger.debug("publish %r", acks)
         request = ua.PublishRequest()
         request.Parameters.SubscriptionAcknowledgements = acks if acks else []
+        await self.await_ready()
         data = await self.client._send_request(request, timeout=0)
         protocol = self.client.protocol
         if protocol is None:
@@ -1007,10 +1064,12 @@ class UaSession(AbstractSession):
 
     async def close_session(self, delete_subscriptions: bool) -> None:
         """Close session and cleanup resources."""
+        self._set_state(SessionState.CLOSING)
         self._closing = True
         self._disconnect_event.set()
         if self._publish_task is not None and not self._publish_task.done():
             self._publish_task.cancel()
+        self._set_state(SessionState.CLOSED)
         # Cleanup would be implemented here
         pass
 
@@ -1032,7 +1091,7 @@ class UaSession(AbstractSession):
     @property
     def ready_event(self) -> asyncio.Event:
         """Event signaled when session is ready."""
-        return self._disconnect_event
+        return self._ready_event
 
     async def __aenter__(self) -> UaSession:
         """Async context manager entry."""

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -913,6 +913,14 @@ class UaSession(AbstractSession):
         for sequence_number in range(start_sequence, end_sequence):
             try:
                 notif_msg = await self.republish(subscription_id, sequence_number)
+                if int(notif_msg.SequenceNumber) != int(sequence_number):
+                    self.logger.warning(
+                        "Stopping gap recovery for subscription %s: expected republish sequence %s, got %s",
+                        subscription_id,
+                        sequence_number,
+                        notif_msg.SequenceNumber,
+                    )
+                    break
                 await self.dispatch_notification_message(subscription_id, notif_msg)
             except Exception:
                 self.logger.exception(

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -473,7 +473,6 @@ class UaSession(AbstractSession):
         response = struct_from_binary(ua.UnregisterNodesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
-        return None
 
     # Subscription Service Set methods
 

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -615,7 +615,7 @@ class UaSession(AbstractSession):
         self.logger.debug("set_publishing_mode")
         request = ua.SetPublishingModeRequest()
         request.Parameters = params
-        data = await self.client._send_request(request)
+        data = await self._send_session_request(request)
         response = struct_from_binary(ua.SetPublishingModeResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
@@ -711,12 +711,6 @@ class UaSession(AbstractSession):
         self._last_publish_sequence_numbers[subscription_id] = (
             notification_message.SequenceNumber
         )
-
-    async def dispatch_notification_message(
-        self, subscription_id: int, notification_message: ua.NotificationMessage
-    ) -> None:
-        """Dispatch notification to registered callback (placeholder)."""
-        pass
 
     def get_subscription_ids(self) -> list[int]:
         """Get list of active subscription IDs."""
@@ -840,6 +834,7 @@ class UaSession(AbstractSession):
 
     def _fail_all_dispatch_workers(self, exc: Exception) -> None:
         """Signal all dispatch workers to stop with error."""
+        self.logger.error("Stopping all subscription dispatch workers: %s", exc)
         for runtime in self._subscription_dispatch_runtime.values():
             task = runtime.task
             if task is not None and not task.done():
@@ -980,6 +975,7 @@ class UaSession(AbstractSession):
             self.logger.info("BadNoSubscription in publish loop")
             raise
         except Exception:
+            self.logger.exception("Unexpected error while reading publish response")
             return None
 
     async def _maybe_recover_gap(
@@ -1073,16 +1069,32 @@ class UaSession(AbstractSession):
         self._publish_task = None
         await self.ensure_publish_loop_running()
 
-    async def close_session(self, delete_subscriptions: bool) -> None:
+    async def close(self) -> None:
         """Close session and cleanup resources."""
+        if self._state in (SessionState.CLOSING, SessionState.CLOSED):
+            return
+
         self._set_state(SessionState.CLOSING)
         self._closing = True
         self._disconnect_event.set()
+
         if self._publish_task is not None and not self._publish_task.done():
             self._publish_task.cancel()
+            try:
+                await self._publish_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                self.logger.exception("Error while stopping publish loop")
+
+        for subscription_id in list(self._subscription_dispatch_runtime.keys()):
+            self._stop_subscription_dispatch_worker(subscription_id)
+
+        self._subscription_callbacks.clear()
+        self._last_publish_sequence_numbers.clear()
+        self._subscription_watchdog_states.clear()
+
         self._set_state(SessionState.CLOSED)
-        # Cleanup would be implemented here
-        pass
 
     async def inform_subscriptions(self, status: ua.StatusCode) -> None:
         """Inform all subscriptions of status change."""
@@ -1115,4 +1127,4 @@ class UaSession(AbstractSession):
         exc_tb: TracebackType | None,
     ) -> None:
         """Async context manager exit - cleanup."""
-        await self.close_session(delete_subscriptions=True)
+        await self.close()

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -2,6 +2,8 @@
 OPC-UA Session implementation handling session-specific services and subscriptions.
 """
 
+from __future__ import annotations
+
 import asyncio
 import inspect
 import logging
@@ -161,7 +163,7 @@ class UaSession(AbstractSession):
 
     def __init__(
         self,
-        client: UaClient,
+        client: "UaClient",
         session_id: ua.NodeId,
         authentication_token: ua.NodeId,
     ) -> None:
@@ -368,11 +370,15 @@ class UaSession(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         return response.Results
 
-    async def add_nodes(self, params: ua.AddNodesParameters) -> list[ua.AddNodesResult]:
+    async def add_nodes(self, params: ua.AddNodesParameters | list[ua.AddNodesItem]) -> list[ua.AddNodesResult]:
         """Add nodes to address space."""
         self.logger.debug("add_nodes")
         request = ua.AddNodesRequest()
-        request.Parameters = params
+        if isinstance(params, list):
+            request.Parameters = ua.AddNodesParameters()
+            request.Parameters.NodesToAdd = params
+        else:
+            request.Parameters = params
         data = await self._send_session_request(request)
         response = struct_from_binary(ua.AddNodesResponse, data)
         self.logger.debug(response)
@@ -416,7 +422,7 @@ class UaSession(AbstractSession):
         response = struct_from_binary(ua.DeleteReferencesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
-        return response.Results
+        return response.Parameters.Results
 
     async def call(
         self, methodstocall: list[ua.CallMethodRequest]

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -8,10 +8,11 @@ import asyncio
 import inspect
 import logging
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from asyncua import ua
 from asyncua.common.session_interface import AbstractSession
@@ -487,7 +488,7 @@ class UaSession(AbstractSession):
         response.ResponseHeader.ServiceResult.check()
         subscription_id = response.Parameters.SubscriptionId
         self._subscription_callbacks[subscription_id] = callback
-        
+
         publishing_interval_ms = float(
             getattr(
                 response.Parameters,
@@ -509,10 +510,10 @@ class UaSession(AbstractSession):
         )
         self.logger.info("Subscription created: %s", subscription_id)
         self._ensure_subscription_dispatch_worker(subscription_id)
-        
+
         if self._publish_task is None or self._publish_task.done():
             self._publish_task = asyncio.create_task(self._publish_loop())
-        
+
         return response.Parameters
 
     async def modify_subscription(
@@ -979,7 +980,7 @@ class UaSession(AbstractSession):
         ack: SubscriptionAcknowledgement | None,
     ) -> ua.PublishResponse | None:
         """Read publish response, handling timeouts and errors."""
-        from asyncua.ua.uaerrors import BadTimeout, BadNoSubscription
+        from asyncua.ua.uaerrors import BadNoSubscription, BadTimeout
         try:
             return await self.publish([ack] if ack else [])
         except BadTimeout:

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -243,6 +243,7 @@ class UaSession(AbstractSession):
             request,
             timeout=timeout,
             bypass_ready_gate=bypass_ready_gate,
+            authentication_token=self.authentication_token,
         )
 
     @property
@@ -948,7 +949,11 @@ class UaSession(AbstractSession):
         request = ua.PublishRequest()
         request.Parameters.SubscriptionAcknowledgements = acks if acks else []
         await self.await_ready()
-        data = await self.client._send_request(request, timeout=0)
+        data = await self.client._send_request(
+            request,
+            timeout=0,
+            authentication_token=self.authentication_token,
+        )
         protocol = self.client.protocol
         if protocol is None:
             raise ConnectionError("Connection is closed")
@@ -1069,8 +1074,8 @@ class UaSession(AbstractSession):
         self._publish_task = None
         await self.ensure_publish_loop_running()
 
-    async def close(self) -> None:
-        """Close session and cleanup resources."""
+    async def _close_local(self) -> None:
+        """Close local session resources without sending CloseSessionRequest."""
         if self._state in (SessionState.CLOSING, SessionState.CLOSED):
             return
 
@@ -1095,6 +1100,13 @@ class UaSession(AbstractSession):
         self._subscription_watchdog_states.clear()
 
         self._set_state(SessionState.CLOSED)
+
+    async def close(self, delete_subscriptions: bool = True) -> None:
+        """Close session and release local and remote resources."""
+        await self.client.close_session(
+            delete_subscriptions=delete_subscriptions,
+            session=self,
+        )
 
     async def inform_subscriptions(self, status: ua.StatusCode) -> None:
         """Inform all subscriptions of status change."""

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -201,6 +201,7 @@ class UaSession(AbstractSession):
         self._disconnect_event = asyncio.Event()
         self._ready_event = asyncio.Event()
         self._state: SessionState = SessionState.IDLE
+        self.registry_session_id: int | None = None
 
     @property
     def state(self) -> SessionState:
@@ -234,7 +235,7 @@ class UaSession(AbstractSession):
 
     async def _send_session_request(
         self,
-        request: ua.BaseRequest,
+        request: Any,
         timeout: float | None = None,
         bypass_ready_gate: bool = False,
     ) -> bytes:
@@ -335,7 +336,7 @@ class UaSession(AbstractSession):
         response = struct_from_binary(ua.BrowseNextResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
-        return response.Results
+        return response.Parameters.Results
 
     async def read(self, parameters: ua.ReadParameters) -> list[ua.DataValue]:
         """Read node attributes."""
@@ -472,12 +473,14 @@ class UaSession(AbstractSession):
         response = struct_from_binary(ua.UnregisterNodesResponse, data)
         self.logger.debug(response)
         response.ResponseHeader.ServiceResult.check()
-        return response.Parameters.UnregisteredNodeIds
+        return nodes
 
     # Subscription Service Set methods
 
     async def create_subscription(
-        self, params: ua.CreateSubscriptionParameters, callback: Callable
+        self,
+        params: ua.CreateSubscriptionParameters,
+        callback: Callable[[ua.PublishResult], Any] | None = None,
     ) -> ua.CreateSubscriptionResult:
         """Create a subscription."""
         self.logger.debug("create_subscription")
@@ -487,6 +490,11 @@ class UaSession(AbstractSession):
         response = struct_from_binary(ua.CreateSubscriptionResponse, data)
         response.ResponseHeader.ServiceResult.check()
         subscription_id = response.Parameters.SubscriptionId
+        if callback is None:
+            def _noop_callback(_publish_result: ua.PublishResult) -> None:
+                return
+
+            callback = _noop_callback
         self._subscription_callbacks[subscription_id] = callback
 
         publishing_interval_ms = float(

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -1,0 +1,1046 @@
+"""
+OPC-UA Session implementation handling session-specific services and subscriptions.
+"""
+
+import asyncio
+import inspect
+import logging
+import time
+from dataclasses import dataclass
+from enum import Enum
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Callable
+
+from asyncua import ua
+from asyncua.common.session_interface import AbstractSession
+from asyncua.ua.ua_binary import struct_from_binary
+from asyncua.ua.uaerrors import BadSessionClosed
+from asyncua.ua.uaprotocol_auto import SubscriptionAcknowledgement
+
+if TYPE_CHECKING:
+    from asyncua.client.ua_client import UaClient
+
+
+class SubscriptionStaleError(ConnectionError):
+    """Raised when subscriptions are detected as stale."""
+
+    def __init__(self, subscription_ids: list[int]) -> None:
+        self.subscription_ids = subscription_ids
+        super().__init__(
+            f"Stale subscriptions with no Publish messages: {subscription_ids}"
+        )
+
+
+class SubscriptionDispatchOverflowError(ConnectionError):
+    """Raised when subscription dispatch queue overflows."""
+
+    def __init__(self, subscription_id: int, queue_size: int) -> None:
+        self.subscription_id = subscription_id
+        self.queue_size = queue_size
+        super().__init__(
+            f"Subscription dispatch queue overflow for subscription "
+            f"{subscription_id} at size {queue_size}"
+        )
+
+
+class SubscriptionDispatchOverflowPolicy(str, Enum):
+    """Policy for handling subscription dispatch queue overflow."""
+
+    DROP_OLDEST = "drop_oldest"
+    WARN = "warn"
+    DISCONNECT = "disconnect"
+
+
+@dataclass
+class _SubscriptionWatchdogState:
+    """Tracks watchdog state for subscription staleness detection."""
+
+    publishing_interval_ms: float
+    keepalive_count: int
+    last_seen_at: float
+    stale_reported: bool = False
+
+
+@dataclass
+class _DispatchSettings:
+    """Settings for subscription dispatch behavior."""
+
+    queue_maxsize: int = 1000
+    overflow_policy: (
+        SubscriptionDispatchOverflowPolicy | str
+    ) = SubscriptionDispatchOverflowPolicy.DROP_OLDEST
+
+
+@dataclass
+class _SequenceRecoverySettings:
+    """Settings for subscription sequence number recovery."""
+
+    auto_republish_on_gap: bool = True
+    max_republish_messages_per_gap: int = 1000
+
+
+@dataclass
+class _WatchdogSettings:
+    """Settings for subscription watchdog monitoring."""
+
+    stale_detection_enabled: bool = True
+    stale_detection_margin: float = 1.2
+
+
+@dataclass
+class _SubscriptionDispatchRuntime:
+    """Runtime state for subscription dispatch worker."""
+
+    queue: asyncio.Queue[ua.PublishResult | None]
+    task: asyncio.Task[None] | None = None
+
+
+def _compute_republish_window(
+    expected_sequence: int,
+    received_sequence: int,
+    max_republish: int,
+) -> tuple[int, int] | None:
+    """Compute republish window for gap recovery."""
+    if received_sequence <= expected_sequence:
+        return None
+    if max_republish <= 0:
+        return None
+
+    missing_count = received_sequence - expected_sequence
+    replay_end_exclusive = received_sequence
+    if missing_count > max_republish:
+        replay_end_exclusive = expected_sequence + max_republish
+    return expected_sequence, replay_end_exclusive
+
+
+def _build_publish_ack(
+    subscription_id: int,
+    notification_message: ua.NotificationMessage,
+) -> SubscriptionAcknowledgement | None:
+    """Build subscription acknowledgement from notification message."""
+    if not notification_message.NotificationData:
+        return None
+    ack = ua.SubscriptionAcknowledgement()
+    ack.SubscriptionId = subscription_id
+    ack.SequenceNumber = notification_message.SequenceNumber
+    return ack
+
+
+async def _invoke_subscription_callback(
+    callback: Callable[[ua.PublishResult], Any],
+    publish_result: ua.PublishResult,
+) -> None:
+    """Invoke subscription callback, handling both sync and async."""
+    result = callback(publish_result)
+    if inspect.isawaitable(result):
+        await result
+
+
+class UaSession(AbstractSession):
+    """
+    OPC-UA Session managing session-specific operations and subscriptions.
+
+    Handles:
+    - Session creation, activation, closure
+    - Subscriptions and monitored items
+    - Publish/subscription loop with gap recovery
+    - Watchdog monitoring for subscription staleness
+    """
+
+    def __init__(
+        self,
+        client: UaClient,
+        session_id: ua.NodeId,
+        authentication_token: ua.NodeId,
+    ) -> None:
+        """Initialize session.
+
+        Args:
+            client: Parent UaClient (sessionless component)
+            session_id: Session identifier from server
+            authentication_token: Token for server authentication
+        """
+        self.logger = logging.getLogger(f"{__name__}.UaSession")
+        self.client = client
+        self.session_id = session_id
+        self.authentication_token = authentication_token
+
+        # Subscription management
+        self._subscription_callbacks: dict[int, Callable[[ua.PublishResult], Any]] = (
+            {}
+        )
+        self._subscription_dispatch_runtime: dict[int, _SubscriptionDispatchRuntime] = (
+            {}
+        )
+        self._last_publish_sequence_numbers: dict[int, int] = {}
+        self._subscription_watchdog_states: dict[int, _SubscriptionWatchdogState] = {}
+
+        # Configuration
+        self.dispatch_settings = _DispatchSettings()
+        self.sequence_recovery_settings = _SequenceRecoverySettings()
+        self.watchdog_settings = _WatchdogSettings()
+
+        # Lifecycle
+        self._publish_task: asyncio.Task[None] | None = None
+        self._closing = False
+        self._disconnect_event = asyncio.Event()
+
+    @property
+    def subscription_dispatch_queue_maxsize(self) -> int:
+        """Get max size for subscription dispatch queue."""
+        return self.dispatch_settings.queue_maxsize
+
+    @subscription_dispatch_queue_maxsize.setter
+    def subscription_dispatch_queue_maxsize(self, value: int) -> None:
+        """Set max size for subscription dispatch queue."""
+        self.dispatch_settings.queue_maxsize = int(value)
+
+    @property
+    def subscription_dispatch_overflow_policy(
+        self,
+    ) -> SubscriptionDispatchOverflowPolicy | str:
+        """Get policy for dispatch queue overflow handling."""
+        return self.dispatch_settings.overflow_policy
+
+    @subscription_dispatch_overflow_policy.setter
+    def subscription_dispatch_overflow_policy(
+        self, value: SubscriptionDispatchOverflowPolicy | str
+    ) -> None:
+        """Set policy for dispatch queue overflow handling."""
+        self.dispatch_settings.overflow_policy = value
+
+    @property
+    def subscription_stale_detection_enabled(self) -> bool:
+        """Get whether stale subscription detection is enabled."""
+        return self.watchdog_settings.stale_detection_enabled
+
+    @subscription_stale_detection_enabled.setter
+    def subscription_stale_detection_enabled(self, value: bool) -> None:
+        """Set whether stale subscription detection is enabled."""
+        self.watchdog_settings.stale_detection_enabled = bool(value)
+
+    @property
+    def subscription_stale_detection_margin(self) -> float:
+        """Get margin for stale subscription detection."""
+        return self.watchdog_settings.stale_detection_margin
+
+    @subscription_stale_detection_margin.setter
+    def subscription_stale_detection_margin(self, value: float) -> None:
+        """Set margin for stale subscription detection."""
+        self.watchdog_settings.stale_detection_margin = float(value)
+
+    @property
+    def auto_republish_on_sequence_gap(self) -> bool:
+        """Get whether to auto-republish on sequence gaps."""
+        return self.sequence_recovery_settings.auto_republish_on_gap
+
+    @auto_republish_on_sequence_gap.setter
+    def auto_republish_on_sequence_gap(self, value: bool) -> None:
+        """Set whether to auto-republish on sequence gaps."""
+        self.sequence_recovery_settings.auto_republish_on_gap = bool(value)
+
+    @property
+    def max_republish_messages_per_gap(self) -> int:
+        """Get max messages to republish per gap."""
+        return self.sequence_recovery_settings.max_republish_messages_per_gap
+
+    @max_republish_messages_per_gap.setter
+    def max_republish_messages_per_gap(self, value: int) -> None:
+        """Set max messages to republish per gap."""
+        self.sequence_recovery_settings.max_republish_messages_per_gap = int(value)
+
+    # Session Service Set methods (from AbstractSession)
+
+    async def browse(self, parameters: ua.BrowseParameters) -> list[ua.BrowseResult]:
+        """Browse node references."""
+        self.logger.debug("browse")
+        request = ua.BrowseRequest()
+        request.Parameters = parameters
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.BrowseResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def browse_next(
+        self, parameters: ua.BrowseNextParameters
+    ) -> list[ua.BrowseResult]:
+        """Browse next set of results."""
+        self.logger.debug("browse_next")
+        request = ua.BrowseNextRequest()
+        request.Parameters = parameters
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.BrowseNextResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def read(self, parameters: ua.ReadParameters) -> list[ua.DataValue]:
+        """Read node attributes."""
+        self.logger.debug("read")
+        request = ua.ReadRequest()
+        request.Parameters = parameters
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.ReadResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def write(self, parameters: ua.WriteParameters) -> list[ua.StatusCode]:
+        """Write node attributes."""
+        self.logger.debug("write")
+        request = ua.WriteRequest()
+        request.Parameters = parameters
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.WriteResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def history_read(
+        self, params: ua.HistoryReadParameters
+    ) -> list[ua.HistoryReadResult]:
+        """Read node history."""
+        self.logger.debug("history_read")
+        request = ua.HistoryReadRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.HistoryReadResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def add_nodes(self, params: ua.AddNodesParameters) -> list[ua.AddNodesResult]:
+        """Add nodes to address space."""
+        self.logger.debug("add_nodes")
+        request = ua.AddNodesRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.AddNodesResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def add_references(
+        self, refs: list[ua.AddReferencesItem]
+    ) -> list[ua.StatusCode]:
+        """Add references to address space."""
+        self.logger.debug("add_references")
+        request = ua.AddReferencesRequest()
+        request.Parameters.ReferencesToAdd = refs
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.AddReferencesResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def delete_nodes(
+        self, params: ua.DeleteNodesParameters
+    ) -> list[ua.StatusCode]:
+        """Delete nodes from address space."""
+        self.logger.debug("delete_nodes")
+        request = ua.DeleteNodesRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.DeleteNodesResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def delete_references(
+        self, refs: list[ua.DeleteReferencesItem]
+    ) -> list[ua.StatusCode]:
+        """Delete references from address space."""
+        self.logger.debug("delete_references")
+        request = ua.DeleteReferencesRequest()
+        request.Parameters.ReferencesToDelete = refs
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.DeleteReferencesResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def call(
+        self, methodstocall: list[ua.CallMethodRequest]
+    ) -> list[ua.CallMethodResult]:
+        """Call methods."""
+        self.logger.debug("call")
+        request = ua.CallRequest()
+        request.Parameters.MethodsToCall = methodstocall
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.CallResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def translate_browsepaths_to_nodeids(
+        self, browse_paths: list[ua.BrowsePath]
+    ) -> list[ua.BrowsePathResult]:
+        """Translate browse paths to node IDs."""
+        self.logger.debug("translate_browsepath_to_nodeid")
+        request = ua.TranslateBrowsePathsToNodeIdsRequest()
+        request.Parameters.BrowsePaths = browse_paths
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.TranslateBrowsePathsToNodeIdsResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def register_nodes(self, nodes: list[ua.NodeId]) -> list[ua.NodeId]:
+        """Register nodes for optimized access."""
+        self.logger.debug("register_nodes")
+        request = ua.RegisterNodesRequest()
+        request.Parameters.NodesToRegister = nodes
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.RegisterNodesResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Parameters.RegisteredNodeIds
+
+    async def unregister_nodes(self, nodes: list[ua.NodeId]) -> list[ua.NodeId]:
+        """Unregister nodes."""
+        self.logger.debug("unregister_nodes")
+        request = ua.UnregisterNodesRequest()
+        request.Parameters.NodesToUnregister = nodes
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.UnregisterNodesResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Parameters.UnregisteredNodeIds
+
+    # Subscription Service Set methods
+
+    async def create_subscription(
+        self, params: ua.CreateSubscriptionParameters, callback: Callable
+    ) -> ua.CreateSubscriptionResult:
+        """Create a subscription."""
+        self.logger.debug("create_subscription")
+        request = ua.CreateSubscriptionRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.CreateSubscriptionResponse, data)
+        response.ResponseHeader.ServiceResult.check()
+        subscription_id = response.Parameters.SubscriptionId
+        self._subscription_callbacks[subscription_id] = callback
+        
+        publishing_interval_ms = float(
+            getattr(
+                response.Parameters,
+                "RevisedPublishingInterval",
+                params.RequestedPublishingInterval or 0.0,
+            )
+            or 0.0
+        )
+        keepalive_count = int(
+            getattr(
+                response.Parameters,
+                "RevisedMaxKeepAliveCount",
+                params.RequestedMaxKeepAliveCount or 1,
+            )
+            or 1
+        )
+        self._register_subscription_watchdog(
+            subscription_id, publishing_interval_ms, keepalive_count
+        )
+        self.logger.info("Subscription created: %s", subscription_id)
+        self._ensure_subscription_dispatch_worker(subscription_id)
+        
+        if self._publish_task is None or self._publish_task.done():
+            self._publish_task = asyncio.create_task(self._publish_loop())
+        
+        return response.Parameters
+
+    async def modify_subscription(
+        self, params: ua.ModifySubscriptionParameters
+    ) -> ua.ModifySubscriptionResult:
+        """Modify a subscription."""
+        self.logger.debug("modify_subscription")
+        request = ua.ModifySubscriptionRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.ModifySubscriptionResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Parameters
+
+    async def delete_subscriptions(
+        self, params: ua.DeleteSubscriptionsParameters
+    ) -> list[ua.StatusCode]:
+        """Delete subscriptions."""
+        self.logger.debug("delete_subscriptions")
+        request = ua.DeleteSubscriptionsRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.DeleteSubscriptionsResponse, data)
+        response.ResponseHeader.ServiceResult.check()
+        for subscription_id in params.SubscriptionIds:
+            self._stop_subscription_dispatch_worker(subscription_id)
+            self._subscription_callbacks.pop(subscription_id, None)
+            self._last_publish_sequence_numbers.pop(subscription_id, None)
+            self._subscription_watchdog_states.pop(subscription_id, None)
+        return response.Results
+
+    async def create_monitored_items(
+        self, params: ua.CreateMonitoredItemsParameters
+    ) -> list[ua.MonitoredItemCreateResult]:
+        """Create monitored items."""
+        self.logger.debug("create_monitored_items")
+        request = ua.CreateMonitoredItemsRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.CreateMonitoredItemsResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def modify_monitored_items(
+        self, params: ua.ModifyMonitoredItemsParameters
+    ) -> list[ua.MonitoredItemModifyResult]:
+        """Modify monitored items."""
+        self.logger.debug("modify_monitored_items")
+        request = ua.ModifyMonitoredItemsRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.ModifyMonitoredItemsResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def delete_monitored_items(
+        self, params: ua.DeleteMonitoredItemsParameters
+    ) -> list[ua.StatusCode]:
+        """Delete monitored items."""
+        self.logger.debug("delete_monitored_items")
+        request = ua.DeleteMonitoredItemsRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.DeleteMonitoredItemsResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Results
+
+    async def transfer_subscriptions(
+        self, params: ua.TransferSubscriptionsParameters
+    ) -> list[ua.TransferResult]:
+        """Transfer subscriptions to another session."""
+        self.logger.debug("transfer_subscriptions")
+        request = ua.TransferSubscriptionsRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.TransferSubscriptionsResponse, data)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Parameters.Results
+
+    async def set_monitoring_mode(
+        self, params: ua.SetMonitoringModeParameters
+    ) -> list[ua.StatusCode]:
+        """Set monitoring mode for monitored items."""
+        self.logger.debug("set_monitoring_mode")
+        request = ua.SetMonitoringModeRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.SetMonitoringModeResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Parameters.Results
+
+    async def set_publishing_mode(
+        self, params: ua.SetPublishingModeParameters
+    ) -> list[ua.StatusCode]:
+        """Set publishing mode for subscriptions."""
+        self.logger.debug("set_publishing_mode")
+        request = ua.SetPublishingModeRequest()
+        request.Parameters = params
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.SetPublishingModeResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Parameters.Results
+
+    # Subscription dispatch and monitoring infrastructure
+
+    def _ensure_subscription_dispatch_worker(self, subscription_id: int) -> None:
+        """Ensure dispatch worker task is running for subscription."""
+        if subscription_id not in self._subscription_dispatch_runtime:
+            queue: asyncio.Queue[ua.PublishResult | None] = asyncio.Queue(
+                maxsize=self.dispatch_settings.queue_maxsize
+            )
+            task = asyncio.create_task(self._subscription_dispatch_worker(subscription_id))
+            self._subscription_dispatch_runtime[subscription_id] = _SubscriptionDispatchRuntime(
+                queue=queue, task=task
+            )
+
+    def _stop_subscription_dispatch_worker(self, subscription_id: int) -> None:
+        """Stop dispatch worker task for subscription."""
+        runtime = self._subscription_dispatch_runtime.pop(subscription_id, None)
+        if runtime is not None and runtime.task is not None:
+            runtime.task.cancel()
+
+    def _get_dispatch_queue(
+        self, subscription_id: int
+    ) -> asyncio.Queue[ua.PublishResult | None] | None:
+        """Get dispatch queue for subscription."""
+        runtime = self._subscription_dispatch_runtime.get(subscription_id)
+        if runtime is None:
+            return None
+        return runtime.queue
+
+    def _register_subscription_watchdog(
+        self, subscription_id: int, publishing_interval_ms: float, keepalive_count: int
+    ) -> None:
+        """Register watchdog for subscription."""
+        if publishing_interval_ms <= 0:
+            self._subscription_watchdog_states.pop(subscription_id, None)
+            return
+        self._subscription_watchdog_states[subscription_id] = _SubscriptionWatchdogState(
+            publishing_interval_ms=publishing_interval_ms,
+            keepalive_count=max(int(keepalive_count), 1),
+            last_seen_at=time.monotonic(),
+        )
+
+    def _mark_subscription_watchdog_activity(self, subscription_id: int) -> None:
+        """Mark activity for subscription watchdog."""
+        state = self._subscription_watchdog_states.get(subscription_id)
+        if state is None:
+            return
+        state.last_seen_at = time.monotonic()
+        state.stale_reported = False
+
+    def _get_stale_subscription_ids(self, now: float) -> list[int]:
+        """Get list of stale subscription IDs."""
+        if not self.watchdog_settings.stale_detection_enabled:
+            return []
+        stale_subscription_ids: list[int] = []
+        margin = max(self.watchdog_settings.stale_detection_margin, 1.0)
+        stale_state_ids_to_prune: list[int] = []
+        for subscription_id, state in self._subscription_watchdog_states.items():
+            if subscription_id not in self._subscription_callbacks:
+                stale_state_ids_to_prune.append(subscription_id)
+                continue
+            timeout = (
+                (state.publishing_interval_ms / 1000.0) * state.keepalive_count * margin
+            )
+            if timeout <= 0:
+                continue
+            if (now - state.last_seen_at) <= timeout:
+                continue
+            if state.stale_reported:
+                continue
+            state.stale_reported = True
+            stale_subscription_ids.append(subscription_id)
+        for stale_state_id in stale_state_ids_to_prune:
+            self._subscription_watchdog_states.pop(stale_state_id, None)
+        return stale_subscription_ids
+
+    def get_next_sequence_number(self, subscription_id: int) -> int:
+        """Get next expected sequence number for subscription."""
+        last_sequence = self._last_publish_sequence_numbers.get(subscription_id, 0)
+        return last_sequence + 1
+
+    def _record_notification_sequence_number(
+        self,
+        subscription_id: int,
+        notification_message: ua.NotificationMessage,
+        source: str = "publish",
+    ) -> None:
+        """Record notification sequence number for gap detection."""
+        self._last_publish_sequence_numbers[subscription_id] = (
+            notification_message.SequenceNumber
+        )
+
+    async def dispatch_notification_message(
+        self, subscription_id: int, notification_message: ua.NotificationMessage
+    ) -> None:
+        """Dispatch notification to registered callback (placeholder)."""
+        pass
+
+    def get_subscription_ids(self) -> list[int]:
+        """Get list of active subscription IDs."""
+        return list(self._subscription_callbacks.keys())
+
+    def _enqueue_with_drop_oldest(
+        self,
+        queue: asyncio.Queue[ua.PublishResult | None],
+        subscription_id: int,
+        publish_result: ua.PublishResult,
+    ) -> bool:
+        """Drop oldest item in queue to make room for new one."""
+        dropped = False
+        try:
+            oldest = queue.get_nowait()
+            queue.task_done()
+            dropped = True
+            if oldest is None:
+                queue.put_nowait(None)
+        except asyncio.QueueEmpty:
+            pass
+        try:
+            queue.put_nowait(publish_result)
+        except asyncio.QueueFull:
+            self.logger.warning(
+                "Subscription %s dispatch queue full after drop; dropping newest",
+                subscription_id,
+            )
+            return False
+        if dropped:
+            self.logger.warning(
+                "Subscription %s dispatch queue overflow; dropped oldest",
+                subscription_id,
+            )
+        return True
+
+    def _enqueue_with_disconnect_policy(
+        self,
+        queue: asyncio.Queue[ua.PublishResult | None],
+        subscription_id: int,
+    ) -> bool:
+        """Treat overflow as fatal, signal disconnect."""
+        overflow_error = SubscriptionDispatchOverflowError(
+            subscription_id, queue.qsize()
+        )
+        self.logger.error("%s", overflow_error)
+        self._fail_all_dispatch_workers(overflow_error)
+        self._closing = True
+        return False
+
+    def _enqueue_with_warn_policy(self, subscription_id: int) -> bool:
+        """Log warning and drop newest item."""
+        self.logger.warning(
+            "Subscription %s dispatch queue overflow; dropping newest",
+            subscription_id,
+        )
+        return False
+
+    def _resolve_overflow_policy(self) -> SubscriptionDispatchOverflowPolicy:
+        """Normalize and validate overflow policy setting."""
+        policy = self.subscription_dispatch_overflow_policy
+        if isinstance(policy, SubscriptionDispatchOverflowPolicy):
+            return policy
+        if isinstance(policy, str):
+            normalized = policy.strip().lower()
+            for candidate in SubscriptionDispatchOverflowPolicy:
+                if candidate.value == normalized:
+                    self.subscription_dispatch_overflow_policy = candidate
+                    return candidate
+            self.logger.warning(
+                "Unknown overflow policy '%s'; fallback to WARN",
+                policy,
+            )
+            self.subscription_dispatch_overflow_policy = (
+                SubscriptionDispatchOverflowPolicy.WARN
+            )
+            return SubscriptionDispatchOverflowPolicy.WARN
+        self.logger.warning(
+            "Unsupported overflow policy type '%s'; fallback to WARN",
+            type(policy).__name__,
+        )
+        self.subscription_dispatch_overflow_policy = (
+            SubscriptionDispatchOverflowPolicy.WARN
+        )
+        return SubscriptionDispatchOverflowPolicy.WARN
+
+    def _enqueue_when_full(
+        self,
+        queue: asyncio.Queue[ua.PublishResult | None],
+        subscription_id: int,
+        publish_result: ua.PublishResult,
+    ) -> bool:
+        """Enqueue with overflow handling based on configured policy."""
+        policy = self._resolve_overflow_policy()
+        if policy == SubscriptionDispatchOverflowPolicy.DROP_OLDEST:
+            return self._enqueue_with_drop_oldest(queue, subscription_id, publish_result)
+        if policy == SubscriptionDispatchOverflowPolicy.DISCONNECT:
+            return self._enqueue_with_disconnect_policy(queue, subscription_id)
+        if policy == SubscriptionDispatchOverflowPolicy.WARN:
+            return self._enqueue_with_warn_policy(subscription_id)
+        return self._enqueue_with_warn_policy(subscription_id)
+
+    def _enqueue_publish_result(
+        self, subscription_id: int, publish_result: ua.PublishResult
+    ) -> bool:
+        """Enqueue publish result for subscription, handling overflow."""
+        callback = self._subscription_callbacks.get(subscription_id)
+        if callback is None:
+            self.logger.warning(
+                "Publish result for unknown subscription %s",
+                subscription_id,
+            )
+            return False
+        queue = self._get_dispatch_queue(subscription_id)
+        if queue is None:
+            return False
+        if not queue.full():
+            queue.put_nowait(publish_result)
+            return True
+        return self._enqueue_when_full(queue, subscription_id, publish_result)
+
+    def _fail_all_dispatch_workers(self, exc: Exception) -> None:
+        """Signal all dispatch workers to stop with error."""
+        for runtime in self._subscription_dispatch_runtime.values():
+            task = runtime.task
+            if task is not None and not task.done():
+                task.cancel()
+        self._subscription_dispatch_runtime.clear()
+
+    async def _subscription_dispatch_worker(
+        self, subscription_id: int
+    ) -> None:
+        """Process queued notifications for subscription."""
+        runtime = self._subscription_dispatch_runtime.get(subscription_id)
+        if runtime is None:
+            return
+        queue = runtime.queue
+        while True:
+            publish_result = await queue.get()
+            try:
+                if publish_result is None:
+                    return
+                callback = self._subscription_callbacks.get(subscription_id)
+                if callback is None:
+                    self.logger.warning(
+                        "Queued result for unknown subscription %s",
+                        subscription_id,
+                    )
+                    continue
+                await _invoke_subscription_callback(callback, publish_result)
+            except Exception:
+                self.logger.exception(
+                    "Exception in subscription callback"
+                )
+            finally:
+                queue.task_done()
+
+    async def flush_subscription_dispatch(
+        self,
+        subscription_ids: list[int] | None = None,
+        timeout: float | None = None,
+    ) -> None:
+        """Wait for all queued notifications to be processed."""
+        if subscription_ids is None:
+            queues = [
+                runtime.queue
+                for runtime in self._subscription_dispatch_runtime.values()
+            ]
+        else:
+            queues = [
+                self._subscription_dispatch_runtime[subscription_id].queue
+                for subscription_id in subscription_ids
+                if subscription_id in self._subscription_dispatch_runtime
+            ]
+        if not queues:
+            return
+        awaitable = asyncio.gather(*(queue.join() for queue in queues))
+        if timeout is None:
+            await awaitable
+        else:
+            await asyncio.wait_for(awaitable, timeout)
+
+    async def _recover_sequence_gap(
+        self,
+        subscription_id: int,
+        expected_sequence: int,
+        received_sequence: int,
+    ) -> None:
+        """Republish missing notifications from sequence gap."""
+        window = _compute_republish_window(
+            expected_sequence,
+            received_sequence,
+            self.sequence_recovery_settings.max_republish_messages_per_gap,
+        )
+        if window is None:
+            return
+        start_sequence, end_sequence = window
+        for sequence_number in range(start_sequence, end_sequence):
+            try:
+                notif_msg = await self.republish(subscription_id, sequence_number)
+                await self.dispatch_notification_message(subscription_id, notif_msg)
+            except Exception:
+                self.logger.exception(
+                    "Gap recovery failed for subscription %s sequence %s",
+                    subscription_id,
+                    sequence_number,
+                )
+                break
+
+    async def republish(
+        self, subscription_id: int, retransmit_sequence_number: int
+    ) -> ua.NotificationMessage:
+        """Request republish of specific notification."""
+        self.logger.debug("republish")
+        request = ua.RepublishRequest()
+        request.Parameters.SubscriptionId = subscription_id
+        request.Parameters.RetransmitSequenceNumber = retransmit_sequence_number
+        data = await self.client._send_request(request)
+        response = struct_from_binary(ua.RepublishResponse, data)
+        self.logger.debug(response)
+        response.ResponseHeader.ServiceResult.check()
+        return response.Parameters.NotificationMessage
+
+    async def publish(
+        self, acks: list[ua.SubscriptionAcknowledgement]
+    ) -> ua.PublishResponse:
+        """Send PublishRequest to server."""
+        self.logger.debug("publish %r", acks)
+        request = ua.PublishRequest()
+        request.Parameters.SubscriptionAcknowledgements = acks if acks else []
+        data = await self.client._send_request(request, timeout=0)
+        protocol = self.client.protocol
+        if protocol is None:
+            raise ConnectionError("Connection is closed")
+        protocol.check_answer(data, "in publish response")
+        try:
+            response = struct_from_binary(ua.PublishResponse, data)
+        except Exception as ex:
+            self.logger.exception("Error parsing notification")
+            from asyncua.ua.uaerrors import UaStructParsingError
+            raise UaStructParsingError from ex
+        return response
+
+    async def _read_publish_response(
+        self,
+        ack: SubscriptionAcknowledgement | None,
+    ) -> ua.PublishResponse | None:
+        """Read publish response, handling timeouts and errors."""
+        from asyncua.ua.uaerrors import BadTimeout, BadNoSubscription
+        try:
+            return await self.publish([ack] if ack else [])
+        except BadTimeout:
+            return None
+        except BadNoSubscription:
+            self.logger.info("BadNoSubscription in publish loop")
+            raise
+        except Exception:
+            return None
+
+    async def _maybe_recover_gap(
+        self,
+        subscription_id: int,
+        notification_message: ua.NotificationMessage,
+    ) -> None:
+        """Check for sequence gaps and recover if enabled."""
+        if (
+            not self.sequence_recovery_settings.auto_republish_on_gap
+            or not notification_message.NotificationData
+            or subscription_id not in self._last_publish_sequence_numbers
+        ):
+            return
+        expected_sequence = self.get_next_sequence_number(subscription_id)
+        received_sequence = int(notification_message.SequenceNumber)
+        if received_sequence > expected_sequence:
+            await self._recover_sequence_gap(
+                subscription_id, expected_sequence, received_sequence
+            )
+
+    async def _handle_publish_response(
+        self, response: ua.PublishResponse
+    ) -> SubscriptionAcknowledgement | None:
+        """Process publish response and dispatch notifications."""
+        from asyncua.ua.uaerrors import BadNoSubscription
+        subscription_id = response.Parameters.SubscriptionId
+        if not subscription_id:
+            raise BadNoSubscription()
+
+        self._mark_subscription_watchdog_activity(subscription_id)
+        stale_ids = self._get_stale_subscription_ids(time.monotonic())
+        if stale_ids:
+            raise SubscriptionStaleError(stale_ids)
+
+        notification_message = response.Parameters.NotificationMessage
+        await self._maybe_recover_gap(subscription_id, notification_message)
+        self._enqueue_publish_result(subscription_id, response.Parameters)
+        self._record_notification_sequence_number(
+            subscription_id,
+            notification_message,
+            source="publish",
+        )
+        return _build_publish_ack(subscription_id, notification_message)
+
+    async def _publish_loop(self) -> None:
+        """Main publish loop for subscriptions."""
+        from asyncua.ua.uaerrors import BadNoSubscription
+        ack: SubscriptionAcknowledgement | None = None
+        while not self._closing:
+            try:
+                response = await self._read_publish_response(ack)
+                if response is None:
+                    ack = None
+                    continue
+                ack = await self._handle_publish_response(response)
+                await asyncio.sleep(0)
+            except BadNoSubscription:
+                return
+            except SubscriptionStaleError:
+                raise
+            except Exception:
+                ack = None
+                self.logger.exception("Unexpected error in publish loop")
+
+    async def dispatch_notification_message(
+        self, subscription_id: int, notification_message: ua.NotificationMessage
+    ) -> None:
+        """Dispatch notification to registered handler."""
+        callback = self._subscription_callbacks.get(subscription_id)
+        if callback is None:
+            return
+        publish_result = ua.PublishResult()
+        publish_result.SubscriptionId = subscription_id
+        publish_result.NotificationMessage = notification_message
+        await _invoke_subscription_callback(callback, publish_result)
+
+    async def ensure_publish_loop_running(self) -> None:
+        """Start publish loop if not already running."""
+        if self._publish_task is None or self._publish_task.done():
+            self._publish_task = asyncio.create_task(self._publish_loop())
+
+    async def restart_publish_loop(self) -> None:
+        """Restart publish loop after subscription changes."""
+        if self._publish_task is not None and not self._publish_task.done():
+            self._publish_task.cancel()
+            try:
+                await self._publish_task
+            except asyncio.CancelledError:
+                pass
+        self._publish_task = None
+        await self.ensure_publish_loop_running()
+
+    async def close_session(self, delete_subscriptions: bool) -> None:
+        """Close session and cleanup resources."""
+        self._closing = True
+        self._disconnect_event.set()
+        if self._publish_task is not None and not self._publish_task.done():
+            self._publish_task.cancel()
+        # Cleanup would be implemented here
+        pass
+
+    async def inform_subscriptions(self, status: ua.StatusCode) -> None:
+        """Inform all subscriptions of status change."""
+        status_message = ua.StatusChangeNotification(Status=status)
+        notification_message = ua.NotificationMessage(
+            NotificationData=[status_message]
+        )
+        for subid, callback in self._subscription_callbacks.items():
+            try:
+                parameters = ua.PublishResult(
+                    subid, NotificationMessage=notification_message
+                )
+                await _invoke_subscription_callback(callback, parameters)
+            except Exception:
+                self.logger.exception("Exception calling user callback")
+
+    @property
+    def ready_event(self) -> asyncio.Event:
+        """Event signaled when session is ready."""
+        return self._disconnect_event
+
+    async def __aenter__(self) -> UaSession:
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Async context manager exit - cleanup."""
+        await self.close_session(delete_subscriptions=True)

--- a/asyncua/common/session_interface.py
+++ b/asyncua/common/session_interface.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from collections.abc import Callable
+from typing import Any
 
 from asyncua import ua
 
@@ -152,7 +154,11 @@ class AbstractSession(ABC):
     # Subscription Service Set: https://reference.opcfoundation.org/Core/Part4/v104/5.13.1/
 
     @abstractmethod
-    async def create_subscription(self, params: ua.CreateSubscriptionParameters) -> ua.CreateSubscriptionResult:
+    async def create_subscription(
+        self,
+        params: ua.CreateSubscriptionParameters,
+        callback: Callable[[ua.PublishResult], Any] | None = None,
+    ) -> ua.CreateSubscriptionResult:
         """
         https://reference.opcfoundation.org/Core/Part4/v104/5.13.2/
 

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -115,6 +115,12 @@ SubscriptionHandler = (
 
 
 def _make_monitored_item_request_from_data(data: SubscriptionItemData) -> ua.MonitoredItemCreateRequest:
+    if data.node is None:
+        raise ua.UaError("Monitored item data is missing node")
+    if data.attribute is None:
+        raise ua.UaError("Monitored item data is missing attribute")
+    if data.client_handle is None:
+        raise ua.UaError("Monitored item data is missing client handle")
     rv = ua.ReadValueId()
     rv.NodeId = data.node.nodeid
     rv.AttributeId = data.attribute
@@ -284,6 +290,11 @@ def _build_event_from_notification(
         return None
 
     data = monitored_items[event_notification.ClientHandle]
+    if data.mfilter is None or not hasattr(data.mfilter, "SelectClauses"):
+        logger.warning(
+            "Received event notification but monitored item has no event filter: %s", event_notification.ClientHandle
+        )
+        return None
     result = Event.from_event_fields(data.mfilter.SelectClauses, event_notification.EventFields)
     result.server_handle = data.server_handle
     return result
@@ -417,7 +428,10 @@ class Subscription:
         if monitored_items_snapshot:
             requests = [
                 _make_monitored_item_request_from_data(data)
-                for data in sorted(monitored_items_snapshot, key=lambda item: item.client_handle)
+                for data in sorted(
+                    monitored_items_snapshot,
+                    key=lambda item: item.client_handle if item.client_handle is not None else -1,
+                )
             ]
             self._monitored_items.clear()
             await self.create_monitored_items(requests)

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -8,8 +8,9 @@ import asyncio
 import collections.abc
 import inspect
 import logging
-from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, Protocol, overload
+import math
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING, Any, Protocol, cast, overload
 
 from asyncua import ua
 from asyncua.client.ua_client import UaClient
@@ -27,12 +28,16 @@ class SubscriptionItemData:
     To store useful data from a monitored item.
     """
 
-    def __init__(self) -> None:
-        self.node: Node | None = None
-        self.client_handle: int | None = None
-        self.server_handle: int | None = None
-        self.attribute: ua.AttributeIds | None = None
-        self.mfilter: ua.MonitoringFilter | ua.EventFilter | None = None
+    def __init__(self):
+        self.node = None
+        self.client_handle = None
+        self.server_handle = None
+        self.attribute = None
+        self.mfilter = None
+        self.monitoring_mode = ua.MonitoringMode.Reporting
+        self.sampling_interval = 0.0
+        self.queue_size = 0
+        self.discard_oldest = True
 
 
 class DataChangeNotif:
@@ -40,11 +45,11 @@ class DataChangeNotif:
     To be send to clients for every datachange notification from server.
     """
 
-    def __init__(self, subscription_data: SubscriptionItemData, monitored_item: ua.MonitoredItemNotification) -> None:
+    def __init__(self, subscription_data: SubscriptionItemData, monitored_item: ua.MonitoredItemNotification):
         self.monitored_item = monitored_item
         self.subscription_data = subscription_data
 
-    def __str__(self) -> str:
+    def __str__(self):
         return f"DataChangeNotification({self.subscription_data}, {self.monitored_item})"
 
     __repr__ = __str__
@@ -98,6 +103,7 @@ class StatusChangeNotificationHandlerAsync(Protocol):
         ...
 
 
+# Protocol type alias for subscription handlers receiving server notifications.
 SubscriptionHandler = (
     DataChangeNotificationHandler
     | EventNotificationHandler
@@ -107,9 +113,180 @@ SubscriptionHandler = (
     | StatusChangeNotificationHandlerAsync
 )
 
-"""
-Protocol class representing subscription handlers to receive events from server.
-"""
+
+def _make_monitored_item_request_from_data(data: SubscriptionItemData) -> ua.MonitoredItemCreateRequest:
+    rv = ua.ReadValueId()
+    rv.NodeId = data.node.nodeid
+    rv.AttributeId = data.attribute
+    mparams = ua.MonitoringParameters()
+    mparams.ClientHandle = data.client_handle
+    mparams.SamplingInterval = data.sampling_interval
+    mparams.QueueSize = data.queue_size
+    mparams.DiscardOldest = data.discard_oldest
+    if data.mfilter:
+        mparams.Filter = data.mfilter
+    mir = ua.MonitoredItemCreateRequest()
+    mir.ItemToMonitor = rv
+    mir.MonitoringMode = data.monitoring_mode
+    mir.RequestedParameters = mparams
+    return mir
+
+
+def _make_monitoring_parameters_request(
+    new_queuesize: int,
+    new_samp_time: ua.Duration,
+    mod_filter: ua.MonitoringFilter | None,
+    client_handle: ua.IntegerId,
+) -> ua.MonitoringParameters:
+    req_params = ua.MonitoringParameters()
+    req_params.ClientHandle = client_handle
+    req_params.QueueSize = new_queuesize
+    req_params.Filter = mod_filter
+    req_params.SamplingInterval = new_samp_time
+    return req_params
+
+
+def _normalize_nodes(nodes: Node | Iterable[Node]) -> tuple[list[Node], bool]:
+    if isinstance(nodes, collections.abc.Iterable):
+        return list(nodes), True
+    return [nodes], False
+
+
+async def _create_event_filter(
+    server: InternalSession | UaClient,
+    evtypes: Node | ua.NodeId | str | int | Iterable[Node | ua.NodeId | str | int],
+    where_clause_generation: bool = True,
+) -> ua.EventFilter:
+    if isinstance(evtypes, int | str | ua.NodeId | Node):
+        evtypes = [evtypes]
+    event_types = [Node(server, evtype) for evtype in evtypes]  # type: ignore[union-attr]
+    return await get_filter_from_event_type(event_types, where_clause_generation)
+
+
+def _is_base_event_type(
+    server: InternalSession | UaClient, evtypes: Node | ua.NodeId | str | int | Iterable[Node | ua.NodeId | str | int]
+) -> bool:
+    if not isinstance(evtypes, int | str | ua.NodeId | Node):
+        return False
+    return Node(server, evtypes).nodeid == ua.NodeId(ua.ObjectIds.BaseEventType)
+
+
+def _create_deadband_filter(deadband_val: ua.Double, deadbandtype: ua.UInt32 = 1) -> ua.DataChangeFilter:
+    deadband_filter = ua.DataChangeFilter()
+    # Send notification when status or value changes.
+    deadband_filter.Trigger = ua.DataChangeTrigger(1)
+    deadband_filter.DeadbandType = deadbandtype
+    # absolute float value or from 0 to 100 for percentage deadband
+    deadband_filter.DeadbandValue = deadband_val
+    return deadband_filter
+
+
+def _create_subscription_item_data(
+    server: InternalSession | UaClient, mi: ua.MonitoredItemCreateRequest
+) -> SubscriptionItemData:
+    data = SubscriptionItemData()
+    data.client_handle = mi.RequestedParameters.ClientHandle
+    data.node = Node(server, mi.ItemToMonitor.NodeId)
+    data.attribute = mi.ItemToMonitor.AttributeId
+    data.monitoring_mode = mi.MonitoringMode
+    data.sampling_interval = mi.RequestedParameters.SamplingInterval
+    data.queue_size = mi.RequestedParameters.QueueSize
+    data.discard_oldest = mi.RequestedParameters.DiscardOldest
+    # TODO: Either use the filter from request or from response.
+    #  Here it uses from request, in modify it uses from response
+    data.mfilter = mi.RequestedParameters.Filter
+    return data
+
+
+def _build_server_to_client_handle_map(monitored_items: dict[int, SubscriptionItemData]) -> dict[int, int]:
+    return {value.server_handle: key for key, value in monitored_items.items()}
+
+
+def _get_expected_samples_per_publish(
+    publishing_interval: float, sampling_interval: ua.Duration, monitoring: ua.MonitoringMode
+) -> int | None:
+    if monitoring != ua.MonitoringMode.Reporting:
+        return None
+    if sampling_interval <= 0:
+        return None
+    if publishing_interval <= 0:
+        return None
+
+    expected_samples_per_publish = math.ceil(publishing_interval / sampling_interval)
+    if expected_samples_per_publish <= 1:
+        return None
+    return expected_samples_per_publish
+
+
+def _is_queue_size_potentially_too_small(queuesize: int, expected_samples_per_publish: int) -> bool:
+    effective_queue_size = 1 if queuesize in (0, 1) else queuesize
+    return effective_queue_size < expected_samples_per_publish
+
+
+def _make_queue_warning_key(
+    publishing_interval: float, sampling_interval: ua.Duration, queuesize: int
+) -> tuple[float, float, int]:
+    return (publishing_interval, float(sampling_interval), queuesize)
+
+
+def _collect_datachange_handler_args(
+    datachange: ua.DataChangeNotification,
+    monitored_items: dict[int, SubscriptionItemData],
+    logger: logging.Logger,
+) -> list[tuple[Node, Any, DataChangeNotif]]:
+    known_handles_args: list[tuple[Node, Any, DataChangeNotif]] = []
+    for item in datachange.MonitoredItems:
+        if item.ClientHandle not in monitored_items:
+            logger.warning("Received a notification for unknown handle: %s", item.ClientHandle)
+            continue
+        data = monitored_items[item.ClientHandle]
+        event_data = DataChangeNotif(data, item)
+        # FIXME: Value can be None
+        known_handles_args.append((data.node, item.Value.Value.Value, event_data))  # type: ignore[union-attr]
+    return known_handles_args
+
+
+async def _dispatch_datachange_notifications(
+    callback: Callable[[Node, Any, DataChangeNotif], Any],
+    known_handles_args: list[tuple[Node, Any, DataChangeNotif]],
+) -> None:
+    tasks = []
+    for args in known_handles_args:
+        result = callback(*args)
+        if inspect.isawaitable(result):
+            tasks.append(result)
+    if tasks:
+        await asyncio.gather(*tasks)
+
+
+async def _dispatch_event_notification(callback: Callable[[Event], Any], event: Event) -> None:
+    result = callback(event)
+    if inspect.isawaitable(result):
+        await result
+
+
+async def _dispatch_status_change_notification(
+    callback: Callable[[ua.StatusChangeNotification], Any],
+    status: ua.StatusChangeNotification,
+) -> None:
+    result = callback(status)
+    if inspect.isawaitable(result):
+        await result
+
+
+def _build_event_from_notification(
+    monitored_items: dict[int, SubscriptionItemData],
+    event_notification: ua.EventFieldList,
+    logger: logging.Logger,
+) -> Event | None:
+    if event_notification.ClientHandle not in monitored_items:
+        logger.warning("Received a notification for unknown handle: %s", event_notification.ClientHandle)
+        return None
+
+    data = monitored_items[event_notification.ClientHandle]
+    result = Event.from_event_fields(data.mfilter.SelectClauses, event_notification.EventFields)
+    result.server_handle = data.server_handle
+    return result
 
 
 class Subscription:
@@ -126,14 +303,58 @@ class Subscription:
         server: InternalSession | UaClient,
         params: ua.CreateSubscriptionParameters,
         handler: SubscriptionHandler,
-    ) -> None:
+    ):
         self.logger = logging.getLogger(__name__)
         self.server: InternalSession | UaClient = server
         self._client_handle = 200
         self._handler: SubscriptionHandler = handler
         self.parameters: ua.CreateSubscriptionParameters = params  # move to data class
         self._monitored_items: dict[int, SubscriptionItemData] = {}
+        self._queue_sizing_warnings_emitted: set[tuple[float, float, int]] = set()
         self.subscription_id: int | None = None
+
+    def _warn_if_potential_queue_overflow(
+        self, queuesize: int, monitoring: ua.MonitoringMode, sampling_interval: ua.Duration
+    ) -> None:
+        """
+        Emit a best-effort warning when queue settings are likely too small.
+
+        This helper compares requested `sampling_interval` against the subscription
+        `RequestedPublishingInterval` and estimates how many samples can arrive
+        within one publish cycle: ``ceil(publishing_interval / sampling_interval)``.
+        If the effective queue size (where OPC UA ``queueSize`` values 0 and 1 are
+        treated as a single-slot queue) is smaller than that estimate, this method
+        logs a warning about potential overflow and possible data loss.
+
+        Notes:
+        - This is a heuristic, not a protocol guarantee. Real overflow behavior
+          depends on source change rate, deadband/filtering, server internals, and
+          network latency.
+        - Warnings are de-duplicated per setting tuple to avoid log spam.
+        - Only applies to monitored items in ``Reporting`` mode.
+        """
+        publishing_interval = float(self.parameters.RequestedPublishingInterval or 0.0)
+        expected_samples_per_publish = _get_expected_samples_per_publish(
+            publishing_interval, sampling_interval, monitoring
+        )
+        if expected_samples_per_publish is None:
+            return
+
+        if not _is_queue_size_potentially_too_small(queuesize, expected_samples_per_publish):
+            return
+
+        warning_key = _make_queue_warning_key(publishing_interval, sampling_interval, queuesize)
+        if warning_key in self._queue_sizing_warnings_emitted:
+            return
+        self._queue_sizing_warnings_emitted.add(warning_key)
+
+        self.logger.warning(
+            "Potential monitored item queue overflow: publishing interval %.1f ms and sampling interval %.1f ms can produce up to %s samples per publish cycle, but queue_size=%s. Consider increasing queue_size or adjusting sampling/publishing intervals.",
+            publishing_interval,
+            sampling_interval,
+            expected_samples_per_publish,
+            queuesize,
+        )
 
     async def init(self) -> ua.CreateSubscriptionResult:
         response = await self.server.create_subscription(self.parameters, callback=self.publish_callback)
@@ -170,52 +391,59 @@ class Subscription:
         """
         Delete subscription on server. This is automatically done by Client and Server classes on exit.
         """
-        if self.subscription_id is None:
-            return
         results = await self.server.delete_subscriptions([self.subscription_id])
         results[0].check()
+        self.subscription_id = None
+        self._monitored_items.clear()
+
+    async def recreate(self) -> tuple[int, int]:
+        if not isinstance(self.server, UaClient):
+            raise ua.uaerrors.UaError(f"recreate() is not supported in {self.server}.")
+        if self.subscription_id is None:
+            raise ua.uaerrors.UaError("Cannot recreate subscription without a valid subscription id")
+
+        old_subscription_id = self.subscription_id
+        monitored_items_snapshot = list(self._monitored_items.values())
+        self.server._subscription_callbacks.pop(old_subscription_id, None)
+        self.server._last_publish_sequence_numbers.pop(old_subscription_id, None)
+        self.server._subscription_watchdog_states.pop(old_subscription_id, None)
+
+        response = await self.server.create_subscription(self.parameters, callback=self.publish_callback)
+        self.subscription_id = response.SubscriptionId
+
+        if monitored_items_snapshot:
+            requests = [
+                _make_monitored_item_request_from_data(data)
+                for data in sorted(monitored_items_snapshot, key=lambda item: item.client_handle)
+            ]
+            self._monitored_items.clear()
+            await self.create_monitored_items(requests)
+
+        self.logger.warning("Subscription recreated from %s to %s", old_subscription_id, self.subscription_id)
+        return old_subscription_id, self.subscription_id
 
     async def _call_datachange(self, datachange: ua.DataChangeNotification) -> None:
         if not hasattr(self._handler, "datachange_notification"):
             self.logger.error("DataChange subscription created but handler has no datachange_notification method")
             return
 
-        known_handles_args: list[tuple] = []
-        for item in datachange.MonitoredItems:
-            if item.ClientHandle not in self._monitored_items:
-                self.logger.warning("Received a notification for unknown handle: %s", item.ClientHandle)
-                continue
-            data = self._monitored_items[item.ClientHandle]
-            event_data = DataChangeNotif(data, item)
-            # FIXME: Value can be None
-            known_handles_args.append((data.node, item.Value.Value.Value, event_data))  # type: ignore[union-attr]
+        known_handles_args = _collect_datachange_handler_args(datachange, self._monitored_items, self.logger)
+        callback = cast(Callable[[Node, Any, DataChangeNotif], Any], self._handler.datachange_notification)
 
         try:
-            tasks = [self._handler.datachange_notification(*args) for args in known_handles_args]
-            if inspect.iscoroutinefunction(self._handler.datachange_notification):
-                await asyncio.gather(*tasks)
+            await _dispatch_datachange_notifications(callback, known_handles_args)
         except Exception as ex:
             self.logger.exception("Exception calling data change handler. Error: %s", ex)
 
     async def _call_event(self, eventlist: ua.EventNotificationList) -> None:
-        for event in eventlist.Events:
-            if event.ClientHandle not in self._monitored_items:
-                self.logger.warning("Received a notification for unknown handle: %s", event.ClientHandle)
+        for event_notification in eventlist.Events:
+            result = _build_event_from_notification(self._monitored_items, event_notification, self.logger)
+            if result is None:
                 continue
-            data = self._monitored_items[event.ClientHandle]
-            if data.mfilter is None or not hasattr(data.mfilter, "SelectClauses"):
-                self.logger.warning(
-                    "Received event notification but monitored item has no event filter: %s", event.ClientHandle
-                )
-                continue
-            result = Event.from_event_fields(data.mfilter.SelectClauses, event.EventFields)  # type: ignore[union-attr]
-            result.server_handle = data.server_handle
             if hasattr(self._handler, "event_notification"):
+                callback = cast(Callable[[Event], Any], self._handler.event_notification)
                 try:
-                    if inspect.iscoroutinefunction(self._handler.event_notification):
-                        await self._handler.event_notification(result)
-                    else:
-                        self._handler.event_notification(result)
+                    await _dispatch_event_notification(callback, result)
                 except Exception:
                     self.logger.exception("Exception calling event handler")
             else:
@@ -225,11 +453,9 @@ class Subscription:
         if not hasattr(self._handler, "status_change_notification"):
             self.logger.error("DataChange subscription has no status_change_notification method")
             return
+        callback = cast(Callable[[ua.StatusChangeNotification], Any], self._handler.status_change_notification)
         try:
-            if inspect.iscoroutinefunction(self._handler.status_change_notification):
-                await self._handler.status_change_notification(status)
-            else:
-                self._handler.status_change_notification(status)
+            await _dispatch_status_change_notification(callback, status)
         except Exception:
             self.logger.exception("Exception calling status change handler")
 
@@ -239,7 +465,7 @@ class Subscription:
         nodes: Node,
         attr: ua.AttributeIds = ua.AttributeIds.Value,
         queuesize: int = 0,
-        monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
+        monitoring=ua.MonitoringMode.Reporting,
         sampling_interval: ua.Duration = 0.0,
     ) -> int: ...
 
@@ -249,7 +475,7 @@ class Subscription:
         nodes: Node | Iterable[Node],
         attr: ua.AttributeIds = ua.AttributeIds.Value,
         queuesize: int = 0,
-        monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
+        monitoring=ua.MonitoringMode.Reporting,
         sampling_interval: ua.Duration = 0.0,
     ) -> list[int | ua.StatusCode]: ...
 
@@ -258,7 +484,7 @@ class Subscription:
         nodes: Node | Iterable[Node],
         attr: ua.AttributeIds = ua.AttributeIds.Value,
         queuesize: int = 0,
-        monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
+        monitoring=ua.MonitoringMode.Reporting,
         sampling_interval: ua.Duration = 50.0,
     ) -> int | list[int | ua.StatusCode]:
         """
@@ -281,17 +507,6 @@ class Subscription:
         return await self._subscribe(
             nodes, attr, queuesize=queuesize, monitoring=monitoring, sampling_interval=sampling_interval
         )
-
-    async def _create_eventfilter(
-        self,
-        evtypes: Node | ua.NodeId | str | int | Iterable[Node | ua.NodeId | str | int],
-        where_clause_generation: bool = True,
-    ) -> ua.EventFilter:
-        if isinstance(evtypes, int | str | ua.NodeId | Node):
-            evtypes = [evtypes]
-        evtypes = [Node(self.server, evtype) for evtype in evtypes]  # type: ignore[union-attr]
-        evfilter = await get_filter_from_event_type(evtypes, where_clause_generation)  # type: ignore[union-attr]
-        return evfilter
 
     async def subscribe_events(
         self,
@@ -318,13 +533,11 @@ class Subscription:
         """
         sourcenode = Node(self.server, sourcenode)
         if evfilter is None:
-            if isinstance(evtypes, int | str | ua.NodeId | Node) and Node(self.server, evtypes).nodeid == ua.NodeId(
-                ua.ObjectIds.BaseEventType
-            ):
+            if _is_base_event_type(self.server, evtypes):
                 # Remove where clause for base event type, for servers that have problems with long WhereClauses.
                 # Also because BaseEventType wants every event we can ommit it. Issue: #1205
                 where_clause_generation = False
-            evfilter = await self._create_eventfilter(evtypes, where_clause_generation)
+            evfilter = await _create_event_filter(self.server, evtypes, where_clause_generation)
         return await self._subscribe(sourcenode, ua.AttributeIds.EventNotifier, evfilter, queuesize=queuesize)  # type: ignore
 
     async def subscribe_alarms_and_conditions(
@@ -354,7 +567,7 @@ class Subscription:
     async def _subscribe(
         self,
         nodes: Node,
-        attr: ua.AttributeIds = ua.AttributeIds.Value,
+        attr=ua.AttributeIds.Value,
         mfilter: ua.MonitoringFilter | None = None,
         queuesize: int = 0,
         monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
@@ -365,7 +578,7 @@ class Subscription:
     async def _subscribe(
         self,
         nodes: Iterable[Node],
-        attr: ua.AttributeIds = ua.AttributeIds.Value,
+        attr=ua.AttributeIds.Value,
         mfilter: ua.MonitoringFilter | None = None,
         queuesize: int = 0,
         monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
@@ -375,7 +588,7 @@ class Subscription:
     async def _subscribe(
         self,
         nodes: Node | Iterable[Node],
-        attr: ua.AttributeIds = ua.AttributeIds.Value,
+        attr=ua.AttributeIds.Value,
         mfilter: ua.MonitoringFilter | None = None,
         queuesize: int = 0,
         monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
@@ -391,12 +604,7 @@ class Subscription:
         :param sampling_interval: ua.Duration
         :return: Integer handle or if multiple Nodes were given a List of Integer handles/ua.StatusCode
         """
-        is_list = True
-        if isinstance(nodes, collections.abc.Iterable):
-            nodes = list(nodes)
-        else:
-            nodes = [nodes]
-            is_list = False
+        nodes, is_list = _normalize_nodes(nodes)
         # Create List of MonitoredItemCreateRequest
         mirs = []
         for node in nodes:
@@ -413,14 +621,9 @@ class Subscription:
         return mids[0]  # type: ignore
 
     def _make_monitored_item_request(
-        self,
-        node: Node,
-        attr: ua.AttributeIds,
-        mfilter: ua.MonitoringFilter | None,
-        queuesize: int,
-        monitoring: ua.MonitoringMode,
-        sampling_interval: ua.Duration,
+        self, node: Node, attr, mfilter, queuesize, monitoring, sampling_interval
     ) -> ua.MonitoredItemCreateRequest:
+        self._warn_if_potential_queue_overflow(queuesize, monitoring, sampling_interval)
         rv = ua.ReadValueId()
         rv.NodeId = node.nodeid
         rv.AttributeId = attr
@@ -453,14 +656,7 @@ class Subscription:
         # insert monitored item into map to avoid notification arrive before result return
         # server_handle is left as None in purpose as we don't get it yet.
         for mi in monitored_items:
-            data = SubscriptionItemData()
-            data.client_handle = mi.RequestedParameters.ClientHandle
-            data.node = Node(self.server, mi.ItemToMonitor.NodeId)
-            data.attribute = mi.ItemToMonitor.AttributeId
-            # TODO: Either use the filter from request or from response.
-            #  Here it uses from request, in modify it uses from response
-            data.mfilter = mi.RequestedParameters.Filter
-            self._monitored_items[mi.RequestedParameters.ClientHandle] = data
+            self._monitored_items[mi.RequestedParameters.ClientHandle] = _create_subscription_item_data(self.server, mi)
         results = await self.server.create_monitored_items(params)
         mids = []
         # process result, add server_handle, or remove it if failed
@@ -484,12 +680,14 @@ class Subscription:
         handles: Iterable[int] = [handle] if isinstance(handle, int) else handle
         if not handles:
             return
+        if self.subscription_id is None:
+            raise ua.UaStatusCodeError(ua.StatusCodes.BadSubscriptionIdInvalid)
         params = ua.DeleteMonitoredItemsParameters()
         params.SubscriptionId = self.subscription_id
         params.MonitoredItemIds = list(handles)
         results = await self.server.delete_monitored_items(params)
         results[0].check()
-        handle_map = {v.server_handle: k for k, v in self._monitored_items.items()}
+        handle_map = _build_server_to_client_handle_map(self._monitored_items)
         for handle in handles:
             if handle in handle_map:
                 del self._monitored_items[handle_map[handle]]
@@ -514,15 +712,13 @@ class Subscription:
         elif mod_filter_val < 0:
             mod_filter = item_to_change.mfilter
         else:
-            mod_filter = ua.DataChangeFilter()
-            # send notification when status or value change
-            mod_filter.Trigger = ua.DataChangeTrigger(1)
-            mod_filter.DeadbandType = 1
-            # absolute float value or from 0 to 100 for percentage deadband
-            mod_filter.DeadbandValue = mod_filter_val
+            mod_filter = _create_deadband_filter(mod_filter_val, 1)
+
+        self._warn_if_potential_queue_overflow(new_queuesize, item_to_change.monitoring_mode, new_samp_time)
+
         modif_item = ua.MonitoredItemModifyRequest()
         modif_item.MonitoredItemId = handle
-        modif_item.RequestedParameters = self._modify_monitored_item_request(
+        modif_item.RequestedParameters = _make_monitoring_parameters_request(
             new_queuesize, new_samp_time, mod_filter, item_to_change.client_handle
         )
         params = ua.ModifyMonitoredItemsParameters()
@@ -531,20 +727,6 @@ class Subscription:
         results = await self.server.modify_monitored_items(params)
         item_to_change.mfilter = results[0].FilterResult
         return results
-
-    def _modify_monitored_item_request(
-        self,
-        new_queuesize: int,
-        new_samp_time: ua.Duration,
-        mod_filter: ua.DataChangeFilter | None,
-        client_handle: ua.IntegerId,
-    ) -> ua.MonitoringParameters:
-        req_params = ua.MonitoringParameters()
-        req_params.ClientHandle = client_handle
-        req_params.QueueSize = new_queuesize
-        req_params.Filter = mod_filter
-        req_params.SamplingInterval = new_samp_time
-        return req_params
 
     @overload
     async def deadband_monitor(
@@ -584,12 +766,7 @@ class Subscription:
         :param queuesize: Wanted queue size, default is 1
         :param attr: Attribute ID
         """
-        deadband_filter = ua.DataChangeFilter()
-        # send notification when status or value change
-        deadband_filter.Trigger = ua.DataChangeTrigger(1)
-        deadband_filter.DeadbandType = deadbandtype
-        # absolute float value or from 0 to 100 for percentage deadband
-        deadband_filter.DeadbandValue = deadband_val
+        deadband_filter = _create_deadband_filter(deadband_val, deadbandtype)
         return await self._subscribe(var, attr, deadband_filter, queuesize)
 
     async def set_monitoring_mode(self, monitoring: ua.MonitoringMode) -> list[ua.uatypes.StatusCode]:

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -391,6 +391,8 @@ class Subscription:
         """
         Delete subscription on server. This is automatically done by Client and Server classes on exit.
         """
+        if self.subscription_id is None:
+            raise ua.uaerrors.UaError("Cannot delete subscription without a valid subscription id")
         results = await self.server.delete_subscriptions([self.subscription_id])
         results[0].check()
         self.subscription_id = None
@@ -404,9 +406,10 @@ class Subscription:
 
         old_subscription_id = self.subscription_id
         monitored_items_snapshot = list(self._monitored_items.values())
-        self.server._subscription_callbacks.pop(old_subscription_id, None)
-        self.server._last_publish_sequence_numbers.pop(old_subscription_id, None)
-        self.server._subscription_watchdog_states.pop(old_subscription_id, None)
+        session = self.server._require_default_session()
+        session._subscription_callbacks.pop(old_subscription_id, None)
+        session._last_publish_sequence_numbers.pop(old_subscription_id, None)
+        session._subscription_watchdog_states.pop(old_subscription_id, None)
 
         response = await self.server.create_subscription(self.parameters, callback=self.publish_callback)
         self.subscription_id = response.SubscriptionId

--- a/asyncua/common/subscription.py
+++ b/asyncua/common/subscription.py
@@ -28,7 +28,7 @@ class SubscriptionItemData:
     To store useful data from a monitored item.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.node = None
         self.client_handle = None
         self.server_handle = None
@@ -45,11 +45,11 @@ class DataChangeNotif:
     To be send to clients for every datachange notification from server.
     """
 
-    def __init__(self, subscription_data: SubscriptionItemData, monitored_item: ua.MonitoredItemNotification):
+    def __init__(self, subscription_data: SubscriptionItemData, monitored_item: ua.MonitoredItemNotification) -> None:
         self.monitored_item = monitored_item
         self.subscription_data = subscription_data
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"DataChangeNotification({self.subscription_data}, {self.monitored_item})"
 
     __repr__ = __str__
@@ -303,7 +303,7 @@ class Subscription:
         server: InternalSession | UaClient,
         params: ua.CreateSubscriptionParameters,
         handler: SubscriptionHandler,
-    ):
+    ) -> None:
         self.logger = logging.getLogger(__name__)
         self.server: InternalSession | UaClient = server
         self._client_handle = 200
@@ -468,7 +468,7 @@ class Subscription:
         nodes: Node,
         attr: ua.AttributeIds = ua.AttributeIds.Value,
         queuesize: int = 0,
-        monitoring=ua.MonitoringMode.Reporting,
+        monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
         sampling_interval: ua.Duration = 0.0,
     ) -> int: ...
 
@@ -478,7 +478,7 @@ class Subscription:
         nodes: Node | Iterable[Node],
         attr: ua.AttributeIds = ua.AttributeIds.Value,
         queuesize: int = 0,
-        monitoring=ua.MonitoringMode.Reporting,
+        monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
         sampling_interval: ua.Duration = 0.0,
     ) -> list[int | ua.StatusCode]: ...
 
@@ -487,7 +487,7 @@ class Subscription:
         nodes: Node | Iterable[Node],
         attr: ua.AttributeIds = ua.AttributeIds.Value,
         queuesize: int = 0,
-        monitoring=ua.MonitoringMode.Reporting,
+        monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
         sampling_interval: ua.Duration = 50.0,
     ) -> int | list[int | ua.StatusCode]:
         """
@@ -570,7 +570,7 @@ class Subscription:
     async def _subscribe(
         self,
         nodes: Node,
-        attr=ua.AttributeIds.Value,
+        attr: ua.AttributeIds = ua.AttributeIds.Value,
         mfilter: ua.MonitoringFilter | None = None,
         queuesize: int = 0,
         monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
@@ -581,7 +581,7 @@ class Subscription:
     async def _subscribe(
         self,
         nodes: Iterable[Node],
-        attr=ua.AttributeIds.Value,
+        attr: ua.AttributeIds = ua.AttributeIds.Value,
         mfilter: ua.MonitoringFilter | None = None,
         queuesize: int = 0,
         monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
@@ -591,7 +591,7 @@ class Subscription:
     async def _subscribe(
         self,
         nodes: Node | Iterable[Node],
-        attr=ua.AttributeIds.Value,
+        attr: ua.AttributeIds = ua.AttributeIds.Value,
         mfilter: ua.MonitoringFilter | None = None,
         queuesize: int = 0,
         monitoring: ua.MonitoringMode = ua.MonitoringMode.Reporting,
@@ -624,7 +624,13 @@ class Subscription:
         return mids[0]  # type: ignore
 
     def _make_monitored_item_request(
-        self, node: Node, attr, mfilter, queuesize, monitoring, sampling_interval
+        self,
+        node: Node,
+        attr: ua.AttributeIds,
+        mfilter: ua.MonitoringFilter | None,
+        queuesize: int,
+        monitoring: ua.MonitoringMode,
+        sampling_interval: ua.Duration,
     ) -> ua.MonitoredItemCreateRequest:
         self._warn_if_potential_queue_overflow(queuesize, monitoring, sampling_interval)
         rv = ua.ReadValueId()

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -5,19 +5,32 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from asyncua import Client, Server, ua
-from asyncua.client.ua_client import (
+from asyncua.client.ua_client import UaClient
+from asyncua.client.ua_session import (
     SubscriptionDispatchOverflowPolicy,
     SubscriptionStaleError,
-    UaClient,
+    UaSession,
     _compute_republish_window,
 )
 from asyncua.common.connection import TransportLimits
 from asyncua.server.uaprocessor import UaProcessor
-from asyncua.ua.uaerrors import BadMaxConnectionsReached, BadSessionNotActivated
+from asyncua.ua.uaerrors import (
+    BadMaxConnectionsReached,
+    BadNoSubscription,
+    BadSessionNotActivated,
+)
 
 from .conftest import find_free_port, port_num
 
 pytestmark = pytest.mark.asyncio
+
+
+def _make_test_session() -> UaSession:
+    return UaSession(
+        client=UaClient(),
+        session_id=ua.NodeId(1, 0),
+        authentication_token=ua.NodeId(2, 0),
+    )
 
 
 async def test_max_connections_1(opc):
@@ -174,7 +187,7 @@ async def test_client_reconnect_after_server_restart():
         client.reconnect_enabled = True
         await client._schedule_reconnect(ConnectionError("forced reconnect after server restart"))
         await _wait_for_recovered_client(client)
-        assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.SESSION_READY
+        assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.CHANNEL_READY
     finally:
         client.reconnect_enabled = False
         await client.disconnect()
@@ -211,7 +224,7 @@ async def test_client_on_reconnected_called_once():
         await asyncio.wait_for(callback_event.wait(), timeout=10)
         await _wait_for_recovered_client(client)
         assert callback_count == 1
-        assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.SESSION_READY
+        assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.CHANNEL_READY
     finally:
         client.reconnect_enabled = False
         await client.disconnect()
@@ -279,7 +292,7 @@ async def test_reconnect_fallback_to_new_session_when_activate_fails(mocker):
 
     assert activate_calls == 2
     client.create_session.assert_awaited_once()
-    assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.SESSION_READY
+    assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.CHANNEL_READY
     assert client._reconnect_event.is_set()
 
 
@@ -391,79 +404,77 @@ async def test_reconnect_does_not_recreate_invalid_subscription_when_disabled(mo
     client._recreate_invalid_subscriptions.assert_not_awaited()
 
 
-async def test_keepalive_does_not_advance_last_notification_sequence_number():
-    uaclient = UaClient()
+async def test_keepalive_advances_last_notification_sequence_number():
+    session = _make_test_session()
     subscription_id = 42
-    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+    session._last_publish_sequence_numbers[subscription_id] = 4
 
     keepalive_message = ua.NotificationMessage()
     keepalive_message.SequenceNumber = 5
     keepalive_message.NotificationData = []
 
-    uaclient._record_notification_sequence_number(subscription_id, keepalive_message)
+    session._record_notification_sequence_number(subscription_id, keepalive_message)
 
-    assert uaclient._last_publish_sequence_numbers[subscription_id] == 4
-    assert uaclient.get_next_sequence_number(subscription_id) == 5
+    assert session._last_publish_sequence_numbers[subscription_id] == 5
+    assert session.get_next_sequence_number(subscription_id) == 6
 
 
 async def test_notification_advances_last_notification_sequence_number():
-    uaclient = UaClient()
+    session = _make_test_session()
     subscription_id = 42
-    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+    session._last_publish_sequence_numbers[subscription_id] = 4
 
     notification_message = ua.NotificationMessage()
     notification_message.SequenceNumber = 5
     notification_message.NotificationData = [ua.StatusChangeNotification()]
 
-    uaclient._record_notification_sequence_number(subscription_id, notification_message)
+    session._record_notification_sequence_number(subscription_id, notification_message)
 
-    assert uaclient._last_publish_sequence_numbers[subscription_id] == 5
-    assert uaclient.get_next_sequence_number(subscription_id) == 6
+    assert session._last_publish_sequence_numbers[subscription_id] == 5
+    assert session.get_next_sequence_number(subscription_id) == 6
 
 
-async def test_sequence_mismatch_logs_warning(caplog):
-    uaclient = UaClient()
+async def test_sequence_mismatch_does_not_log_warning(caplog):
+    session = _make_test_session()
     subscription_id = 42
-    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+    session._last_publish_sequence_numbers[subscription_id] = 4
 
     notification_message = ua.NotificationMessage()
     notification_message.SequenceNumber = 7
     notification_message.NotificationData = [ua.StatusChangeNotification()]
 
-    with caplog.at_level("WARNING", logger="asyncua.client.ua_client.UaClient"):
-        uaclient._record_notification_sequence_number(subscription_id, notification_message, source="publish")
+    with caplog.at_level("WARNING", logger="asyncua.client.ua_session.UaSession"):
+        session._record_notification_sequence_number(subscription_id, notification_message, source="publish")
 
-    assert "Detected notification sequence mismatch" in caplog.text
-    assert "expected 5 but received 7" in caplog.text
+    assert "Detected notification sequence mismatch" not in caplog.text
+    assert session._last_publish_sequence_numbers[subscription_id] == 7
 
 
 async def test_keepalive_sequence_mismatch_does_not_log_warning(caplog):
-    uaclient = UaClient()
+    session = _make_test_session()
     subscription_id = 42
-    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+    session._last_publish_sequence_numbers[subscription_id] = 4
 
     keepalive_message = ua.NotificationMessage()
     keepalive_message.SequenceNumber = 7
     keepalive_message.NotificationData = []
 
-    with caplog.at_level("WARNING", logger="asyncua.client.ua_client.UaClient"):
-        uaclient._record_notification_sequence_number(subscription_id, keepalive_message, source="publish")
+    with caplog.at_level("WARNING", logger="asyncua.client.ua_session.UaSession"):
+        session._record_notification_sequence_number(subscription_id, keepalive_message, source="publish")
 
     assert "Detected notification sequence mismatch" not in caplog.text
 
 
 async def test_publish_loop_recovers_sequence_gap_via_republish(mocker):
-    uaclient = UaClient()
+    session = _make_test_session()
     subscription_id = 42
     observed_sequences = []
 
     def _callback(result):
         observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
-        if int(result.NotificationMessage.SequenceNumber) == 7:
-            uaclient._closing = True
 
-    uaclient._subscription_callbacks[subscription_id] = _callback
-    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+    session._subscription_callbacks[subscription_id] = _callback
+    session._last_publish_sequence_numbers[subscription_id] = 4
 
     publish_message = ua.NotificationMessage()
     publish_message.SequenceNumber = 7
@@ -472,7 +483,6 @@ async def test_publish_loop_recovers_sequence_gap_via_republish(mocker):
     publish_result = ua.PublishResult(subscription_id, NotificationMessage=publish_message)
     publish_response = ua.PublishResponse()
     publish_response.Parameters = publish_result
-    uaclient.publish = AsyncMock(return_value=publish_response)  # type: ignore[method-assign]
 
     async def _republish(_subscription_id, sequence_number):
         msg = ua.NotificationMessage()
@@ -480,32 +490,31 @@ async def test_publish_loop_recovers_sequence_gap_via_republish(mocker):
         msg.NotificationData = [ua.StatusChangeNotification()]
         return msg
 
-    uaclient.republish = AsyncMock(side_effect=_republish)  # type: ignore[method-assign]
+    session.republish = AsyncMock(side_effect=_republish)  # type: ignore[method-assign]
 
-    await uaclient._publish_loop()
-    await uaclient.flush_subscription_dispatch()
+    # Test the gap recovery handler directly instead of full loop
+    await session._handle_publish_response(publish_response)
+    await session.flush_subscription_dispatch()
 
-    assert [args.args for args in uaclient.republish.await_args_list] == [
+    assert [args.args for args in session.republish.await_args_list] == [
         (subscription_id, 5),
         (subscription_id, 6),
     ]
     assert observed_sequences == [5, 6, 7]
-    assert uaclient._last_publish_sequence_numbers[subscription_id] == 7
+    assert session._last_publish_sequence_numbers[subscription_id] == 7
 
 
 async def test_publish_loop_sequence_gap_republish_cap(mocker):
-    uaclient = UaClient()
+    session = _make_test_session()
     subscription_id = 42
     observed_sequences = []
-    uaclient.max_republish_messages_per_gap = 1
+    session.sequence_recovery_settings.max_republish_messages_per_gap = 1
 
     def _callback(result):
         observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
-        if int(result.NotificationMessage.SequenceNumber) == 7:
-            uaclient._closing = True
 
-    uaclient._subscription_callbacks[subscription_id] = _callback
-    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+    session._subscription_callbacks[subscription_id] = _callback
+    session._last_publish_sequence_numbers[subscription_id] = 4
 
     publish_message = ua.NotificationMessage()
     publish_message.SequenceNumber = 7
@@ -514,7 +523,6 @@ async def test_publish_loop_sequence_gap_republish_cap(mocker):
     publish_result = ua.PublishResult(subscription_id, NotificationMessage=publish_message)
     publish_response = ua.PublishResponse()
     publish_response.Parameters = publish_result
-    uaclient.publish = AsyncMock(return_value=publish_response)  # type: ignore[method-assign]
 
     async def _republish(_subscription_id, sequence_number):
         msg = ua.NotificationMessage()
@@ -522,12 +530,13 @@ async def test_publish_loop_sequence_gap_republish_cap(mocker):
         msg.NotificationData = [ua.StatusChangeNotification()]
         return msg
 
-    uaclient.republish = AsyncMock(side_effect=_republish)  # type: ignore[method-assign]
+    session.republish = AsyncMock(side_effect=_republish)  # type: ignore[method-assign]
 
-    await uaclient._publish_loop()
-    await uaclient.flush_subscription_dispatch()
+    # Test the gap recovery handler directly instead of full loop
+    await session._handle_publish_response(publish_response)
+    await session.flush_subscription_dispatch()
 
-    assert [args.args for args in uaclient.republish.await_args_list] == [(subscription_id, 5)]
+    assert [args.args for args in session.republish.await_args_list] == [(subscription_id, 5)]
     assert observed_sequences == [5, 7]
 
 
@@ -539,9 +548,9 @@ async def test_compute_republish_window_caps_and_handles_empty():
 
 
 async def test_recover_sequence_gap_stops_on_unexpected_republish_sequence(mocker):
-    uaclient = UaClient()
+    session = _make_test_session()
     subscription_id = 42
-    uaclient.dispatch_notification_message = AsyncMock()  # type: ignore[method-assign]
+    session.dispatch_notification_message = AsyncMock()  # type: ignore[method-assign]
 
     async def _republish(_subscription_id, _sequence_number):
         msg = ua.NotificationMessage()
@@ -549,26 +558,26 @@ async def test_recover_sequence_gap_stops_on_unexpected_republish_sequence(mocke
         msg.NotificationData = [ua.StatusChangeNotification()]
         return msg
 
-    uaclient.republish = AsyncMock(side_effect=_republish)  # type: ignore[method-assign]
+    session.republish = AsyncMock(side_effect=_republish)  # type: ignore[method-assign]
 
-    await uaclient._recover_sequence_gap(subscription_id, expected_sequence=5, received_sequence=8)
+    await session._recover_sequence_gap(subscription_id, expected_sequence=5, received_sequence=8)
 
-    uaclient.dispatch_notification_message.assert_not_awaited()
-    assert [args.args for args in uaclient.republish.await_args_list] == [(subscription_id, 5)]
+    session.dispatch_notification_message.assert_not_awaited()
+    assert [args.args for args in session.republish.await_args_list] == [(subscription_id, 5)]
 
 
 async def test_dispatch_queue_overflow_drop_oldest_keeps_latest():
-    uaclient = UaClient()
+    session = _make_test_session()
     subscription_id = 42
     observed_sequences: list[int] = []
 
     def _callback(result):
         observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
 
-    uaclient.subscription_dispatch_queue_maxsize = 1
-    uaclient.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.DROP_OLDEST
-    uaclient._subscription_callbacks[subscription_id] = _callback
-    uaclient._ensure_subscription_dispatch_worker(subscription_id)
+    session.subscription_dispatch_queue_maxsize = 1
+    session.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.DROP_OLDEST
+    session._subscription_callbacks[subscription_id] = _callback
+    session._ensure_subscription_dispatch_worker(subscription_id)
 
     msg1 = ua.NotificationMessage()
     msg1.SequenceNumber = 1
@@ -578,26 +587,26 @@ async def test_dispatch_queue_overflow_drop_oldest_keeps_latest():
     msg2.SequenceNumber = 2
     msg2.NotificationData = [ua.StatusChangeNotification()]
 
-    assert uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg1))
-    assert uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg2))
+    assert session._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg1))
+    assert session._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg2))
 
-    await uaclient.flush_subscription_dispatch()
+    await session.flush_subscription_dispatch()
 
     assert observed_sequences == [2]
 
 
 async def test_dispatch_queue_overflow_warn_drops_newest(caplog):
-    uaclient = UaClient()
+    session = _make_test_session()
     subscription_id = 42
     observed_sequences: list[int] = []
 
     def _callback(result):
         observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
 
-    uaclient.subscription_dispatch_queue_maxsize = 1
-    uaclient.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.WARN
-    uaclient._subscription_callbacks[subscription_id] = _callback
-    uaclient._ensure_subscription_dispatch_worker(subscription_id)
+    session.subscription_dispatch_queue_maxsize = 1
+    session.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.WARN
+    session._subscription_callbacks[subscription_id] = _callback
+    session._ensure_subscription_dispatch_worker(subscription_id)
 
     msg1 = ua.NotificationMessage()
     msg1.SequenceNumber = 1
@@ -607,18 +616,18 @@ async def test_dispatch_queue_overflow_warn_drops_newest(caplog):
     msg2.SequenceNumber = 2
     msg2.NotificationData = [ua.StatusChangeNotification()]
 
-    with caplog.at_level("WARNING", logger="asyncua.client.ua_client.UaClient"):
-        assert uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg1))
-        assert not uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg2))
+    with caplog.at_level("WARNING", logger="asyncua.client.ua_session.UaSession"):
+        assert session._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg1))
+        assert not session._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg2))
 
-    await uaclient.flush_subscription_dispatch()
+    await session.flush_subscription_dispatch()
 
     assert observed_sequences == [1]
     assert "dispatch queue overflow" in caplog.text
 
 
 async def test_flush_subscription_dispatch_waits_for_callback_completion():
-    uaclient = UaClient()
+    session = _make_test_session()
     subscription_id = 42
     callback_started = asyncio.Event()
     callback_resume = asyncio.Event()
@@ -627,17 +636,17 @@ async def test_flush_subscription_dispatch_waits_for_callback_completion():
         callback_started.set()
         await callback_resume.wait()
 
-    uaclient._subscription_callbacks[subscription_id] = _callback
-    uaclient._ensure_subscription_dispatch_worker(subscription_id)
+    session._subscription_callbacks[subscription_id] = _callback
+    session._ensure_subscription_dispatch_worker(subscription_id)
 
     msg = ua.NotificationMessage()
     msg.SequenceNumber = 1
     msg.NotificationData = [ua.StatusChangeNotification()]
 
-    assert uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg))
+    assert session._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg))
     await callback_started.wait()
 
-    flush_task = asyncio.create_task(uaclient.flush_subscription_dispatch())
+    flush_task = asyncio.create_task(session.flush_subscription_dispatch())
     await asyncio.sleep(0)
     assert not flush_task.done()
 
@@ -679,57 +688,57 @@ async def test_uaprocessor_close_skips_self_watchdog_await():
 
 
 async def test_overflow_policy_string_is_normalized_to_enum():
-    uaclient = UaClient()
-    uaclient.subscription_dispatch_overflow_policy = "DROP_OLDEST"
+    session = _make_test_session()
+    session.subscription_dispatch_overflow_policy = "DROP_OLDEST"
 
-    policy = uaclient._resolve_overflow_policy()
+    policy = session._resolve_overflow_policy()
 
     assert policy == SubscriptionDispatchOverflowPolicy.DROP_OLDEST
-    assert uaclient.subscription_dispatch_overflow_policy == SubscriptionDispatchOverflowPolicy.DROP_OLDEST
+    assert session.subscription_dispatch_overflow_policy == SubscriptionDispatchOverflowPolicy.DROP_OLDEST
 
 
 async def test_subscription_watchdog_detects_stale_subscription():
-    uaclient = UaClient()
-    uaclient.subscription_stale_detection_enabled = True
-    uaclient.subscription_stale_detection_margin = 1.0
-    uaclient._subscription_callbacks[1] = lambda _result: None
+    session = _make_test_session()
+    session.subscription_stale_detection_enabled = True
+    session.subscription_stale_detection_margin = 1.0
+    session._subscription_callbacks[1] = lambda _result: None
 
-    uaclient._register_subscription_watchdog(subscription_id=1, publishing_interval_ms=1000.0, keepalive_count=2)
-    uaclient._subscription_watchdog_states[1].last_seen_at = 0.0
+    session._register_subscription_watchdog(subscription_id=1, publishing_interval_ms=1000.0, keepalive_count=2)
+    session._subscription_watchdog_states[1].last_seen_at = 0.0
 
-    stale_ids = uaclient._get_stale_subscription_ids(now=2.5)
+    stale_ids = session._get_stale_subscription_ids(now=2.5)
 
     assert stale_ids == [1]
 
 
 async def test_subscription_watchdog_activity_clears_stale_state():
-    uaclient = UaClient()
-    uaclient.subscription_stale_detection_enabled = True
-    uaclient.subscription_stale_detection_margin = 1.0
-    uaclient._subscription_callbacks[1] = lambda _result: None
+    session = _make_test_session()
+    session.subscription_stale_detection_enabled = True
+    session.subscription_stale_detection_margin = 1.0
+    session._subscription_callbacks[1] = lambda _result: None
 
-    uaclient._register_subscription_watchdog(subscription_id=1, publishing_interval_ms=1000.0, keepalive_count=2)
-    state = uaclient._subscription_watchdog_states[1]
+    session._register_subscription_watchdog(subscription_id=1, publishing_interval_ms=1000.0, keepalive_count=2)
+    state = session._subscription_watchdog_states[1]
     state.last_seen_at = 0.0
     state.stale_reported = True
 
-    uaclient._mark_subscription_watchdog_activity(1)
+    session._mark_subscription_watchdog_activity(1)
 
-    assert uaclient._subscription_watchdog_states[1].stale_reported is False
+    assert session._subscription_watchdog_states[1].stale_reported is False
 
 
 async def test_subscription_watchdog_ignores_orphaned_state():
-    uaclient = UaClient()
-    uaclient.subscription_stale_detection_enabled = True
-    uaclient.subscription_stale_detection_margin = 1.2
+    session = _make_test_session()
+    session.subscription_stale_detection_enabled = True
+    session.subscription_stale_detection_margin = 1.2
 
-    uaclient._register_subscription_watchdog(subscription_id=571478, publishing_interval_ms=100.0, keepalive_count=10)
-    uaclient._subscription_watchdog_states[571478].last_seen_at = 0.0
+    session._register_subscription_watchdog(subscription_id=571478, publishing_interval_ms=100.0, keepalive_count=10)
+    session._subscription_watchdog_states[571478].last_seen_at = 0.0
 
-    stale_ids = uaclient._get_stale_subscription_ids(now=10.0)
+    stale_ids = session._get_stale_subscription_ids(now=10.0)
 
     assert stale_ids == []
-    assert 571478 not in uaclient._subscription_watchdog_states
+    assert 571478 not in session._subscription_watchdog_states
 
 
 async def test_try_recover_stale_subscriptions_recovers_subset_once(mocker):
@@ -814,6 +823,6 @@ async def test_finalize_successful_reconnect_restarts_background_tasks_when_miss
 
     assert client._monitor_server_task is not None
     assert client._renew_channel_task is not None
-    assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.SESSION_READY
+    assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.CHANNEL_READY
 
 

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -1,9 +1,18 @@
 import asyncio
 import struct
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from asyncua import Client, Server, ua
+from asyncua.client.ua_client import (
+    SubscriptionDispatchOverflowPolicy,
+    SubscriptionStaleError,
+    UaClient,
+    _compute_republish_window,
+)
+from asyncua.common.connection import TransportLimits
+from asyncua.server.uaprocessor import UaProcessor
 from asyncua.ua.uaerrors import BadMaxConnectionsReached, BadSessionNotActivated
 
 from .conftest import find_free_port, port_num
@@ -116,9 +125,695 @@ async def test_session_watchdog():
     client = Client(f"opc.tcp://127.0.0.1:{port}", timeout=0.5, watchdog_intervall=1)
     client.session_timeout = 1000  # 1 second
     await client.connect()
-    client._closing = True  # Kill the keepalive tasks
-    await asyncio.sleep(3)  # Wait for the watchdog to terminate the session due to inactivity
+    await client._cancel_background_tasks(disable_pre_hook=False)  # Kill the keepalive tasks
+    await asyncio.sleep(2)  # Wait for the watchdog to terminate the session due to inactivity
     with pytest.raises(BadSessionNotActivated):
         server_time_node = client.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
         await server_time_node.read_value()
     await client.disconnect()
+
+
+async def _start_test_server(port: int) -> Server:
+    srv = Server()
+    await srv.init()
+    srv.set_endpoint(f"opc.tcp://127.0.0.1:{port}")
+    await srv.start()
+    return srv
+
+
+async def _stop_test_server(srv: Server, timeout: float = 10.0) -> None:
+    await asyncio.wait_for(srv.stop(), timeout=timeout)
+
+
+async def _wait_for_recovered_client(cl: Client, timeout: float = 10.0) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            await cl.get_namespace_array()
+            return
+        except Exception:
+            await asyncio.sleep(0.1)
+    raise TimeoutError("Client did not recover in time")
+
+
+async def test_client_reconnect_after_server_restart():
+    port = find_free_port()
+    srv = await _start_test_server(port)
+    client = Client(f"opc.tcp://127.0.0.1:{port}", timeout=0.5, watchdog_intervall=0.2)
+    client.reconnect_initial_delay = 0.1
+    client.reconnect_max_delay = 0.2
+    client.reconnect_request_timeout = 3.0
+
+    await client.connect()
+    client.reconnect_enabled = False
+    await _stop_test_server(srv)
+    await asyncio.sleep(0.5)
+
+    srv = await _start_test_server(port)
+    try:
+        client.reconnect_enabled = True
+        await client._schedule_reconnect(ConnectionError("forced reconnect after server restart"))
+        await _wait_for_recovered_client(client)
+        assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.SESSION_READY
+    finally:
+        client.reconnect_enabled = False
+        await client.disconnect()
+        await _stop_test_server(srv)
+
+
+async def test_client_on_reconnected_called_once():
+    port = find_free_port()
+    srv = await _start_test_server(port)
+    client = Client(f"opc.tcp://127.0.0.1:{port}", timeout=0.5, watchdog_intervall=0.2)
+    client.reconnect_initial_delay = 0.1
+    client.reconnect_max_delay = 0.2
+    client.reconnect_request_timeout = 3.0
+
+    callback_event = asyncio.Event()
+    callback_count = 0
+
+    async def on_reconnected():
+        nonlocal callback_count
+        callback_count += 1
+        callback_event.set()
+
+    client.on_reconnected = on_reconnected
+
+    await client.connect()
+    client.reconnect_enabled = False
+    await _stop_test_server(srv)
+    await asyncio.sleep(0.5)
+
+    srv = await _start_test_server(port)
+    try:
+        client.reconnect_enabled = True
+        await client._schedule_reconnect(ConnectionError("forced reconnect after server restart"))
+        await asyncio.wait_for(callback_event.wait(), timeout=10)
+        await _wait_for_recovered_client(client)
+        assert callback_count == 1
+        assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.SESSION_READY
+    finally:
+        client.reconnect_enabled = False
+        await client.disconnect()
+        await _stop_test_server(srv)
+
+
+async def test_request_waits_during_reconnect_and_recovers():
+    port = find_free_port()
+    srv = await _start_test_server(port)
+    client = Client(f"opc.tcp://127.0.0.1:{port}", timeout=0.5, watchdog_intervall=0.2)
+    client.reconnect_initial_delay = 0.1
+    client.reconnect_max_delay = 0.2
+    client.reconnect_request_timeout = 10.0
+
+    await client.connect()
+    client.reconnect_enabled = False
+    await _stop_test_server(srv)
+    client.reconnect_enabled = True
+    await client._schedule_reconnect(ConnectionError("forced test reconnect"))
+
+    wait_task = asyncio.create_task(client.check_connection())
+
+    srv = await _start_test_server(port)
+    try:
+        await asyncio.wait_for(wait_task, timeout=20)
+        namespace_array = await asyncio.wait_for(client.get_namespace_array(), timeout=10)
+        assert isinstance(namespace_array, list)
+        assert namespace_array
+    finally:
+        client.reconnect_enabled = False
+        await client.disconnect()
+        await _stop_test_server(srv)
+
+
+async def test_reconnect_fallback_to_new_session_when_activate_fails(mocker):
+    client = Client("opc.tcp://127.0.0.1:4840", timeout=0.5, watchdog_intervall=0.2)
+    client.reconnect_enabled = True
+    client._session_authentication_token = ua.NodeId(ua.ObjectIds.RootFolder)
+    client._session_counter = 10
+
+    client.uaclient.protocol = mocker.MagicMock()
+    client.uaclient.protocol.authentication_token = ua.NodeId()
+    client.uaclient.get_subscription_ids = mocker.MagicMock(return_value=[])
+    client.uaclient.ensure_publish_loop_running = mocker.MagicMock()
+
+    client._cancel_background_tasks = AsyncMock()  # type: ignore[method-assign]
+    client.disconnect_socket = mocker.MagicMock()
+    client.connect_socket = AsyncMock()  # type: ignore[method-assign]
+    client.send_hello = AsyncMock()  # type: ignore[method-assign]
+    client.open_secure_channel = AsyncMock()  # type: ignore[method-assign]
+    client.create_session = AsyncMock()  # type: ignore[method-assign]
+
+    activate_calls = 0
+
+    async def _activate_side_effect(*_args, **_kwargs):
+        nonlocal activate_calls
+        activate_calls += 1
+        if activate_calls == 1:
+            raise ua.UaError("activate failed on old session")
+        return mocker.MagicMock(ServerNonce=b"ok")
+
+    client.activate_session = AsyncMock(side_effect=_activate_side_effect)  # type: ignore[method-assign]
+
+    await client._reconnect_loop(ConnectionError("test reconnect"))
+
+    assert activate_calls == 2
+    client.create_session.assert_awaited_once()
+    assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.SESSION_READY
+    assert client._reconnect_event.is_set()
+
+
+async def test_reconnect_logs_transfer_subscriptions_failure(mocker):
+    client = Client("opc.tcp://127.0.0.1:4840", timeout=0.5, watchdog_intervall=0.2)
+    client.reconnect_enabled = True
+    client._session_authentication_token = ua.NodeId(ua.ObjectIds.RootFolder)
+
+    client.uaclient.protocol = mocker.MagicMock()
+    client.uaclient.protocol.authentication_token = ua.NodeId()
+    client.uaclient.get_subscription_ids = mocker.MagicMock(return_value=[1])
+    client.uaclient.get_next_sequence_number = mocker.MagicMock(return_value=1)
+    client.uaclient.ensure_publish_loop_running = mocker.MagicMock()
+
+    transfer_result = ua.TransferResult()
+    transfer_result.StatusCode = ua.StatusCode(ua.StatusCodes.BadSubscriptionIdInvalid)
+    client.uaclient.transfer_subscriptions = AsyncMock(return_value=[transfer_result])
+    client._republish_subscriptions = AsyncMock(return_value=set())  # type: ignore[method-assign]
+
+    client._cancel_background_tasks = AsyncMock()  # type: ignore[method-assign]
+    client.disconnect_socket = mocker.MagicMock()
+    client.connect_socket = AsyncMock()  # type: ignore[method-assign]
+    client.send_hello = AsyncMock()  # type: ignore[method-assign]
+    client.open_secure_channel = AsyncMock()  # type: ignore[method-assign]
+    client.create_session = AsyncMock()  # type: ignore[method-assign]
+
+    async def _activate_side_effect(*_args, **_kwargs):
+        if client._session_authentication_token is not None:
+            client._session_authentication_token = None
+            raise ua.UaError("force new session")
+        return mocker.MagicMock(ServerNonce=b"ok")
+
+    client.activate_session = AsyncMock(side_effect=_activate_side_effect)  # type: ignore[method-assign]
+    log_warning = mocker.patch("asyncua.client.client._logger.warning")
+
+    await client._reconnect_loop(ConnectionError("test reconnect"))
+
+    assert client.uaclient.transfer_subscriptions.await_count == 1
+    assert any("TransferSubscriptions failed" in str(call.args[0]) for call in log_warning.call_args_list)
+
+
+async def test_republish_handles_bad_subscription_id_invalid(mocker):
+    client = Client("opc.tcp://127.0.0.1:4840", timeout=0.5, watchdog_intervall=0.2)
+    dispatch = AsyncMock()
+    client.uaclient.dispatch_notification_message = dispatch
+
+    async def _republish(_subscription_id, _seq):
+        raise ua.UaStatusCodeError(ua.StatusCodes.BadSubscriptionIdInvalid)
+
+    client.uaclient.republish = AsyncMock(side_effect=_republish)
+    log_warning = mocker.patch("asyncua.client.client._logger.warning")
+
+    invalid_ids = await client._republish_subscriptions({42: 1})
+
+    assert dispatch.await_count == 0
+    assert invalid_ids == {42}
+    assert any("must be recreated" in str(call.args[0]) for call in log_warning.call_args_list)
+
+
+async def test_reconnect_recreates_invalid_managed_subscription(mocker):
+    client = Client("opc.tcp://127.0.0.1:4840", timeout=0.5, watchdog_intervall=0.2)
+    client.auto_recreate_invalid_subscriptions = True
+    subscription = mocker.MagicMock()
+    subscription.subscription_id = 42
+    subscription.recreate = AsyncMock(return_value=(42, 142))
+    client._managed_subscriptions.add(subscription)
+
+    log_warning = mocker.patch("asyncua.client.client._logger.warning")
+
+    await client._recreate_invalid_subscriptions({42})
+
+    subscription.recreate.assert_awaited_once()
+    assert any("Recreated invalid subscription" in str(call.args[0]) for call in log_warning.call_args_list)
+
+
+async def test_reconnect_does_not_recreate_invalid_subscription_when_disabled(mocker):
+    client = Client("opc.tcp://127.0.0.1:4840", timeout=0.5, watchdog_intervall=0.2)
+    client.reconnect_enabled = True
+    client.auto_recreate_invalid_subscriptions = False
+    client._session_authentication_token = ua.NodeId(ua.ObjectIds.RootFolder)
+
+    client.uaclient.protocol = mocker.MagicMock()
+    client.uaclient.protocol.authentication_token = ua.NodeId()
+    client.uaclient.get_subscription_ids = mocker.MagicMock(return_value=[42])
+    client.uaclient.get_next_sequence_number = mocker.MagicMock(return_value=1)
+    client.uaclient.ensure_publish_loop_running = mocker.MagicMock()
+    client.uaclient.transfer_subscriptions = AsyncMock(return_value=[])
+
+    client._cancel_background_tasks = AsyncMock()  # type: ignore[method-assign]
+    client.disconnect_socket = mocker.MagicMock()
+    client.connect_socket = AsyncMock()  # type: ignore[method-assign]
+    client.send_hello = AsyncMock()  # type: ignore[method-assign]
+    client.open_secure_channel = AsyncMock()  # type: ignore[method-assign]
+
+    async def _activate_side_effect(*_args, **_kwargs):
+        if client._session_authentication_token is not None:
+            client._session_authentication_token = None
+            raise ua.UaError("force new session")
+        return mocker.MagicMock(ServerNonce=b"ok")
+
+    client.activate_session = AsyncMock(side_effect=_activate_side_effect)  # type: ignore[method-assign]
+    client.create_session = AsyncMock()  # type: ignore[method-assign]
+    client._republish_subscriptions = AsyncMock(return_value={42})  # type: ignore[method-assign]
+    client._recreate_invalid_subscriptions = AsyncMock()  # type: ignore[method-assign]
+
+    await client._reconnect_loop(ConnectionError("test reconnect"))
+
+    client._republish_subscriptions.assert_awaited_once()
+    client._recreate_invalid_subscriptions.assert_not_awaited()
+
+
+async def test_keepalive_does_not_advance_last_notification_sequence_number():
+    uaclient = UaClient()
+    subscription_id = 42
+    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+
+    keepalive_message = ua.NotificationMessage()
+    keepalive_message.SequenceNumber = 5
+    keepalive_message.NotificationData = []
+
+    uaclient._record_notification_sequence_number(subscription_id, keepalive_message)
+
+    assert uaclient._last_publish_sequence_numbers[subscription_id] == 4
+    assert uaclient.get_next_sequence_number(subscription_id) == 5
+
+
+async def test_notification_advances_last_notification_sequence_number():
+    uaclient = UaClient()
+    subscription_id = 42
+    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+
+    notification_message = ua.NotificationMessage()
+    notification_message.SequenceNumber = 5
+    notification_message.NotificationData = [ua.StatusChangeNotification()]
+
+    uaclient._record_notification_sequence_number(subscription_id, notification_message)
+
+    assert uaclient._last_publish_sequence_numbers[subscription_id] == 5
+    assert uaclient.get_next_sequence_number(subscription_id) == 6
+
+
+async def test_sequence_mismatch_logs_warning(caplog):
+    uaclient = UaClient()
+    subscription_id = 42
+    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+
+    notification_message = ua.NotificationMessage()
+    notification_message.SequenceNumber = 7
+    notification_message.NotificationData = [ua.StatusChangeNotification()]
+
+    with caplog.at_level("WARNING", logger="asyncua.client.ua_client.UaClient"):
+        uaclient._record_notification_sequence_number(subscription_id, notification_message, source="publish")
+
+    assert "Detected notification sequence mismatch" in caplog.text
+    assert "expected 5 but received 7" in caplog.text
+
+
+async def test_keepalive_sequence_mismatch_does_not_log_warning(caplog):
+    uaclient = UaClient()
+    subscription_id = 42
+    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+
+    keepalive_message = ua.NotificationMessage()
+    keepalive_message.SequenceNumber = 7
+    keepalive_message.NotificationData = []
+
+    with caplog.at_level("WARNING", logger="asyncua.client.ua_client.UaClient"):
+        uaclient._record_notification_sequence_number(subscription_id, keepalive_message, source="publish")
+
+    assert "Detected notification sequence mismatch" not in caplog.text
+
+
+async def test_publish_loop_recovers_sequence_gap_via_republish(mocker):
+    uaclient = UaClient()
+    subscription_id = 42
+    observed_sequences = []
+
+    def _callback(result):
+        observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
+        if int(result.NotificationMessage.SequenceNumber) == 7:
+            uaclient._closing = True
+
+    uaclient._subscription_callbacks[subscription_id] = _callback
+    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+
+    publish_message = ua.NotificationMessage()
+    publish_message.SequenceNumber = 7
+    publish_message.NotificationData = [ua.StatusChangeNotification()]
+
+    publish_result = ua.PublishResult(subscription_id, NotificationMessage=publish_message)
+    publish_response = ua.PublishResponse()
+    publish_response.Parameters = publish_result
+    uaclient.publish = AsyncMock(return_value=publish_response)  # type: ignore[method-assign]
+
+    async def _republish(_subscription_id, sequence_number):
+        msg = ua.NotificationMessage()
+        msg.SequenceNumber = sequence_number
+        msg.NotificationData = [ua.StatusChangeNotification()]
+        return msg
+
+    uaclient.republish = AsyncMock(side_effect=_republish)  # type: ignore[method-assign]
+
+    await uaclient._publish_loop()
+    await uaclient.flush_subscription_dispatch()
+
+    assert [args.args for args in uaclient.republish.await_args_list] == [
+        (subscription_id, 5),
+        (subscription_id, 6),
+    ]
+    assert observed_sequences == [5, 6, 7]
+    assert uaclient._last_publish_sequence_numbers[subscription_id] == 7
+
+
+async def test_publish_loop_sequence_gap_republish_cap(mocker):
+    uaclient = UaClient()
+    subscription_id = 42
+    observed_sequences = []
+    uaclient.max_republish_messages_per_gap = 1
+
+    def _callback(result):
+        observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
+        if int(result.NotificationMessage.SequenceNumber) == 7:
+            uaclient._closing = True
+
+    uaclient._subscription_callbacks[subscription_id] = _callback
+    uaclient._last_publish_sequence_numbers[subscription_id] = 4
+
+    publish_message = ua.NotificationMessage()
+    publish_message.SequenceNumber = 7
+    publish_message.NotificationData = [ua.StatusChangeNotification()]
+
+    publish_result = ua.PublishResult(subscription_id, NotificationMessage=publish_message)
+    publish_response = ua.PublishResponse()
+    publish_response.Parameters = publish_result
+    uaclient.publish = AsyncMock(return_value=publish_response)  # type: ignore[method-assign]
+
+    async def _republish(_subscription_id, sequence_number):
+        msg = ua.NotificationMessage()
+        msg.SequenceNumber = sequence_number
+        msg.NotificationData = [ua.StatusChangeNotification()]
+        return msg
+
+    uaclient.republish = AsyncMock(side_effect=_republish)  # type: ignore[method-assign]
+
+    await uaclient._publish_loop()
+    await uaclient.flush_subscription_dispatch()
+
+    assert [args.args for args in uaclient.republish.await_args_list] == [(subscription_id, 5)]
+    assert observed_sequences == [5, 7]
+
+
+async def test_compute_republish_window_caps_and_handles_empty():
+    assert _compute_republish_window(5, 5, 10) is None
+    assert _compute_republish_window(5, 7, 0) is None
+    assert _compute_republish_window(5, 7, 10) == (5, 7)
+    assert _compute_republish_window(5, 20, 3) == (5, 8)
+
+
+async def test_recover_sequence_gap_stops_on_unexpected_republish_sequence(mocker):
+    uaclient = UaClient()
+    subscription_id = 42
+    uaclient.dispatch_notification_message = AsyncMock()  # type: ignore[method-assign]
+
+    async def _republish(_subscription_id, _sequence_number):
+        msg = ua.NotificationMessage()
+        msg.SequenceNumber = 999
+        msg.NotificationData = [ua.StatusChangeNotification()]
+        return msg
+
+    uaclient.republish = AsyncMock(side_effect=_republish)  # type: ignore[method-assign]
+
+    await uaclient._recover_sequence_gap(subscription_id, expected_sequence=5, received_sequence=8)
+
+    uaclient.dispatch_notification_message.assert_not_awaited()
+    assert [args.args for args in uaclient.republish.await_args_list] == [(subscription_id, 5)]
+
+
+async def test_dispatch_queue_overflow_drop_oldest_keeps_latest():
+    uaclient = UaClient()
+    subscription_id = 42
+    observed_sequences: list[int] = []
+
+    def _callback(result):
+        observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
+
+    uaclient.subscription_dispatch_queue_maxsize = 1
+    uaclient.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.DROP_OLDEST
+    uaclient._subscription_callbacks[subscription_id] = _callback
+    uaclient._ensure_subscription_dispatch_worker(subscription_id)
+
+    msg1 = ua.NotificationMessage()
+    msg1.SequenceNumber = 1
+    msg1.NotificationData = [ua.StatusChangeNotification()]
+
+    msg2 = ua.NotificationMessage()
+    msg2.SequenceNumber = 2
+    msg2.NotificationData = [ua.StatusChangeNotification()]
+
+    assert uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg1))
+    assert uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg2))
+
+    await uaclient.flush_subscription_dispatch()
+
+    assert observed_sequences == [2]
+
+
+async def test_dispatch_queue_overflow_warn_drops_newest(caplog):
+    uaclient = UaClient()
+    subscription_id = 42
+    observed_sequences: list[int] = []
+
+    def _callback(result):
+        observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
+
+    uaclient.subscription_dispatch_queue_maxsize = 1
+    uaclient.subscription_dispatch_overflow_policy = SubscriptionDispatchOverflowPolicy.WARN
+    uaclient._subscription_callbacks[subscription_id] = _callback
+    uaclient._ensure_subscription_dispatch_worker(subscription_id)
+
+    msg1 = ua.NotificationMessage()
+    msg1.SequenceNumber = 1
+    msg1.NotificationData = [ua.StatusChangeNotification()]
+
+    msg2 = ua.NotificationMessage()
+    msg2.SequenceNumber = 2
+    msg2.NotificationData = [ua.StatusChangeNotification()]
+
+    with caplog.at_level("WARNING", logger="asyncua.client.ua_client.UaClient"):
+        assert uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg1))
+        assert not uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg2))
+
+    await uaclient.flush_subscription_dispatch()
+
+    assert observed_sequences == [1]
+    assert "dispatch queue overflow" in caplog.text
+
+
+async def test_flush_subscription_dispatch_waits_for_callback_completion():
+    uaclient = UaClient()
+    subscription_id = 42
+    callback_started = asyncio.Event()
+    callback_resume = asyncio.Event()
+
+    async def _callback(_result):
+        callback_started.set()
+        await callback_resume.wait()
+
+    uaclient._subscription_callbacks[subscription_id] = _callback
+    uaclient._ensure_subscription_dispatch_worker(subscription_id)
+
+    msg = ua.NotificationMessage()
+    msg.SequenceNumber = 1
+    msg.NotificationData = [ua.StatusChangeNotification()]
+
+    assert uaclient._enqueue_publish_result(subscription_id, ua.PublishResult(subscription_id, NotificationMessage=msg))
+    await callback_started.wait()
+
+    flush_task = asyncio.create_task(uaclient.flush_subscription_dispatch())
+    await asyncio.sleep(0)
+    assert not flush_task.done()
+
+    callback_resume.set()
+    await flush_task
+
+
+async def test_prepare_close_session_without_protocol_cancels_dispatch_worker():
+    uaclient = UaClient()
+    subscription_id = 42
+    uaclient._subscription_callbacks[subscription_id] = lambda _result: None
+    uaclient._ensure_subscription_dispatch_worker(subscription_id)
+
+    runtime = uaclient._subscription_dispatch_runtime[subscription_id]
+    task = runtime.task
+    assert task is not None
+
+    uaclient.protocol = None
+    assert uaclient._prepare_close_session() is False
+
+    await asyncio.sleep(0)
+    assert subscription_id not in uaclient._subscription_dispatch_runtime
+    assert task.done()
+
+
+async def test_uaprocessor_close_skips_self_watchdog_await():
+    transport = MagicMock()
+    transport.get_extra_info.side_effect = lambda _key: ("127.0.0.1", 4840)
+    processor = UaProcessor(MagicMock(), transport, TransportLimits())
+
+    session = MagicMock()
+    session.close_session = AsyncMock()
+    processor.session = session
+    processor._session_watchdog_task = asyncio.current_task()
+
+    await processor.close()
+
+    session.close_session.assert_awaited_once_with(True)
+
+
+async def test_overflow_policy_string_is_normalized_to_enum():
+    uaclient = UaClient()
+    uaclient.subscription_dispatch_overflow_policy = "DROP_OLDEST"
+
+    policy = uaclient._resolve_overflow_policy()
+
+    assert policy == SubscriptionDispatchOverflowPolicy.DROP_OLDEST
+    assert uaclient.subscription_dispatch_overflow_policy == SubscriptionDispatchOverflowPolicy.DROP_OLDEST
+
+
+async def test_subscription_watchdog_detects_stale_subscription():
+    uaclient = UaClient()
+    uaclient.subscription_stale_detection_enabled = True
+    uaclient.subscription_stale_detection_margin = 1.0
+    uaclient._subscription_callbacks[1] = lambda _result: None
+
+    uaclient._register_subscription_watchdog(subscription_id=1, publishing_interval_ms=1000.0, keepalive_count=2)
+    uaclient._subscription_watchdog_states[1].last_seen_at = 0.0
+
+    stale_ids = uaclient._get_stale_subscription_ids(now=2.5)
+
+    assert stale_ids == [1]
+
+
+async def test_subscription_watchdog_activity_clears_stale_state():
+    uaclient = UaClient()
+    uaclient.subscription_stale_detection_enabled = True
+    uaclient.subscription_stale_detection_margin = 1.0
+    uaclient._subscription_callbacks[1] = lambda _result: None
+
+    uaclient._register_subscription_watchdog(subscription_id=1, publishing_interval_ms=1000.0, keepalive_count=2)
+    state = uaclient._subscription_watchdog_states[1]
+    state.last_seen_at = 0.0
+    state.stale_reported = True
+
+    uaclient._mark_subscription_watchdog_activity(1)
+
+    assert uaclient._subscription_watchdog_states[1].stale_reported is False
+
+
+async def test_subscription_watchdog_ignores_orphaned_state():
+    uaclient = UaClient()
+    uaclient.subscription_stale_detection_enabled = True
+    uaclient.subscription_stale_detection_margin = 1.2
+
+    uaclient._register_subscription_watchdog(subscription_id=571478, publishing_interval_ms=100.0, keepalive_count=10)
+    uaclient._subscription_watchdog_states[571478].last_seen_at = 0.0
+
+    stale_ids = uaclient._get_stale_subscription_ids(now=10.0)
+
+    assert stale_ids == []
+    assert 571478 not in uaclient._subscription_watchdog_states
+
+
+async def test_try_recover_stale_subscriptions_recovers_subset_once(mocker):
+    client = Client("opc.tcp://127.0.0.1:4840", timeout=0.5, watchdog_intervall=0.2)
+    client.uaclient.restart_publish_loop = AsyncMock()  # type: ignore[method-assign]
+
+    stale_sub = mocker.MagicMock()
+    stale_sub.subscription_id = 1
+    stale_sub.recreate = AsyncMock(return_value=(1, 101))
+
+    healthy_sub = mocker.MagicMock()
+    healthy_sub.subscription_id = 2
+    healthy_sub.recreate = AsyncMock(return_value=(2, 102))
+
+    client._managed_subscriptions = {stale_sub, healthy_sub}
+
+    recovered = await client._try_recover_stale_subscriptions([1])
+
+    assert recovered is True
+    stale_sub.recreate.assert_awaited_once()
+    healthy_sub.recreate.assert_not_awaited()
+    client.uaclient.restart_publish_loop.assert_awaited_once()
+
+
+async def test_try_recover_stale_subscriptions_escalates_when_all_stale(mocker):
+    client = Client("opc.tcp://127.0.0.1:4840", timeout=0.5, watchdog_intervall=0.2)
+    client.uaclient.restart_publish_loop = AsyncMock()  # type: ignore[method-assign]
+
+    sub_a = mocker.MagicMock()
+    sub_a.subscription_id = 1
+    sub_a.recreate = AsyncMock(return_value=(1, 101))
+
+    sub_b = mocker.MagicMock()
+    sub_b.subscription_id = 2
+    sub_b.recreate = AsyncMock(return_value=(2, 102))
+
+    client._managed_subscriptions = {sub_a, sub_b}
+
+    recovered = await client._try_recover_stale_subscriptions([1, 2])
+
+    assert recovered is False
+    sub_a.recreate.assert_not_awaited()
+    sub_b.recreate.assert_not_awaited()
+    client.uaclient.restart_publish_loop.assert_not_awaited()
+
+
+async def test_check_connection_stale_publish_task_uses_targeted_recovery(mocker):
+    client = Client("opc.tcp://127.0.0.1:4840", timeout=0.5, watchdog_intervall=0.2)
+    client._is_protocol_open = mocker.MagicMock(return_value=True)
+    client._try_recover_stale_subscriptions = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    client._lost_connection = AsyncMock()  # type: ignore[method-assign]
+    client._schedule_reconnect = AsyncMock()  # type: ignore[method-assign]
+    client.uaclient.inform_subscriptions = AsyncMock()  # type: ignore[method-assign]
+
+    task = asyncio.get_running_loop().create_future()
+    task.set_exception(SubscriptionStaleError([1]))
+    client.uaclient._publish_task = task
+
+    await client.check_connection()
+
+    client._try_recover_stale_subscriptions.assert_awaited_once_with([1])
+    client._lost_connection.assert_not_awaited()
+    client.uaclient.inform_subscriptions.assert_not_awaited()
+    client._schedule_reconnect.assert_not_awaited()
+
+
+async def test_finalize_successful_reconnect_restarts_background_tasks_when_missing(mocker):
+    client = Client("opc.tcp://127.0.0.1:4840", timeout=0.5, watchdog_intervall=0.2)
+    client._monitor_server_task = None
+    client._renew_channel_task = None
+
+    async def _noop_monitor_loop():
+        return None
+
+    async def _noop_renew_loop():
+        return None
+
+    client._monitor_server_loop = _noop_monitor_loop  # type: ignore[method-assign]
+    client._renew_channel_loop = _noop_renew_loop  # type: ignore[method-assign]
+
+    await client._finalize_successful_reconnect(1)
+
+    assert client._monitor_server_task is not None
+    assert client._renew_channel_task is not None
+    assert client.uaclient.connection_state == client.uaclient.CONNECTION_STATE.SESSION_READY
+
+

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -267,7 +267,13 @@ async def test_reconnect_fallback_to_new_session_when_activate_fails(mocker):
     client._session_counter = 10
 
     client.uaclient.protocol = mocker.MagicMock()
-    client.uaclient.protocol.authentication_token = ua.NodeId()
+    old_session = UaSession(
+        client=client.uaclient,
+        session_id=ua.NodeId(ua.ObjectIds.RootFolder),
+        authentication_token=client._session_authentication_token,
+    )
+    client.uaclient._register_session(old_session)
+    client.uaclient._default_session = old_session
     client.uaclient.get_subscription_ids = mocker.MagicMock(return_value=[])
     client.uaclient.ensure_publish_loop_running = mocker.MagicMock()
 
@@ -283,7 +289,7 @@ async def test_reconnect_fallback_to_new_session_when_activate_fails(mocker):
     async def _activate_side_effect(*_args, **_kwargs):
         nonlocal activate_calls
         activate_calls += 1
-        if activate_calls == 1:
+        if _kwargs.get("session") is old_session:
             raise ua.UaError("activate failed on old session")
         return mocker.MagicMock(ServerNonce=b"ok")
 
@@ -681,19 +687,27 @@ async def test_flush_subscription_dispatch_waits_for_callback_completion():
 
 async def test_prepare_close_session_without_protocol_cancels_dispatch_worker():
     uaclient = UaClient()
-    subscription_id = 42
-    uaclient._subscription_callbacks[subscription_id] = lambda _result: None
-    uaclient._ensure_subscription_dispatch_worker(subscription_id)
+    session = UaSession(
+        client=uaclient,
+        session_id=ua.NodeId(1, 0),
+        authentication_token=ua.NodeId(2, 0),
+    )
+    uaclient._register_session(session)
+    uaclient._default_session = session
 
-    runtime = uaclient._subscription_dispatch_runtime[subscription_id]
+    subscription_id = 42
+    session._subscription_callbacks[subscription_id] = lambda _result: None
+    session._ensure_subscription_dispatch_worker(subscription_id)
+
+    runtime = session._subscription_dispatch_runtime[subscription_id]
     task = runtime.task
     assert task is not None
 
     uaclient.protocol = None
-    assert uaclient._prepare_close_session() is False
+    await uaclient.close_session(session=session)
 
     await asyncio.sleep(0)
-    assert subscription_id not in uaclient._subscription_dispatch_runtime
+    assert subscription_id not in session._subscription_dispatch_runtime
     assert task.done()
 
 

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -19,6 +19,7 @@ from asyncua.ua.uaerrors import (
     BadNoSubscription,
     BadSessionNotActivated,
 )
+from asyncua.ua.ua_binary import struct_to_binary
 
 from .conftest import find_free_port, port_num
 
@@ -350,6 +351,30 @@ async def test_republish_handles_bad_subscription_id_invalid(mocker):
     assert dispatch.await_count == 0
     assert invalid_ids == {42}
     assert any("must be recreated" in str(call.args[0]) for call in log_warning.call_args_list)
+
+
+async def test_uasession_republish_reads_direct_notification_message_field():
+    session = _make_test_session()
+    expected_subscription_id = 42
+    expected_sequence = 7
+
+    notification_message = ua.NotificationMessage()
+    notification_message.SequenceNumber = 99
+    notification_message.NotificationData = []
+
+    response = ua.RepublishResponse()
+    response.NotificationMessage = notification_message
+
+    session._send_session_request = AsyncMock(  # type: ignore[method-assign]
+        return_value=struct_to_binary(response)
+    )
+
+    republished = await session.republish(expected_subscription_id, expected_sequence)
+
+    assert republished.SequenceNumber == 99
+    request = session._send_session_request.await_args.args[0]
+    assert request.Parameters.SubscriptionId == expected_subscription_id
+    assert request.Parameters.RetransmitSequenceNumber == expected_sequence
 
 
 async def test_reconnect_recreates_invalid_managed_subscription(mocker):

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -14,12 +14,11 @@ from asyncua.client.ua_session import (
 )
 from asyncua.common.connection import TransportLimits
 from asyncua.server.uaprocessor import UaProcessor
+from asyncua.ua.ua_binary import struct_to_binary
 from asyncua.ua.uaerrors import (
     BadMaxConnectionsReached,
-    BadNoSubscription,
     BadSessionNotActivated,
 )
-from asyncua.ua.ua_binary import struct_to_binary
 
 from .conftest import find_free_port, port_num
 

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -34,6 +34,26 @@ def _make_test_session() -> UaSession:
     )
 
 
+async def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        if predicate():
+            return
+        await asyncio.sleep(interval)
+    raise TimeoutError("Condition not met before timeout")
+
+
+async def _wait_for_exception(operation, expected_exception, timeout: float = 3.0, interval: float = 0.05) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        try:
+            await operation()
+        except expected_exception:
+            return
+        await asyncio.sleep(interval)
+    raise TimeoutError("Expected exception was not raised before timeout")
+
+
 async def test_max_connections_1(opc):
     opc.server.iserver.isession.__class__.max_connections = 1
     port = opc.server.endpoint.port
@@ -53,16 +73,13 @@ async def test_max_connections_1(opc):
 async def test_dos_server(opc):
     # See issue 1013 a crafted packet triggered dos
     port = opc.server.endpoint.port
-    async with Client(f"opc.tcp://127.0.0.1:{port}") as c:
+    async with Client(f"opc.tcp://127.0.0.1:{port}", timeout=0.5) as c:
         # craft invalid packet that trigger dos
         message_type, chunk_type, packet_size = [ua.MessageType.SecureOpen, b"E", 0]
         c.uaclient.protocol.transport.write(struct.pack("<3scI", message_type, chunk_type, packet_size))
-        # sleep to give the server time to handle the message because we bypass the asyncio
-        await asyncio.sleep(1.0)
-        with pytest.raises(ConnectionError):
-            # now try to read a value to see if server is still alive
-            server_time_node = c.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
-            await server_time_node.read_value()
+        # Poll for disconnect instead of sleeping a fixed amount.
+        server_time_node = c.get_node(ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
+        await _wait_for_exception(server_time_node.read_value, ConnectionError, timeout=2.0)
 
 
 async def test_safe_disconnect():
@@ -90,7 +107,7 @@ async def test_client_connection_lost():
         myhandler = LostSubHandler()
         _ = await cl.create_subscription(1, myhandler)
         await srv.stop()
-        await asyncio.sleep(2)
+        await _wait_for_exception(cl.check_connection, ConnectionError, timeout=3.0)
         with pytest.raises(ConnectionError):
             # check if connection is alive
             await cl.check_connection()
@@ -125,7 +142,7 @@ async def test_client_connection_lost_callback():
     async with Client(f"opc.tcp://127.0.0.1:{port}", timeout=0.5, watchdog_intervall=1) as cl:
         cl.connection_lost_callback = clb.clb
         await srv.stop()
-        await asyncio.sleep(2)
+        await _wait_until(lambda: clb.called, timeout=3.0)
         assert clb.called
         assert isinstance(clb.ex, Exception)
 
@@ -283,6 +300,7 @@ async def test_reconnect_fallback_to_new_session_when_activate_fails(mocker):
     client.send_hello = AsyncMock()  # type: ignore[method-assign]
     client.open_secure_channel = AsyncMock()  # type: ignore[method-assign]
     client.create_session = AsyncMock()  # type: ignore[method-assign]
+    client.close_session = AsyncMock()  # type: ignore[method-assign]
 
     activate_calls = 0
 
@@ -313,6 +331,7 @@ async def test_reconnect_logs_transfer_subscriptions_failure(mocker):
     client.uaclient.get_subscription_ids = mocker.MagicMock(return_value=[1])
     client.uaclient.get_next_sequence_number = mocker.MagicMock(return_value=1)
     client.uaclient.ensure_publish_loop_running = mocker.MagicMock()
+    client.uaclient.restart_publish_loop = AsyncMock()
 
     transfer_result = ua.TransferResult()
     transfer_result.StatusCode = ua.StatusCode(ua.StatusCodes.BadSubscriptionIdInvalid)
@@ -325,6 +344,7 @@ async def test_reconnect_logs_transfer_subscriptions_failure(mocker):
     client.send_hello = AsyncMock()  # type: ignore[method-assign]
     client.open_secure_channel = AsyncMock()  # type: ignore[method-assign]
     client.create_session = AsyncMock()  # type: ignore[method-assign]
+    client.close_session = AsyncMock()  # type: ignore[method-assign]
 
     async def _activate_side_effect(*_args, **_kwargs):
         if client._session_authentication_token is not None:
@@ -372,7 +392,7 @@ async def test_uasession_republish_reads_direct_notification_message_field():
     response.NotificationMessage = notification_message
 
     session._send_session_request = AsyncMock(  # type: ignore[method-assign]
-        return_value=struct_to_binary(response)
+        return_value=ua.utils.Buffer(struct_to_binary(response))
     )
 
     republished = await session.republish(expected_subscription_id, expected_sequence)
@@ -410,6 +430,7 @@ async def test_reconnect_does_not_recreate_invalid_subscription_when_disabled(mo
     client.uaclient.get_subscription_ids = mocker.MagicMock(return_value=[42])
     client.uaclient.get_next_sequence_number = mocker.MagicMock(return_value=1)
     client.uaclient.ensure_publish_loop_running = mocker.MagicMock()
+    client.uaclient.restart_publish_loop = AsyncMock()
     client.uaclient.transfer_subscriptions = AsyncMock(return_value=[])
 
     client._cancel_background_tasks = AsyncMock()  # type: ignore[method-assign]
@@ -417,6 +438,7 @@ async def test_reconnect_does_not_recreate_invalid_subscription_when_disabled(mo
     client.connect_socket = AsyncMock()  # type: ignore[method-assign]
     client.send_hello = AsyncMock()  # type: ignore[method-assign]
     client.open_secure_channel = AsyncMock()  # type: ignore[method-assign]
+    client.close_session = AsyncMock()  # type: ignore[method-assign]
 
     async def _activate_side_effect(*_args, **_kwargs):
         if client._session_authentication_token is not None:
@@ -505,6 +527,7 @@ async def test_publish_loop_recovers_sequence_gap_via_republish(mocker):
         observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
 
     session._subscription_callbacks[subscription_id] = _callback
+    session._ensure_subscription_dispatch_worker(subscription_id)
     session._last_publish_sequence_numbers[subscription_id] = 4
 
     publish_message = ua.NotificationMessage()
@@ -545,6 +568,7 @@ async def test_publish_loop_sequence_gap_republish_cap(mocker):
         observed_sequences.append(int(result.NotificationMessage.SequenceNumber))
 
     session._subscription_callbacks[subscription_id] = _callback
+    session._ensure_subscription_dispatch_worker(subscription_id)
     session._last_publish_sequence_numbers[subscription_id] = 4
 
     publish_message = ua.NotificationMessage()
@@ -834,7 +858,14 @@ async def test_check_connection_stale_publish_task_uses_targeted_recovery(mocker
 
     task = asyncio.get_running_loop().create_future()
     task.set_exception(SubscriptionStaleError([1]))
-    client.uaclient._publish_task = task
+    session = UaSession(
+        client=client.uaclient,
+        session_id=ua.NodeId(1, 0),
+        authentication_token=ua.NodeId(2, 0),
+    )
+    client.uaclient._register_session(session)
+    client.uaclient._default_session = session
+    session._publish_task = task
 
     await client.check_connection()
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import sys
 from asyncio import Future, TimeoutError, sleep, wait_for
 from copy import copy
@@ -6,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from asyncua.common.subscription import Subscription
+from asyncua.common.subscription import Subscription, SubscriptionItemData
 
 try:
     from unittest.mock import AsyncMock
@@ -16,6 +17,71 @@ import asyncua
 from asyncua import Client, ua
 
 from .conftest import Opc
+
+
+class _DummyNode:
+    def __init__(self):
+        self.nodeid = ua.NodeId(ua.ObjectIds.Server)
+
+
+def _build_subscription_for_queue_sizing() -> Subscription:
+    params = ua.CreateSubscriptionParameters()
+    params.RequestedPublishingInterval = 100.0
+    return Subscription(object(), params, object())
+
+
+def test_warns_on_potential_queue_overflow(caplog):
+    sub = _build_subscription_for_queue_sizing()
+    node = _DummyNode()
+
+    with caplog.at_level(logging.WARNING):
+        sub._make_monitored_item_request(
+            node,
+            ua.AttributeIds.Value,
+            None,
+            queuesize=1,
+            monitoring=ua.MonitoringMode.Reporting,
+            sampling_interval=10.0,
+        )
+
+    assert "Potential monitored item queue overflow" in caplog.text
+
+
+def test_no_warning_when_queue_size_is_sufficient(caplog):
+    sub = _build_subscription_for_queue_sizing()
+    node = _DummyNode()
+
+    with caplog.at_level(logging.WARNING):
+        sub._make_monitored_item_request(
+            node,
+            ua.AttributeIds.Value,
+            None,
+            queuesize=10,
+            monitoring=ua.MonitoringMode.Reporting,
+            sampling_interval=10.0,
+        )
+
+    assert "Potential monitored item queue overflow" not in caplog.text
+
+
+async def test_modify_monitored_item_warns_on_potential_queue_overflow(caplog):
+    sub = _build_subscription_for_queue_sizing()
+    data = SubscriptionItemData()
+    data.server_handle = 1
+    data.client_handle = 1
+    data.monitoring_mode = ua.MonitoringMode.Reporting
+    data.mfilter = None
+    sub._monitored_items[data.client_handle] = data
+
+    result = ua.MonitoredItemModifyResult()
+    result.FilterResult = None
+    sub.server = AsyncMock()
+    sub.server.modify_monitored_items.return_value = [result]
+
+    with caplog.at_level(logging.WARNING):
+        await sub.modify_monitored_item(handle=1, new_samp_time=10.0, new_queuesize=1)
+
+    assert "Potential monitored item queue overflow" in caplog.text
 
 
 class MySubHandler:


### PR DESCRIPTION
## PR Summary

This PR adds a resilient reconnect and recovery flow for the OPC UA client, with a focus on preventing hard client failures during transient connection loss.

- Added reconnect state handling and request gating in [asyncua/client/client.py](asyncua/client/client.py), so requests wait during reconnect instead of failing immediately.
- Added a background reconnect loop with retry/backoff and clean task shutdown handling.
- Updated recovery sequence to be spec-aligned:
  - re-establish SecureChannel,
  - try `ActivateSession` on the existing session first,
  - create a new session only if activation fails.
- Implemented subscription recovery path:
  - `TransferSubscriptions` for newly created sessions,
  - `Republish` loop per subscription until `BadMessageNotAvailable`,
  - restart publish loop after recovery.
- Added session token persistence for session reuse attempts.
- Added missing low-level APIs in [asyncua/client/ua_client.py](asyncua/client/ua_client.py):
  - `TransferSubscriptions` implementation,
  - `Republish` request support,
  - per-subscription publish sequence tracking and replay dispatch helpers.
- Recreate Subscription if configured