### PR TITLE
Fix XmlImporter._sort_nodes hang on Type-class TypeDefinition cycles

### DIFF
--- a/asyncua/common/xmlimporter.py
+++ b/asyncua/common/xmlimporter.py
@@ -801,6 +801,18 @@ class XmlImporter:
             sorted_ndatas.append(ndata)
             sorted_nodes[nid] = ndata
 
+        # Type-class nodes do not require a resolved TypeDefinition before
+        # themselves; only instance nodes need their typedef ordered first.
+        # TwinCAT / Beckhoff NodeSet exports often attach a TypeDefinition
+        # reference on UA*Type nodes that points at an instance of that type,
+        # which forms a cycle under the instance rule (GH-1996).
+        type_node_kinds = {
+            "UAObjectType",
+            "UAVariableType",
+            "UADataType",
+            "UAReferenceType",
+        }
+
         last_len = 0
         while len(sorted_nodes) < len(ndatas):
             for nid, ndata in all_nodes.items():
@@ -809,7 +821,11 @@ class XmlImporter:
                 if ndata.datatype is not None and ndata.datatype in all_nodes:
                     if ndata.datatype not in sorted_nodes:
                         continue
-                if ndata.typedef is not None and ndata.typedef in all_nodes:
+                if (
+                    ndata.typedef is not None
+                    and ndata.typedef in all_nodes
+                    and ndata.nodetype not in type_node_kinds
+                ):
                     if ndata.typedef not in sorted_nodes:
                         continue
                 if ndata.parent is None or ndata.parent not in all_nodes:
@@ -820,6 +836,7 @@ class XmlImporter:
                     if ndata.parent in sorted_nodes:
                         add_to_sorted(nid, ndata)
             if last_len == len(sorted_nodes):
-                # When no change is found we are in a endlessloop
+                # When no change is found we are in an endless loop
                 raise ValueError("Ordering of nodes is not possible")
+            last_len = len(sorted_nodes)
         return sorted_ndatas

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1201,3 +1201,64 @@ def test_option_set_size():
     assert len(binary) == 2
     val_2 = ua_binary.from_binary(ua.DataSetFieldFlags, ua.utils.Buffer(binary))
     assert val == val_2
+
+
+def test_sort_nodes_progress_check_and_type_class_typedef():
+    """XmlImporter._sort_nodes must not hang and must sort Type-class nodes (GH-1996).
+
+    1. Progress detection: last_len must be updated each iteration so an
+       unresolvable graph raises instead of spinning forever.
+    2. Type-class nodes: a UAObjectType whose typedef points at an instance
+       of itself (TwinCAT export pattern) must still sort.
+    """
+    from asyncua.common.xmlimporter import XmlImporter
+    from asyncua.common.xmlparser import NodeData
+
+    importer = XmlImporter.__new__(XmlImporter)
+
+    # --- Type-class + instance cycle that previously hung ---
+    type_node = NodeData()
+    type_node.nodeid = "ns=1;i=1000"
+    type_node.nodetype = "UAObjectType"
+    type_node.parent = None
+    type_node.typedef = "ns=1;i=1001"  # points at instance (export quirk)
+    type_node.datatype = None
+    type_node.definitions = []
+
+    instance = NodeData()
+    instance.nodeid = "ns=1;i=1001"
+    instance.nodetype = "UAObject"
+    instance.parent = None
+    instance.typedef = "ns=1;i=1000"  # real TypeDefinition of the type
+    instance.datatype = None
+    instance.definitions = []
+
+    sorted_nodes = importer._sort_nodes([type_node, instance])
+    assert {n.nodeid for n in sorted_nodes} == {type_node.nodeid, instance.nodeid}
+    # Type must come before instance (instance depends on typedef)
+    ids = [n.nodeid for n in sorted_nodes]
+    assert ids.index(type_node.nodeid) < ids.index(instance.nodeid)
+
+    # --- Truly unresolvable: mutual parent cycle, no progress ---
+    a = NodeData()
+    a.nodeid = "ns=1;i=1"
+    a.nodetype = "UAObject"
+    a.parent = "ns=1;i=2"
+    a.typedef = None
+    a.datatype = None
+    a.definitions = []
+
+    b = NodeData()
+    b.nodeid = "ns=1;i=2"
+    b.nodetype = "UAObject"
+    b.parent = "ns=1;i=1"
+    b.typedef = None
+    b.datatype = None
+    b.definitions = []
+
+    try:
+        importer._sort_nodes([a, b])
+        raise AssertionError("expected ValueError for unresolvable parent cycle")
+    except ValueError as exc:
+        assert "Ordering of nodes is not possible" in str(exc)
+


### PR DESCRIPTION
## Summary

Fixes #1996

`XmlImporter._sort_nodes` could hang forever on NodeSet2 XML from Beckhoff TwinCAT and similar exporters:

1. **Broken progress check** — `last_len` was set once to `0` and never updated after each iteration. Once any nodes had been sorted, a remaining cycle never triggered the `"Ordering of nodes is not possible"` error and the `while` loop spun forever.
2. **Type-class TypeDefinition dependency** — Instance nodes correctly wait for their `TypeDefinition` target. Type-class nodes (`UAObjectType` / `UAVariableType` / `UADataType` / `UAReferenceType`) do not need that ordering, but TwinCAT exports often attach a `TypeDefinition` reference on type nodes that points at an instance of that type, creating an unresolvable cycle under the instance rule.

**Impact:** On a ~9,000-node TwinCAT NodeSet2 export, the importer hung for 30+ minutes with flat CPU — no error, no progress. This blocks loading Beckhoff/Siemens companion-spec address spaces that are standard in factory automation.

Related: #554 (broader xml import reference ordering — enhancement, not fixed here).

## Changes

- Update `last_len` after each successful progress so stuck graphs raise `ValueError` instead of hanging
- Skip the typedef pre-sort requirement for Type-class nodes
- Unit tests for the TwinCAT-style cycle and for true unresolvable parent cycles

## Tests

```bash
pytest tests/test_unit.py::test_sort_nodes_progress_check_and_type_class_typedef -q
# 1 passed
```