### PR TITLE
Fix certificate example writing CSR instead of signed cert

### DIFF
--- a/examples/generate_certificates.py
+++ b/examples/generate_certificates.py
@@ -88,16 +88,12 @@ async def generate_csr():
         x509.DNSName(f"{HOSTNAME}"),
     ]
 
-    key: RSAPrivateKey = generate_private_key()
     key = await load_private_key(base_private / "myserver.pem")
     csr: x509.CertificateSigningRequest = generate_app_certificate_signing_request(
         key, f"myserver@{HOSTNAME}", NAMES, subject_alt_names, extended=CLIENT_SERVER_USE
     )
 
-    # key_file = base_private / 'myserver.pem'
     csr_file = base_csr / "myserver.csr"
-
-    # key_file.write_bytes(dump_private_key_as_pem(key))
     async with await anyio.open_file(str(csr_file), "wb") as f:
         await f.write(csr.public_bytes(encoding=Encoding.PEM))
 
@@ -107,12 +103,14 @@ async def sign_csr():
     key_ca = await load_private_key(base_private / "ca_application.pem")
     csr_file: Path = base_csr / "myserver.csr"
     async with await anyio.open_file(str(csr_file), "rb") as f:
-        csr = x509.load_pem_x509_csr(f.read_file())
+        csr = x509.load_pem_x509_csr(await f.read())
 
     cert: x509.Certificate = sign_certificate_request(csr, issuer, key_ca, days=30)
 
+    # Write the signed certificate (not the CSR). DER matches the .der path
+    # and generate_self_signed_certificate / generate_applicationgroup_ca.
     async with await anyio.open_file(str(base_certs / "myserver.der"), "wb") as f:
-        await f.write(csr.public_bytes(encoding=Encoding.PEM))
+        await f.write(cert.public_bytes(encoding=Encoding.DER))
 
 
 async def main():

--- a/tests/test_gen_certificates.py
+++ b/tests/test_gen_certificates.py
@@ -242,6 +242,56 @@ async def test_app_sign_certificate_request() -> None:
     )
 
 
+async def test_signed_certificate_written_as_der_not_csr(tmp_path) -> None:
+    """After sign_certificate_request, persist the cert DER — not CSR PEM (GH-1959).
+
+    examples/generate_certificates.py sign_csr() previously wrote
+    csr.public_bytes(PEM) into myserver.der. The signed certificate must be
+    written instead, in DER form to match the .der path and other helpers.
+    """
+    hostname = socket.gethostname()
+    names = {
+        "countryName": "NL",
+        "stateOrProvinceName": "ZH",
+        "localityName": "Foo",
+        "organizationName": "Bar Ltd",
+    }
+    subject_alt_names: list[x509.GeneralName] = [
+        x509.UniformResourceIdentifier(f"urn:{hostname}:foobar:myserver"),
+        x509.DNSName(f"{hostname}"),
+    ]
+    extended = [ExtendedKeyUsageOID.CLIENT_AUTH, ExtendedKeyUsageOID.SERVER_AUTH]
+
+    key_ca = generate_private_key()
+    issuer = generate_self_signed_app_certificate(
+        key_ca, "Application CA", names, subject_alt_names, extended=[], days=365
+    )
+    key_server = generate_private_key()
+    csr = generate_app_certificate_signing_request(
+        key_server, f"myserver@{hostname}", names, subject_alt_names, extended=extended
+    )
+    cert = sign_certificate_request(csr, issuer, key_ca, days=30)
+
+    # Correct pattern used by the fixed example (and generate_self_signed_certificate)
+    out_path = tmp_path / "myserver.der"
+    cert_der = cert.public_bytes(serialization.Encoding.DER)
+    out_path.write_bytes(cert_der)
+
+    # Must not be CSR material (the old bug wrote CSR PEM into the .der path)
+    csr_pem = csr.public_bytes(serialization.Encoding.PEM)
+    csr_der = csr.public_bytes(serialization.Encoding.DER)
+    assert out_path.read_bytes() != csr_pem
+    assert out_path.read_bytes() != csr_der
+    assert out_path.read_bytes() == cert_der
+
+    loaded = await load_certificate(str(out_path))
+    assert loaded.subject == cert.subject
+    assert loaded.issuer == issuer.subject
+    assert loaded.public_key().public_numbers() == csr.public_key().public_numbers()
+    # DER-encoded X.509 cert is not PEM
+    assert not out_path.read_bytes().startswith(b"-----BEGIN")
+
+
 async def test_generate_load_private_key_pem(tmp_path):
     key_path = tmp_path / "cert.pem"
     key = generate_private_key()

--- a/tests/test_gen_certificates.py
+++ b/tests/test_gen_certificates.py
@@ -287,7 +287,15 @@ async def test_signed_certificate_written_as_der_not_csr(tmp_path) -> None:
     loaded = await load_certificate(str(out_path))
     assert loaded.subject == cert.subject
     assert loaded.issuer == issuer.subject
-    assert loaded.public_key().public_numbers() == csr.public_key().public_numbers()
+    loaded_pub = loaded.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    csr_pub = csr.public_key().public_bytes(
+        serialization.Encoding.DER,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    assert loaded_pub == csr_pub
     # DER-encoded X.509 cert is not PEM
     assert not out_path.read_bytes().startswith(b"-----BEGIN")
 


### PR DESCRIPTION
## Summary

Fixes #1959

`examples/generate_certificates.py` `sign_csr()` wrote the **CSR** public bytes (PEM) into `myserver.der` instead of the **signed certificate**. That left the example producing a non-certificate payload and ignored the result of `sign_certificate_request`.

Anyone following this example to stand up PKI for encrypted OPC UA (plant-floor servers,
CA-signed app certs) gets a `.der` file that is not an X.509 certificate. Downstream
`load_certificate()` / trust-store setup then fails or, worse, misconfigures security
policies — symptoms overlap with encrypted-session failures reported in #1797.

Related: #1921 (encryption/authorization documentation gap for the example ecosystem).

## Changes

- Write `cert.public_bytes(Encoding.DER)` to `myserver.der` (matches other helpers in the same file)
- Load the CSR with `await f.read()` (async file API; `f.read_file()` is invalid)
- Drop redundant `generate_private_key()` in `generate_csr()` that was immediately overwritten by `load_private_key`
- Regression test: signed cert is written as DER, reloads as X.509, and is not CSR material

## Tests

```bash
pytest tests/test_gen_certificates.py::test_signed_certificate_written_as_der_not_csr -q
# 1 passed
```

Smoke-ran the example after the fix:

```bash
python examples/generate_certificates.py
# myserver.der loads as x509 DER cert; issuer is Application CA;
# cert public key matches CSR public key
```