### PR TITLE
Keep ServerArray in sync when setting application URI

### DIFF
--- a/asyncua/server/server.py
+++ b/asyncua/server/server.py
@@ -273,6 +273,9 @@ class Server:
         your server to a discovery server, it really should be unique in
         your system!
         default is : "urn:freeopcua:python:server"
+
+        Per OPC UA Part 5 §6.3.1, both NamespaceArray[1] and ServerArray[0]
+        shall equal the ApplicationUri.
         """
         self._application_uri = uri
         ns_node = self.get_node(ua.NodeId(ua.ObjectIds.Server_NamespaceArray))
@@ -282,6 +285,15 @@ class Server:
         else:
             uries.append(uri)
         await ns_node.write_value(uries)
+
+        # Keep ServerArray in sync (Part 5 §6.3.1)
+        sa_node = self.get_node(ua.NodeId(ua.ObjectIds.Server_ServerArray))
+        server_array = await sa_node.read_value()
+        if server_array:
+            server_array[0] = uri
+        else:
+            server_array = [uri]
+        await sa_node.write_value(server_array)
 
     async def find_servers(self, uris: list[str] | None = None) -> list[ua.ApplicationDescription]:
         """

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -954,3 +954,15 @@ assert not loaded, loaded
         [sys.executable, "-c", code],
         check=True,
     )
+
+
+async def test_set_application_uri_updates_server_array(server):
+    """set_application_uri must update both NamespaceArray[1] and ServerArray[0] (GH-1966)."""
+    new_uri = "urn:freeopcua:python:server:test_server_array"
+    await server.set_application_uri(new_uri)
+
+    ns = await server.get_node(ua.NodeId(ua.ObjectIds.Server_NamespaceArray)).read_value()
+    sa = await server.get_node(ua.NodeId(ua.ObjectIds.Server_ServerArray)).read_value()
+    assert ns[1] == new_uri
+    assert sa[0] == new_uri
+    assert server.get_application_uri() == new_uri


### PR DESCRIPTION
## Summary

Fixes #1966

`Server.set_application_uri` updated `NamespaceArray[1]` but left `ServerArray[0]` at the default ApplicationUri written during `init()`. After calling `set_application_uri` post-init (as in `server-with-encryption.py`), the two arrays diverged.

OPC UA Part 5 §6.3.1 requires both `NamespaceArray[1]` and `ServerArray[0]` to equal the ApplicationUri. Strict servers, discovery/LDS registration, and certificate SAN matching all consult these values; a mismatch surfaces as failed discovery (#1708), rejected sessions, or trust validation failures on encrypted endpoints.

Related: #1999 (sync wrapper exposure of the same API).
Related: #1708 (LDS/discovery reports ApplicationUri from server metadata).

## Repro

Run `examples/server-with-encryption.py`, then read `Server_NamespaceArray[1]` and
`Server_ServerArray[0]` — they differ on master after `set_application_uri`.

## Changes

- Also write `ServerArray[0]` (or create `[uri]`) inside `set_application_uri`
- Regression test asserting both arrays match after the call

## Tests

```bash
pytest tests/test_server.py::test_set_application_uri_updates_server_array -q
# 1 passed
```