### PR TITLE
fix: task awaiting on itself during watchdog timeout

### DIFF
--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -528,7 +528,7 @@ class UaProcessor:
         _logger.info("Cleanup client connection: %s", self.name)
         self._closing = True
         try:
-            if self._session_watchdog_task:
+            if self._session_watchdog_task and self._session_watchdog_task is not asyncio.current_task():
                 await self._session_watchdog_task
         finally:
             if self.session:


### PR DESCRIPTION
- resolves #1864
- resolves #1763

## Problem

I had the same issue as the issues linked above where a client for some reason stops responding correctly, causing a timeout of the watchdog that then raised an exception since it tried to await on itself.

The issue is the following:
- the `close` method in the `UaProcessor` awaits on the `self._session_watchdog_task` before closing
- this `close` method is also used by `_session_watchdog_loop` which is the task that is awaited by `close`

This causes the `_session_watchdog_task` to await on itself via the `close` method it awaits.

## Solution
My solution here is to just check what the current asyncio task is, and if the current task is the `_session_watchdog_task`, then we skip awaiting it.

There are other possible solutions like instead of `await self.close()`, `close` is called via a new task. However, that doesnt seem as clean and simple.

## Tests
I am unfamiliar with this repo and testing, so i just tested this solution within my own software stack.
I was able to replicate the issue and saw that this change fixed the problem.
Feel free to add tests or similar if this is not sufficiently tested.