### PR TITLE
Fix PubSub UdpSettings key name case mismatch and TTL type check

### DIFF
--- a/asyncua/pubsub/udp.py
+++ b/asyncua/pubsub/udp.py
@@ -77,7 +77,7 @@ class UdpSettings:
             for kv in kvs:
                 key = kv.Key.Name
                 value = kv.Value
-                if key == "ttl" and value.VariantType == VariantType.Boolean:
+                if key == "ttl":
                     self.TTL = value.Value
                 if key == "loopback" and value.VariantType == VariantType.Boolean:
                     self.Loopback = value.Value
@@ -89,7 +89,7 @@ class UdpSettings:
         if self.TTL is not None:
             kvs.append(KeyValuePair(QualifiedName("ttl"), Variant(self.TTL)))
         kvs.append(KeyValuePair(QualifiedName("reuse"), Variant(self.Reuse)))
-        kvs.append(KeyValuePair(QualifiedName("Loopback"), Variant(self.Loopback)))
+        kvs.append(KeyValuePair(QualifiedName("loopback"), Variant(self.Loopback)))
         return kvs
 
     def create_socket(

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -339,3 +339,31 @@ async def test_load_save_ua_binary_publisher(server: Server, tmpdir_factory):
     assert len(wgr._writer) == 1
     dsw = wgr.get_writer("Demo DataSetWriter")
     assert dsw is not None
+
+
+def test_udp_settings_key_value_roundtrip():
+    """Test that get_key_value/set_key_value round-trip preserves all settings.
+
+    Regression test for https://github.com/FreeOpcUa/opcua-asyncio/issues/1945
+    where 'Loopback' (capital L) in get_key_value did not match 'loopback'
+    (lowercase l) in set_key_value, causing the value to be silently lost.
+    """
+    original = UdpSettings(Addr=("239.0.0.1", 4840), Loopback=False, Reuse=False, TTL=5)
+    kvs = original.get_key_value()
+
+    restored = UdpSettings(Addr=("239.0.0.1", 4840))
+    restored.set_key_value(kvs)
+
+    assert restored.Loopback == original.Loopback
+    assert restored.Reuse == original.Reuse
+    assert restored.TTL == original.TTL
+
+
+def test_udp_settings_key_names_consistent():
+    """Test that key names in get_key_value match the keys expected by set_key_value."""
+    settings = UdpSettings(Addr=("239.0.0.1", 4840), TTL=10)
+    kvs = settings.get_key_value()
+    key_names = [kv.Key.Name for kv in kvs]
+    assert "loopback" in key_names
+    assert "reuse" in key_names
+    assert "ttl" in key_names


### PR DESCRIPTION
## Summary

Fix two bugs in `UdpSettings.set_key_value()`/`get_key_value()` that cause settings to be silently lost during round-trip (e.g. via `PubSubConnection.from_cfg()` → `UdpSettings.from_cfg()`):

1. **Loopback key name case mismatch**: `get_key_value()` emitted `"Loopback"` (capital L) but `set_key_value()` matched `"loopback"` (lowercase l). The Loopback setting was silently dropped.
2. **TTL type check incorrect**: `set_key_value()` checked `VariantType.Boolean` for the TTL key, but `Variant(int)` creates an `Int64` variant, so the check always failed and TTL was silently dropped.

Closes #1945

<details>
<summary>Before</summary>

```
Original: Loopback=False, Reuse=False, TTL=5
Keys: [('ttl', 5), ('reuse', False), ('Loopback', False)]
Restored: Loopback=True, Reuse=False, TTL=None
Loopback preserved: False
TTL preserved: False
```

</details>

<details>
<summary>After</summary>

```
Original: Loopback=False, Reuse=False, TTL=5
Keys: [('ttl', 5), ('reuse', False), ('loopback', False)]
Restored: Loopback=False, Reuse=False, TTL=5
Loopback preserved: True
TTL preserved: True
```

</details>

<details>
<summary>Test output (7 passed)</summary>

```
tests/test_pubsub.py::test_uadp_basic PASSED                             [ 14%]
tests/test_pubsub.py::test_connection PASSED                             [ 28%]
tests/test_pubsub.py::test_full_simple PASSED                            [ 42%]
tests/test_pubsub.py::test_datasource_and_subscribed_dataset PASSED      [ 57%]
tests/test_pubsub.py::test_load_save_ua_binary_publisher PASSED          [ 71%]
tests/test_pubsub.py::test_udp_settings_key_value_roundtrip PASSED       [ 85%]
tests/test_pubsub.py::test_udp_settings_key_names_consistent PASSED      [100%]

============================== 7 passed in 8.45s ===============================
```

</details>