### PR TITLE
Fix _to_nodeid for integer identifiers > 255

### DIFF
--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -42,7 +42,14 @@ def _check_results(results: list[ua.StatusCode], reqlen: int = 1) -> None:
 
 def _to_nodeid(nodeid: Node | ua.NodeId | str | int) -> ua.NodeId:
     if isinstance(nodeid, int):
-        return ua.TwoByteNodeId(nodeid)
+        # Pick the compact NodeId encoding that can hold the identifier.
+        # TwoByteNodeId only supports 0..255; larger standard reference type
+        # ids (e.g. HasDictionaryEntry = 17597) need FourByte/Numeric.
+        if nodeid <= 255:
+            return ua.TwoByteNodeId(nodeid)
+        if nodeid <= 65535:
+            return ua.FourByteNodeId(nodeid)
+        return ua.NumericNodeId(nodeid)
     if isinstance(nodeid, Node):
         return nodeid.nodeid
     if isinstance(nodeid, ua.NodeId):

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -42,9 +42,6 @@ def _check_results(results: list[ua.StatusCode], reqlen: int = 1) -> None:
 
 def _to_nodeid(nodeid: Node | ua.NodeId | str | int) -> ua.NodeId:
     if isinstance(nodeid, int):
-        # Use NodeId's range-based encoding (TwoByte/FourByte/Numeric).
-        # Plain TwoByteNodeId only allows 0..255; standard reference type ids
-        # such as HasDictionaryEntry (17597) need a wider form (GH-1831).
         return ua.NodeId(nodeid)
     if isinstance(nodeid, Node):
         return nodeid.nodeid

--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -42,14 +42,10 @@ def _check_results(results: list[ua.StatusCode], reqlen: int = 1) -> None:
 
 def _to_nodeid(nodeid: Node | ua.NodeId | str | int) -> ua.NodeId:
     if isinstance(nodeid, int):
-        # Pick the compact NodeId encoding that can hold the identifier.
-        # TwoByteNodeId only supports 0..255; larger standard reference type
-        # ids (e.g. HasDictionaryEntry = 17597) need FourByte/Numeric.
-        if nodeid <= 255:
-            return ua.TwoByteNodeId(nodeid)
-        if nodeid <= 65535:
-            return ua.FourByteNodeId(nodeid)
-        return ua.NumericNodeId(nodeid)
+        # Use NodeId's range-based encoding (TwoByte/FourByte/Numeric).
+        # Plain TwoByteNodeId only allows 0..255; standard reference type ids
+        # such as HasDictionaryEntry (17597) need a wider form (GH-1831).
+        return ua.NodeId(nodeid)
     if isinstance(nodeid, Node):
         return nodeid.nodeid
     if isinstance(nodeid, ua.NodeId):

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -472,9 +472,12 @@ class NodeId:
     def __post_init__(self) -> None:
         if self.NodeIdType is None:
             if isinstance(self.Identifier, int):
-                if self.Identifier < 255 and self.NamespaceIndex == 0:
+                # Match TwoByteNodeId / FourByteNodeId validation bounds:
+                # TwoByte: Identifier 0..255, NamespaceIndex == 0
+                # FourByte: Identifier 0..65535, NamespaceIndex 0..255
+                if self.Identifier <= 255 and self.NamespaceIndex == 0:
                     object.__setattr__(self, "NodeIdType", NodeIdType.TwoByte)
-                elif self.Identifier < 2**16 and self.NamespaceIndex < 255:
+                elif self.Identifier <= 65535 and self.NamespaceIndex <= 255:
                     object.__setattr__(self, "NodeIdType", NodeIdType.FourByte)
                 else:
                     object.__setattr__(self, "NodeIdType", NodeIdType.Numeric)

--- a/asyncua/ua/uatypes.py
+++ b/asyncua/ua/uatypes.py
@@ -472,9 +472,6 @@ class NodeId:
     def __post_init__(self) -> None:
         if self.NodeIdType is None:
             if isinstance(self.Identifier, int):
-                # Match TwoByteNodeId / FourByteNodeId validation bounds:
-                # TwoByte: Identifier 0..255, NamespaceIndex == 0
-                # FourByte: Identifier 0..65535, NamespaceIndex 0..255
                 if self.Identifier <= 255 and self.NamespaceIndex == 0:
                     object.__setattr__(self, "NodeIdType", NodeIdType.TwoByte)
                 elif self.Identifier <= 65535 and self.NamespaceIndex <= 255:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -629,6 +629,32 @@ def test_equal_nodeid():
     assert id(nid1) != id(nid2)
 
 
