### PR TITLE
fix: skip invalid bits when parsing enum bitfield

### DIFF
--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -277,7 +277,7 @@ class _MaskEnum(IntEnum):
         """Take an integer and interpret it as a set of enum values."""
         if not isinstance(the_int, int):
             raise ValueError(f"Argument should be an int, we received {the_int} fo type {type(the_int)}")
-        return {cls(b) for b in cls._bits(the_int)}
+        return {cls(b) for b in cls._bits(the_int) if b in cls._value2member_map_}
 
     @classmethod
     def to_bitfield(cls, collection: Any) -> int:


### PR DESCRIPTION
Fix ValueError when parsing bitfield with undefined enum values.

Some servers may return undefined enumeration values.
The original code would crash if the input contains bits not defined in the enum.
This fix filters out invalid bits before creating enum members.