### PR TITLE
fix: stop read_raw_history looping on a repeated continuation point

### DIFF
--- a/asyncua/common/node.py
+++ b/asyncua/common/node.py
@@ -701,12 +701,17 @@ class Node:
         history = []
         continuation_point = None
         while True:
+            previous_continuation_point = continuation_point
             result = await self.history_read(details, continuation_point)
             result.StatusCode.check()
             continuation_point = result.ContinuationPoint
             history.extend(result.HistoryData.DataValues)  # type: ignore[attr-defined]
             # No more data available
             if continuation_point is None:
+                break
+            # Server is not making progress: it returned the same continuation
+            # point again, so continuing would loop forever
+            if continuation_point == previous_continuation_point:
                 break
             # No more data needed
             if numvalues > 0:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -2,6 +2,9 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
+from asyncua import ua
+from asyncua.common.node import Node
+
 pytestmark = pytest.mark.asyncio
 
 
@@ -115,3 +118,31 @@ async def test_history_var_read_3_with_end(history_server):
     assert 3 == len(res)
     assert res[2].Value.Value == history_server.values[-3]
     assert res[0].Value.Value == history_server.values[-1]
+
+
+async def test_history_var_read_repeated_continuation_point():
+    """
+    Some servers do not treat numvalues=0 as "as many as you can" and answer
+    with no data plus the same continuation point over and over. read_raw_history
+    must not loop forever on such a server.
+    """
+
+    class _StuckServerNode(Node):
+        def __init__(self):
+            self.calls = 0
+
+        async def history_read(self, details, continuation_point=None):
+            self.calls += 1
+            if self.calls > 10:
+                raise AssertionError("read_raw_history did not stop on a repeated continuation point")
+            result = ua.HistoryReadResult()
+            result.StatusCode = ua.StatusCode(ua.StatusCodes.Good)
+            result.ContinuationPoint = b"\x00\x00\x01\x9d"
+            result.HistoryData = ua.HistoryData()
+            result.HistoryData.DataValues = []
+            return result
+
+    node = _StuckServerNode()
+    res = await node.read_raw_history(numvalues=0)
+    assert [] == res
+    assert 2 == node.calls


### PR DESCRIPTION
Closes #1958

Some servers do not treat `NumValuesPerNode=0` as "as many values as you can" and instead answer with an empty `DataValues` list plus the *same* `ContinuationPoint` on every call. `read_raw_history` only stopped on a `None` continuation point (or when `numvalues > 0`), so against such a server the loop never terminated.

The fix breaks out when the server hands back the continuation point it already gave us, i.e. when it is making no progress. Added a regression test that drives `read_raw_history` against a stub node returning a fixed continuation point; it hangs/asserts without the change and passes with it.
