### PR TITLE
fix(server): do not report values for monitored items created in Disabled mode

### DIFF
--- a/asyncua/server/monitored_item_service.py
+++ b/asyncua/server/monitored_item_service.py
@@ -176,7 +176,8 @@ class MonitoredItemService:
         self._commit_monitored_item(result, mdata)
         if result.StatusCode.is_good():
             self._monitored_datachange[handle] = result.MonitoredItemId
-            await self.trigger_datachange(handle, params.ItemToMonitor.NodeId, params.ItemToMonitor.AttributeId)
+            if mdata.mode != ua.MonitoringMode.Disabled:
+                await self.trigger_datachange(handle, params.ItemToMonitor.NodeId, params.ItemToMonitor.AttributeId)
         return result
 
     def delete_monitored_items(self, ids: list[int]) -> list[ua.StatusCode]:
@@ -243,6 +244,8 @@ class MonitoredItemService:
             event = ua.MonitoredItemNotification()
             mid = self._monitored_datachange[handle]
             mdata = self._monitored_items[mid]
+            if mdata.mode == ua.MonitoringMode.Disabled:
+                return
             mdata.mvalue.set_current_datavalue(value)
             if mdata.filter:
                 deadband_flag_pass = self._is_data_changed(

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -340,6 +340,25 @@ async def test_set_monitoring_mode(opc, mocker):
     await sub.delete()
 
 
+async def test_monitored_item_created_disabled_does_not_report(opc):
+    """
+    A monitored item created with MonitoringMode.Disabled must not be reported.
+    """
+    myhandler = MySubHandlerCounter()
+    o = opc.opc.nodes.objects
+    v = await o.add_variable(3, "SubscriptionVariableDisabled", 123)
+    sub = await opc.opc.create_subscription(100, myhandler)
+    handle = await sub.subscribe_data_change(v, monitoring=ua.MonitoringMode.Disabled)
+    await sleep(0.3)
+    assert myhandler.datachange_count == 0
+    await v.write_value(456)
+    await sleep(0.3)
+    assert myhandler.datachange_count == 0
+    await sub.unsubscribe(handle)
+    await sub.delete()
+    await opc.opc.delete_nodes([v])
+
+
 @pytest.mark.parametrize("opc", ["client"], indirect=True)
 async def test_set_publishing_mode(opc, mocker):
     """


### PR DESCRIPTION
Closes #1913

A MonitoredItem created with `MonitoringMode.Disabled` was reported anyway: `_create_data_change_monitored_item` unconditionally called `trigger_datachange` after committing the item, and `datachange_callback` queued every later change regardless of the item's mode. Part 4 [5.13.1.3](https://reference.opcfoundation.org/Core/Part4/v105/docs/5.13.1.3) says the first sample is reported when the item is created enabled (or enabled later), so a disabled item must stay silent. Both paths now check `mdata.mode`, which `_make_monitored_item_common` already populates from the request.

Note this fixes only the first half of the issue — the server still has no `SetMonitoringMode` implementation (`uaprocessor.py` returns dummy Good results), so enabling a disabled item later still does not emit an initial value. That needs a separate change.

`test_monitored_item_created_disabled_does_not_report` in `tests/test_subscriptions.py` fails without the fix and passes with it.
