### PR TITLE
Implement PublishRequest limit, no subscriptions and timeout responses

### DIFF
--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -325,7 +325,7 @@ class InternalSession(AbstractSession):
 
         return subscription_result
 
-    def publish(self, acks: Iterable[ua.SubscriptionAcknowledgement] | None = None) -> None:
+    def publish(self, acks: Iterable[ua.SubscriptionAcknowledgement] | None = None) -> int:
         return self.subscription_service.publish(acks or [])
 
     def modify_subscription(

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -91,7 +91,7 @@ class SubscriptionService:
                 res.append(ua.StatusCode())
         stop_results = await asyncio.gather(*[sub.stop() for sub in existing_subs], return_exceptions=True)
         for stop_result in stop_results:
-            if isinstance(res, Exception):
+            if isinstance(stop_result, Exception):
                 self.logger.warning("Exception while stopping subscription", exc_info=stop_result)
         return res
 

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -95,10 +95,15 @@ class SubscriptionService:
                 self.logger.warning("Exception while stopping subscription", exc_info=stop_result)
         return res
 
-    def publish(self, acks: Iterable[ua.SubscriptionAcknowledgement]) -> None:
+    def publish(self, acks: Iterable[ua.SubscriptionAcknowledgement]) -> int:
         self.logger.info("publish request with acks %s", acks)
-        for subid, sub in self.subscriptions.items():
-            sub.publish([ack.SequenceNumber for ack in acks if ack.SubscriptionId == subid])
+        if not self.subscriptions:
+            raise utils.ServiceError(ua.StatusCodes.BadNoSubscription)
+        for ack in acks:
+            sub = self.subscriptions.get(ack.SubscriptionId)
+            if sub is not None:
+                sub.publish([ack.SequenceNumber])
+        return len(self.subscriptions)
 
     async def create_monitored_items(
         self, params: ua.CreateMonitoredItemsParameters

--- a/asyncua/server/uaprocessor.py
+++ b/asyncua/server/uaprocessor.py
@@ -3,6 +3,7 @@ import copy
 import logging
 import time
 from collections import deque
+from typing import Literal
 
 from asyncua import ua
 
@@ -21,6 +22,12 @@ class PublishRequestData:
         self.seqhdr = seqhdr
         self.timestamp = time.monotonic()
 
+    def has_timed_out(self, now: float) -> bool:
+        return (
+            self.requesthdr.TimeoutHint != 0
+            and self.requesthdr.TimeoutHint / 1000 < now - self.timestamp
+        )
+
 
 class UaProcessor:
     """
@@ -38,7 +45,7 @@ class UaProcessor:
         self._publish_requests: deque[PublishRequestData] = deque()
         # queue for publish results callbacks (using SubscriptionId)
         # rely on dict insertion order (therefore can't use set())
-        self._publish_results_subs: dict[ua.IntegerId, bool] = {}
+        self._publish_results_subs: dict[ua.IntegerId, Literal[True]] = {}
         self._limits = copy.deepcopy(limits)  # Copy limits because they get overriden
         self._connection = SecureConnection(SecurityPolicyNone(), self._limits)
         self._closing: bool = False
@@ -72,6 +79,7 @@ class UaProcessor:
         self.send_response(request.RequestHeader.RequestHandle, seqhdr, response, ua.MessageType.SecureOpen)
 
     def get_publish_request(self, subscription_id: ua.IntegerId):
+        now = time.monotonic()
         while True:
             if not self._publish_requests:
                 # only store one callback per subscription
@@ -84,13 +92,30 @@ class UaProcessor:
                 return None
             # We pop left from the Publish Request deque (FIFO)
             requestdata = self._publish_requests.popleft()
-            if requestdata.requesthdr.TimeoutHint == 0 or (
-                requestdata.requesthdr.TimeoutHint != 0
-                and time.monotonic() - requestdata.timestamp < requestdata.requesthdr.TimeoutHint / 1000
-            ):
+            if not requestdata.has_timed_out(now):
                 # Continue and use `requestdata` only if there was no timeout
                 break
+            self._send_publish_request_timeout(requestdata)
         return requestdata
+
+    def get_oldest_request_to_discard(self):
+        if self._publish_requests:
+            now = time.monotonic()
+            for i, requestdata in enumerate(self._publish_requests):
+                if requestdata.has_timed_out(now):
+                    del self._publish_requests[i]
+                    self._send_publish_request_timeout(requestdata)
+                    break
+            else:
+                return self._publish_requests.popleft()
+        return None
+
+    def _send_publish_request_timeout(self, requestdata: PublishRequestData):
+        # "If the request timed out, a Bad_Timeout Service result is
+        # sent and another Publish request is used."
+        response = ua.ServiceFault()
+        response.ResponseHeader.ServiceResult = ua.StatusCode(ua.StatusCodes.BadTimeout)
+        self.send_response(requestdata.requesthdr.RequestHandle, requestdata.seqhdr, response)
 
     async def forward_publish_response(self, result: ua.PublishResult, requestdata: PublishRequestData):
         """
@@ -467,7 +492,7 @@ class UaProcessor:
                 if not self.session:
                     return False
                 params = struct_from_binary(ua.PublishParameters, body)
-                self.session.publish(params.SubscriptionAcknowledgements)
+                subscriptions = self.session.publish(params.SubscriptionAcknowledgements)
                 data = PublishRequestData(requesthdr=requesthdr, seqhdr=seqhdr)
                 # If there is an enqueued publish results callback, try to call it immediately
                 while self._publish_results_subs:
@@ -481,6 +506,16 @@ class UaProcessor:
                         # publish request has been consumed
                         break
                 else:
+                    if len(self._publish_requests) >= self.publish_request_limit(subscriptions):
+                        # "When a Server receives a new Publish request that
+                        # exceeds its limit it shall de-queue the oldest
+                        # Publish request and return a response with the
+                        # result set to Bad_TooManyPublishRequests."
+                        oldest = self.get_oldest_request_to_discard()
+                        if oldest is not None:
+                            response = ua.ServiceFault()
+                            response.ResponseHeader.ServiceResult = ua.StatusCode(ua.StatusCodes.BadTooManyPublishRequests)
+                            self.send_response(oldest.requesthdr.RequestHandle, oldest.seqhdr, response)
                     # Store the Publish Request (will be used to send publish answers from server)
                     self._publish_requests.append(data)
 
@@ -541,6 +576,15 @@ class UaProcessor:
                 raise ServiceError(ua.StatusCodes.BadServiceUnsupported)
 
         return True
+
+    def publish_request_limit(self, subscription_count: int) -> int:
+        # "A Server should limit the number of active Publish
+        # requests to avoid an infinite number since it is
+        # expected that the Publish requests are queued in the
+        # Server. But a Server shall accept more queued Publish
+        # requests than created Subscriptions."
+        # TODO Make the limit configurable
+        return subscription_count + 10
 
     async def close(self):
         """

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -14,6 +14,7 @@ except ImportError:
     from asynctest import CoroutineMock as AsyncMock  # type: ignore[no-redef]
 import asyncua
 from asyncua import Client, ua
+from asyncua.ua.ua_binary import nodeid_from_binary, struct_from_binary
 
 from .conftest import Opc
 
@@ -311,8 +312,10 @@ async def test_create_subscription_publishing(opc):
     # publishing default to True
     sub = await opc.opc.create_subscription(100, myhandler)
     assert sub.parameters.PublishingEnabled
+    await sub.delete()
     sub = await opc.opc.create_subscription(100, myhandler, publishing=False)
     assert not sub.parameters.PublishingEnabled
+    await sub.delete()
 
 
 @pytest.mark.parametrize("opc", ["client"], indirect=True)
@@ -334,6 +337,8 @@ async def test_set_monitoring_mode(opc, mocker):
     await sub.set_monitoring_mode(ua.MonitoringMode.Reporting)
     assert monitoring_mode.MonitoringMode == ua.MonitoringMode.Reporting
 
+    await sub.delete()
+
 
 @pytest.mark.parametrize("opc", ["client"], indirect=True)
 async def test_set_publishing_mode(opc, mocker):
@@ -353,6 +358,8 @@ async def test_set_publishing_mode(opc, mocker):
 
     await sub.set_publishing_mode(True)
     assert publishing_mode.PublishingEnabled
+
+    await sub.delete()
 
 
 async def test_subscription_data_change_bool(opc):
@@ -1002,6 +1009,7 @@ async def test_internal_server_subscription(opc):
     # Check that the results are not left un-acknowledged on internal Server Subscriptions.
     assert len(internal_sub._not_acknowledged_results) == 0
     await opc.opc.delete_nodes([sub_obj])
+    await sub.delete()
 
 
 @pytest.mark.parametrize("opc", ["client"], indirect=True)
@@ -1056,3 +1064,75 @@ async def test_maxkeepalive_count(opc, mocker):
     mock_create_subscription.reset_mock()
     sub = await client.create_subscription(mock_period, sub_handler)
     mock_update_subscription.assert_not_called()
+
+
+@pytest.mark.parametrize("opc", ["client"], indirect=True)
+async def test_publish_without_subscription(opc):
+    assert opc.server.iserver.subscription_service.subscriptions == {}, "Some prior test has left subscriptions on the server"
+    with pytest.raises(ua.UaStatusCodeError) as excinfo:
+        _ = await opc.opc.uaclient.session.publish([])
+    assert excinfo.value.code == ua.StatusCodes.BadNoSubscription
+
+
+@pytest.mark.parametrize("opc", ["client"], indirect=True)
+async def test_too_many_publish(opc, mocker):
+    assert opc.server.iserver.subscription_service.subscriptions == {}, "Some prior test has left subscriptions on the server"
+    mocker.patch.object(opc.opc.uaclient.session, "ensure_publish_loop", lambda: None)
+    sub_handler = MySubHandler()
+    sub = await opc.opc.create_subscription(500, sub_handler)
+    try:
+        requests = [asyncio.create_task(opc.opc.uaclient.session.publish([])) for _ in range(12)]
+        while True:
+            done, pending = await asyncio.wait(requests, timeout=5, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                exception = task.exception()
+                if exception is None:
+                    requests.remove(task)
+                    requests.append(asyncio.create_task(opc.opc.uaclient.session.publish([])))
+                else:
+                    assert isinstance(exception, ua.UaStatusCodeError)
+                    assert exception.code == ua.StatusCodes.BadTooManyPublishRequests
+                    assert task is requests[0]
+                    break
+            else:
+                continue
+            for task in pending:
+                task.cancel()
+            break
+    finally:
+        await sub.delete()
+
+
+@pytest.mark.parametrize("opc", ["client"], indirect=True, scope="function")
+async def test_timeout_publish(opc, mocker):
+    mocker.patch.object(opc.opc.uaclient.session, "ensure_publish_loop", lambda: None)
+
+    sub_handler = MySubHandler()
+    sub = await opc.opc.create_subscription(1000, sub_handler)
+
+    o = opc.opc.nodes.objects
+    var = await o.add_variable(3, "SubVarPublishTimeout", -1)
+    try:
+        await sub.subscribe_data_change(var)
+
+        protocol = opc.opc.uaclient.protocol
+        assert protocol is not None
+
+        for value in range(2):
+            request = ua.PublishRequest()
+            fut = protocol._send_request(request, 0.001, ua.MessageType.SecureMessage)
+
+            done, _ = await asyncio.wait([fut], return_when=asyncio.FIRST_COMPLETED, timeout=1)
+            if done:
+                data = fut.result()
+            else:
+                await var.write_value(value)
+                data = await asyncio.wait_for(fut, timeout=5)
+            typeid = nodeid_from_binary(data)
+            if typeid.Identifier != ua.ObjectIds.PublishResponse_Encoding_DefaultBinary:
+                break
+        header = struct_from_binary(ua.ResponseHeader, data)
+        assert header.ServiceResult.value == ua.StatusCodes.BadTimeout
+    finally:
+        await sub.delete()
+        await opc.opc.delete_nodes([var])


### PR DESCRIPTION
The PublishRequest does not result in BadNoSubscription when there are no subscriptions. It also does not return a response at all with a timeout while it should return a ServiceFault with BadTimeout. Also, there is no limit to queued PublishRequest when it should result in BadTooManyPublishRequests for the oldest PublishRequest.

The publish request itself also unnecessarily had nested loops over all subscriptions and acks potentially affecting performance with large number of subscriptions and acks.

The ModifySubscriptionRequest was not part of the default roleruleset therefore resulting in BadUserAccessDenied.

The DeleteSubscription exception checking tested wrong variable.

The PublishRequest is missing tests in this PR. I'm not sure how such tests should be implemented.