+
+def test_to_nodeid_int_ranges():
+    """_to_nodeid must encode large integer identifiers (GH-1831).
+
+    Standard reference types such as HasDictionaryEntry (17597) exceed the
+    TwoByteNodeId range and previously raised ValueError.
+    """
+    from asyncua.common.node import _to_nodeid
+
+    n = _to_nodeid(53)
+    assert isinstance(n, ua.TwoByteNodeId)
+    assert n.Identifier == 53
+
+    n = _to_nodeid(256)
+    assert isinstance(n, ua.FourByteNodeId)
+    assert n.Identifier == 256
+
+    n = _to_nodeid(ua.ObjectIds.HasDictionaryEntry)  # 17597
+    assert isinstance(n, (ua.FourByteNodeId, ua.NodeId))
+    assert n.Identifier == 17597
+
+    n = _to_nodeid(70000)
+    assert isinstance(n, ua.NumericNodeId)
+    assert n.Identifier == 70000
+
+
 def test_zero_nodeid():
     assert ua.NodeId() == ua.NodeId(0, 0)
     assert ua.NodeId() == ua.NodeId.from_string("ns=0;i=0;")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -638,21 +638,49 @@ def test_to_nodeid_int_ranges():
     """
     from asyncua.common.node import _to_nodeid
 
-    n = _to_nodeid(53)
-    assert isinstance(n, ua.TwoByteNodeId)
-    assert n.Identifier == 53
+    # Inclusive TwoByte upper bound (0..255)
+    for value in (0, 53, 255):
+        n = _to_nodeid(value)
+        assert n.NodeIdType == ua.NodeIdType.TwoByte
+        assert n.Identifier == value
+        assert n.NamespaceIndex == 0
 
-    n = _to_nodeid(256)
-    assert isinstance(n, ua.FourByteNodeId)
-    assert n.Identifier == 256
+    # FourByte for mid-range identifiers (256..65535), ns=0
+    for value in (256, ua.ObjectIds.HasDictionaryEntry, 65535):
+        n = _to_nodeid(value)
+        assert n.NodeIdType == ua.NodeIdType.FourByte
+        assert n.Identifier == value
 
-    n = _to_nodeid(ua.ObjectIds.HasDictionaryEntry)  # 17597
-    assert isinstance(n, (ua.FourByteNodeId, ua.NodeId))
-    assert n.Identifier == 17597
+    # Numeric for identifiers beyond uint16
+    n = _to_nodeid(65536)
+    assert n.NodeIdType == ua.NodeIdType.Numeric
+    assert n.Identifier == 65536
 
     n = _to_nodeid(70000)
-    assert isinstance(n, ua.NumericNodeId)
+    assert n.NodeIdType == ua.NodeIdType.Numeric
     assert n.Identifier == 70000
+
+
+def test_nodeid_encoding_range_bounds():
+    """NodeId auto-encoding must use inclusive TwoByte/FourByte bounds.
+
+    TwoByteNodeId allows Identifier 0..255; FourByteNodeId allows
+    Identifier 0..65535 and NamespaceIndex 0..255.  The previous
+    NodeId.__post_init__ used strict < checks, so Identifier 255 and
+    NamespaceIndex 255 were classified one encoding wider than needed.
+    """
+    assert ua.NodeId(255).NodeIdType == ua.NodeIdType.TwoByte
+    assert ua.NodeId(256).NodeIdType == ua.NodeIdType.FourByte
+    assert ua.NodeId(65535).NodeIdType == ua.NodeIdType.FourByte
+    assert ua.NodeId(65536).NodeIdType == ua.NodeIdType.Numeric
+
+    # NamespaceIndex 255 still fits in the FourByte namespace byte
+    assert ua.NodeId(1, 255).NodeIdType == ua.NodeIdType.FourByte
+    assert ua.NodeId(1, 256).NodeIdType == ua.NodeIdType.Numeric
+
+    # Subclass constructors stay consistent with auto-guess
+    assert ua.TwoByteNodeId(255).NodeIdType == ua.NodeIdType.TwoByte
+    assert ua.FourByteNodeId(65535, 255).NodeIdType == ua.NodeIdType.FourByte
 
 
 def test_zero_nodeid():


### PR DESCRIPTION
## Summary

Fixes #1831

`_to_nodeid()` always built a `TwoByteNodeId` for `int` inputs. That encoding only allows identifiers `0..255`, so standard reference types such as `HasDictionaryEntry` (`17597`) failed with:

```
ValueError: TwoByteNodeId cannot have identifier > 255
```

when used with `get_referenced_nodes(refs=...)`, `add_reference`, etc.

This breaks dictionary and companion-spec browsing on real servers (Siemens,
Beckhoff TwinCAT, Prosys exports): walking nodes by standard reference type
ObjectId is a routine client pattern and should not require manually
constructing `FourByteNodeId`/`NumericNodeId` wrappers.

Related: #1792 (separate NodeId `from_string`/`to_string` parsing bugs in
the same `uatypes.py` module — not addressed here).

## Changes

- Route integer node ids through `ua.NodeId()`, which selects compact encoding by range
- Fix off-by-one in `NodeId` auto-encoding so bounds match the subclass validators:
  - TwoByte: Identifier `0..255` (was `< 255`)
  - FourByte: Identifier `0..65535`, NamespaceIndex `0..255` (was NamespaceIndex `< 255`)
- Unit regressions for small / mid / large ranges, `ObjectIds.HasDictionaryEntry`, and encoding bounds

## Repro

```python
nodes = await node.get_referenced_nodes(
    refs=ua.ObjectIds.HasDictionaryEntry,
    direction=ua.BrowseDirection.Forward,
)
# ValueError: TwoByteNodeId cannot have identifier > 255
```

## Tests

```bash
pytest tests/test_unit.py::test_to_nodeid_int_ranges tests/test_unit.py::test_nodeid_encoding_range_bounds -q
# 2 passed
```