### PR TITLE
fix(server): trigger keep-alive at RevisedMaxKeepAliveCount

### DIFF
--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -127,14 +127,14 @@ class InternalSubscription:
     def has_published_results(self) -> bool:
         if self._startup or self._triggered_datachanges or self._triggered_events:
             return True
-        if self._keep_alive_count > self.data.RevisedMaxKeepAliveCount:
+        self._keep_alive_count += 1
+        if self._keep_alive_count >= self.data.RevisedMaxKeepAliveCount:
             self.logger.debug(
-                "keep alive count %s is > than max keep alive count %s, sending publish event",
+                "keep alive count %s reached max keep alive count %s, sending publish event",
                 self._keep_alive_count,
                 self.data.RevisedMaxKeepAliveCount,
             )
             return True
-        self._keep_alive_count += 1
         return False
 
     async def publish_results(self, requestdata: PublishRequestData | None = None) -> bool:

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1316,3 +1316,25 @@ def test_sort_nodes_progress_check_and_type_class_typedef():
     except ValueError as exc:
         assert "Ordering of nodes is not possible" in str(exc)
 
+
+@pytest.mark.parametrize("max_keep_alive_count", [1, 2, 3])
+def test_keep_alive_triggers_at_max_keep_alive_count(max_keep_alive_count):
+    """A keep-alive must be sent on the RevisedMaxKeepAliveCount-th idle cycle."""
+    from asyncua.server.address_space import AddressSpace
+    from asyncua.server.internal_subscription import InternalSubscription
+
+    async def _callback(*args, **kwargs):
+        pass
+
+    data = ua.CreateSubscriptionResult()
+    data.SubscriptionId = 1
+    data.RevisedPublishingInterval = 100.0
+    data.RevisedMaxKeepAliveCount = max_keep_alive_count
+    data.RevisedLifetimeCount = 10000
+    sub = InternalSubscription(data, AddressSpace(), _callback, ua.NodeId(1))
+    # skip the initial publish that is always sent on startup
+    sub._startup = False
+
+    for cycle in range(1, max_keep_alive_count):
+        assert not sub.has_published_results(), f"unexpected keep-alive on cycle {cycle}"
+    assert sub.has_published_results()


### PR DESCRIPTION
Closes #1965

`has_published_results()` compared the keep-alive counter with `> RevisedMaxKeepAliveCount` and only incremented it *after* the check, so a keep-alive PublishResponse was emitted two publishing cycles late (with `RevisedMaxKeepAliveCount=1` it fired on cycle 3, not cycle 1). Incrementing before the comparison and using `>=` makes it fire on the RevisedMaxKeepAliveCount-th idle cycle, which is what strict clients expect.

Added a parametrized test over MaxKeepAliveCount 1/2/3; it fails 3/3 on master and passes with the fix.
