### PR TITLE
Limit concurrent client requests

### DIFF
--- a/asyncua/client/client.py
+++ b/asyncua/client/client.py
@@ -235,6 +235,10 @@ class Client:
         """
         self._locale = locale
 
+    def set_max_concurrent_requests(self, max_concurrent_requests: int) -> None:
+        """Set the maximum number of requests sent concurrently."""
+        self.uaclient.set_max_concurrent_requests(max_concurrent_requests)
+
     async def set_security_string(self, string: str) -> None:
         """
         Set SecureConnection mode.

--- a/asyncua/client/ua_client.py
+++ b/asyncua/client/ua_client.py
@@ -392,12 +392,15 @@ class UaClient:
     with code that used to call them on `UaClient` directly.
     """
 
+    _max_concurrent_requests = 100
+
     def __init__(self, timeout: float = 1.0) -> None:
         """
         :param timeout: Timout in seconds
         """
         self.logger = logging.getLogger(f"{__name__}.UaClient")
         self._timeout = timeout
+        self._request_semaphore = asyncio.Semaphore(self._max_concurrent_requests)
         self.security_policy: security_policies.SecurityPolicy = security_policies.SecurityPolicyNone()
         self.protocol: UASocketProtocol | None = None
         self._pre_request_hook: Callable[[], Awaitable[None]] | None = None
@@ -515,6 +518,11 @@ class UaClient:
     def set_security(self, policy: security_policies.SecurityPolicy) -> None:
         self.security_policy = policy
 
+    def set_max_concurrent_requests(self, max_concurrent_requests: int) -> None:
+        """Set the maximum number of requests sent concurrently."""
+        self._max_concurrent_requests = max_concurrent_requests
+        self._request_semaphore = asyncio.Semaphore(max_concurrent_requests)
+
     def _make_protocol(self) -> UASocketProtocol:
         self.protocol = UASocketProtocol(self._timeout, security_policy=self.security_policy)
         self.protocol.pre_request_hook = self._pre_request_hook
@@ -585,9 +593,10 @@ class UaClient:
     async def _send_request(
         self, request: Any, timeout: float | None = None, message_type: ua.MessageType = ua.MessageType.SecureMessage
     ) -> Buffer:
-        if self.protocol is None:
-            raise ConnectionError("Connection is not open")
-        return await self.protocol.send_request(request, timeout, message_type)
+        async with self._request_semaphore:
+            if self.protocol is None:
+                raise ConnectionError("Connection is not open")
+            return await self.protocol.send_request(request, timeout, message_type)
 
     # --- back-compat: properties that previously lived on UaClient ---
 

--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -310,6 +310,9 @@ class Client:
     def set_locale(self, locale: Sequence[str]) -> None:
         self.aio_obj.set_locale(locale)
 
+    def set_max_concurrent_requests(self, max_concurrent_requests: int) -> None:
+        self.aio_obj.set_max_concurrent_requests(max_concurrent_requests)
+
     @syncmethod
     def load_private_key(
         self, path: str, password: str | bytes | None = None, extension: str | None = None

--- a/tests/test_request_limiter.py
+++ b/tests/test_request_limiter.py
@@ -1,0 +1,53 @@
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from asyncua import ua
+from asyncua.client.client import Client
+from asyncua.client.ua_client import UaClient
+from asyncua.common.utils import Buffer
+
+
+def test_request_limit_has_a_high_default() -> None:
+    assert UaClient._max_concurrent_requests == 100
+
+
+@pytest.mark.asyncio
+async def test_request_limit_caps_in_flight_requests() -> None:
+    client = Client("opc.tcp://localhost:4840")
+    client.set_max_concurrent_requests(2)
+    release = asyncio.Event()
+    limit_reached = asyncio.Event()
+    active = 0
+    peak = 0
+
+    async def send_request(
+        request: Any,
+        timeout: float | None = None,
+        message_type: ua.MessageType = ua.MessageType.SecureMessage,
+    ) -> Buffer:
+        nonlocal active, peak
+        active += 1
+        peak = max(peak, active)
+        if active == 2:
+            limit_reached.set()
+        await release.wait()
+        active -= 1
+        return Buffer(b"")
+
+    protocol = AsyncMock()
+    protocol.send_request.side_effect = send_request
+    client.uaclient.protocol = protocol
+
+    requests = [asyncio.create_task(client.uaclient._send_request(ua.ReadRequest())) for _ in range(3)]
+    await asyncio.wait_for(limit_reached.wait(), timeout=1)
+    await asyncio.sleep(0)
+
+    assert client.uaclient._max_concurrent_requests == 2
+    assert active == 2
+    assert peak == 2
+
+    release.set()
+    await asyncio.gather(*requests)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -81,6 +81,11 @@ def test_sync_client(client, idx):
     assert myvar.read_value() == 6.7
 
 
+def test_sync_client_set_max_concurrent_requests(client):
+    client.set_max_concurrent_requests(3)
+    assert client.aio_obj.uaclient._max_concurrent_requests == 3
+
+
 def test_sync_uaclient_method(client, idx):
     client.load_type_definitions()
     myvar = client.nodes.root.get_child(["0:Objects", f"{idx}:MyObject", f"{idx}:MyVariable"])


### PR DESCRIPTION
## Summary

- keep a high private `UaClient._max_concurrent_requests` default of 100
- limit transport requests with one asyncio semaphore
- let `UaClient.set_max_concurrent_requests()` own both configuration and semaphore replacement
- expose `Client.set_max_concurrent_requests()` as a thin public delegation layer
- expose the same setter on sync `Client` for API parity

## Why

Some OPC UA servers and PLCs stop responding when many large service requests are pipelined at once. A high default preserves normal concurrency while allowing applications to lower the limit for constrained servers.

Fixes #1987.

## Validation

- request-limiter behavior tests
- sync Client setter parity test
- Ruff / mypy on changed modules