### PR TITLE
fix(server): refresh names in Browse ReferenceDescription

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -147,8 +147,30 @@ class ViewService:
         for ref in node.references:
             if not self._is_suitable_ref(desc, ref):
                 continue
-            res.References.append(ref)
+            res.References.append(self._refresh_ref(ref))
         return res
+
+    def _refresh_ref(self, ref: ua.ReferenceDescription) -> ua.ReferenceDescription:
+        """Return `ref` with BrowseName/DisplayName taken from the target node.
+
+        The values stored on a ReferenceDescription are a snapshot taken when the
+        reference was created, so a later write to the target's BrowseName or
+        DisplayName attribute would otherwise never show up in Browse results.
+        """
+        target = self._aspace.get(ref.NodeId)
+        if target is None:
+            return ref
+        changes = {}
+        for name, attr in (("BrowseName", ua.AttributeIds.BrowseName), ("DisplayName", ua.AttributeIds.DisplayName)):
+            attval = target.attributes.get(attr)
+            if attval is None or attval.value is None or attval.value.Value is None:
+                continue
+            current = attval.value.Value.Value
+            if current is not None and current != getattr(ref, name):
+                changes[name] = current
+        if not changes:
+            return ref
+        return dataclasses.replace(ref, **changes)
 
     def _is_suitable_ref(self, desc: ua.BrowseDescription, ref: ua.ReferenceDescription) -> bool:
         if not self._suitable_direction(desc.BrowseDirection, ref.IsForward):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -959,6 +959,25 @@ async def test_incl_subtypes(opc):
     assert 0 == len(descs)
 
 
+async def test_browse_reflects_written_display_name(opc):
+    objects = opc.opc.nodes.objects
+    f = await objects.add_folder(3, "MyFolder_BrowseRefresh")
+    o = await f.add_object(3, "MyObject_BrowseRefresh", ua.ObjectIds.BaseObjectType)
+
+    await o.write_attribute(
+        ua.AttributeIds.DisplayName,
+        ua.DataValue(ua.Variant(ua.LocalizedText("Renamed"), ua.VariantType.LocalizedText)),
+    )
+
+    descs = await f.get_children_descriptions()
+    desc = next(d for d in descs if d.NodeId == o.nodeid)
+    assert ua.LocalizedText("Renamed") == desc.DisplayName
+    # refreshing the name must not drop the other reference fields
+    assert ua.NodeId(ua.ObjectIds.BaseObjectType) == desc.TypeDefinition
+
+    await opc.opc.delete_nodes([o, f])
+
+
 async def test_add_node_with_type(opc):
     objects = opc.opc.nodes.objects
     f = await objects.add_folder(3, "MyFolder_TypeTest")


### PR DESCRIPTION
Closes #1903

A `ReferenceDescription` stores a snapshot of the target node's `BrowseName`/`DisplayName` taken when the reference is created, so writing the target's DisplayName attribute later updated the attribute store but not the reference — `Browse` kept returning the original name (and the reporter's delete/re-add workaround lost `TypeDefinition`).

`ViewService._browse` now reads both names from the target node before returning each reference, leaving every other reference field untouched. New `test_browse_reflects_written_display_name` in `tests/test_common.py` fails without the change and passes with it; it also asserts `TypeDefinition` survives.
