### PR TITLE
Fix default request timeout to be the Client.timeout, not 1

### DIFF
--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -583,7 +583,7 @@ class UaClient:
             self._set_state(UaClientState.SOCKET_OPEN)
 
     async def _send_request(
-        self, request: Any, timeout: float = 1, message_type: ua.MessageType = ua.MessageType.SecureMessage
+        self, request: Any, timeout: float | None = None, message_type: ua.MessageType = ua.MessageType.SecureMessage
     ) -> Buffer:
         if self.protocol is None:
             raise ConnectionError("Connection is not open")

--- a/asyncua/client/ua_session.py
+++ b/asyncua/client/ua_session.py
@@ -89,7 +89,7 @@ class UaSession(AbstractSession):
     async def _send_request(
         self,
         request: Any,
-        timeout: float = 1,
+        timeout: float | None = None,
         message_type: ua.MessageType = ua.MessageType.SecureMessage,
     ) -> Buffer:
         return await self._client._send_request(request, timeout, message_type)


### PR DESCRIPTION
This is a fix for the timeout problem we have found when bumping from 1.1.0 to 2.0, and this maybe the fix to #1987.

The issue is that timeout set on `Client` does not propagate to methods like `read()` or `write()` on inner objects like `UaClient`. 

## Old behavior
Methods like `UaClient.create_subscription()`, `UaClient.read()` or `UaClient.write()` call `self.protocol.send_request()` (`UASocketProtocol.send_request()`) with timeout argument not set and defaulting to None.

`UASocketProtocol.send_request()` in case of timeout argument being None uses `self.timeout` which is propagated from `UaClient` and `Client`.

## Current behavior
Methods like `UaClient.create_subscription()`, `UaClient.read()` or `UaClient.write()` call a corresponding method on `self.session` (`UaSession`). Methods on `UaSession` call `UaSession._send_request()` without timeout argument which then defaults to 1.

`UaSession._send_request()` calls `UaClient._send_request()` with timeout argument propagated (though the default value was also for some reason 1).

`UaClient._send_request()` propagates the timeout of 1 to `UASocketProtocol.send_request()`. The defaulting to `self.timeout` is never triggered and all such operations have a timeout of 1. 

This makes a bit longer operations, or multiple concurrent operations fail.