### PR TITLE
Defer standard server address-space import until use

### DIFF
--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -26,7 +26,6 @@ from .address_space import AddressSpace, AttributeService, MethodService, NodeDa
 from .event_generator import EventGenerator
 from .history import HistoryManager
 from .internal_session import InternalSession
-from .standard_address_space import standard_address_space
 from .subscription_service import SubscriptionService
 from .user_managers import PermissiveUserManager, UserManager
 
@@ -155,6 +154,8 @@ class InternalServer:
                 self.aspace.load_aspace_shelf(shelf_file)
                 return
         # import address space from code generated from xml
+        from .standard_address_space import standard_address_space
+
         await asyncio.to_thread(standard_address_space.fill_address_space, self.node_mgt_service)
         # import address space directly from xml, this has performance impact so disabled
         # importer = xmlimporter.XmlImporter(self.node_mgt_service)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,6 +6,8 @@ Tests that can only be run on server side must be defined here
 import asyncio
 import logging
 import shelve
+import subprocess
+import sys
 from datetime import timedelta
 from enum import EnumMeta
 from pathlib import Path
@@ -905,3 +907,30 @@ async def test_start_server_when_port_is_in_use(server: Server):
         await server2.start()
     # now it should still be possible to stop the server with exceptions
     await server2.stop()
+
+
+def test_import_asyncua_does_not_import_generated_standard_address_space_services():
+    """
+    Regression test verifying that importing top-level asyncua does not
+    import the server standard address-space.
+
+    See https://github.com/FreeOpcUa/opcua-asyncio/issues/1977
+    """
+    code = """
+import sys
+import asyncua
+
+loaded = [
+    name for name in sys.modules
+    if (
+        name.startswith("asyncua.server.standard_address_space.standard_address_space_services")
+        or name == "asyncua.server.standard_address_space.standard_address_space"
+    )
+]
+assert not loaded, loaded
+"""
+
+    subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+    )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -930,6 +930,8 @@ loaded = [
 assert not loaded, loaded
 """
 
+    # Subprocess required to avoid interference from other tests that
+    # may already have imported server modules.
     subprocess.run(
         [sys.executable, "-c", code],
         check=True,


### PR DESCRIPTION
This PR defers importing the generated standard server address-space modules until `InternalServer.load_standard_address_space()` actually needs them.

Currently, `asyncua.server.internal_server` imports `standard_address_space` at module import time. Because `asyncua.__init__` imports `Server`, this means a plain `import asyncua` also imports the generated server standard address-space modules, even when no server is initialized (such as in client-only applications).

The generated standard address space is only needed when a server loads the standard address-space, so this PR moves that import to the point of use.

Before this change, measuring RSS:
```shell
import asyncua time: 183.4 ms
max RSS increase: 27.9 MB
Generated standard address-space modules loaded during import
```

After this change:
```
import asyncua time: 175.2 ms
max RSS increase: 17.7 MB
OK: generated standard address-space modules were not loaded during import.
```

Fixes #1977