### PR TITLE
Expose set_application_uri on sync Server wrapper

### DIFF
--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -598,6 +598,12 @@ class Server:
     def set_server_name(self, name: str) -> None:
         return self.aio_obj.set_server_name(name)
 
+    def get_application_uri(self) -> str:
+        return self.aio_obj.get_application_uri()
+
+    @syncmethod
+    def set_application_uri(self, uri: str) -> None: ...
+
     def set_security_policy(
         self, security_policy: list[ua.SecurityPolicyType], permission_ruleset: Any | None = None
     ) -> None:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -86,6 +86,19 @@ def test_sync_client_set_max_concurrent_requests(client):
     assert client.aio_obj.uaclient._max_concurrent_requests == 3
 
 
+def test_sync_server_set_application_uri(tloop):
+    """Sync Server must expose set_application_uri / get_application_uri (GH-1967)."""
+    s = Server(tloop=tloop)
+    s.disable_clock(True)
+    new_uri = "urn:freeopcua:python:server:sync_test_app_uri"
+    s.set_application_uri(new_uri)
+    assert s.get_application_uri() == new_uri
+    # Namespace index 1 holds the application URI.
+    namespaces = s.get_namespace_array()
+    assert namespaces[1] == new_uri
+    s.stop()
+
+
 def test_sync_uaclient_method(client, idx):
     client.load_type_definitions()
     myvar = client.nodes.root.get_child(["0:Objects", f"{idx}:MyObject", f"{idx}:MyVariable"])


### PR DESCRIPTION
## Summary

Fixes #1967

The async `Server` API provides `set_application_uri` / `get_application_uri`
to update the application URI and namespace array entry. The sync wrapper was
missing these methods, so sync users could not set a non-default ApplicationUri
for certificate matching.

This blocks a common industrial deployment path: scripts and glue code that
use the sync API (rather than asyncio) cannot align the server ApplicationUri
with the URI embedded in X.509 SAN/Subject before enabling SignAndEncrypt — the
same workflow documented in `examples/server-with-encryption.py`.

Related: #2001 (ServerArray half of OPC UA Part 5 §6.3.1; pair with that PR
for full spec compliance when calling `set_application_uri` post-init).
Related: #1254 (sync wrapper + certificate trust workflows).

## Repro / severity

```python
from asyncua.sync import Server

s = Server()
s.set_application_uri("urn:myplant:plc:server")  # AttributeError on master
```

Without this, sync callers are stuck on the default `urn:freeopcua:python:server`
ApplicationUri. Certificate validators and peers that match on ApplicationUri
then reject the connection or fail trust checks — often surfaced as opaque
timeouts (#1254) rather than a clear API error.

## Changes

- Add `Server.get_application_uri()` and `@syncmethod Server.set_application_uri(uri)`
  on the sync wrapper.
- Unit test covering URI update and namespace array index 1.

## Tests

```bash
pytest tests/test_sync.py::test_sync_server_set_application_uri -q
# 1 passed
```