### PR TITLE
Keep sync Client ThreadLoop alive across disconnects

### DIFF
--- a/asyncua/sync.py
+++ b/asyncua/sync.py
@@ -18,6 +18,7 @@ from typing import Any, Literal, TypeVar, overload
 from cryptography import x509
 
 from asyncua import client, common, server, ua
+from asyncua.client.ua_client import UaClientState
 from asyncua.common import node, shortcuts, subscription, type_dictionary_builder, xmlexporter
 from asyncua.common.events import Event
 from asyncua.crypto import uacrypto
@@ -239,6 +240,9 @@ class Client:
     the sync client has one extra parameter: sync_wrapper_timeout.
     if no ThreadLoop is provided this timeout is used to define how long the sync wrapper
     waits for an async call to return. defualt is 120s and hopefully should fit most applications
+
+    Disconnecting keeps the ThreadLoop alive for later reconnects. Call close
+    when the client is no longer needed.
     """
 
     def __init__(
@@ -258,6 +262,10 @@ class Client:
         self.aio_obj: client.Client = client.Client(url, timeout, watchdog_intervall)
         self.nodes: Shortcuts = Shortcuts(self.tloop, self.aio_obj.uaclient)
 
+    def _stop_owned_tloop(self) -> None:
+        if self.close_tloop and self.tloop.is_alive():
+            self.tloop.stop()
+
     def __str__(self) -> str:
         return "Sync" + self.aio_obj.__str__()
 
@@ -275,31 +283,29 @@ class Client:
     def connect(self) -> None: ...
 
     def disconnect(self) -> None:
-        try:
-            self.tloop.post(self.aio_obj.disconnect())
-        finally:
-            if self.close_tloop:
-                self.tloop.stop()
+        self.tloop.post(self.aio_obj.disconnect())
 
     @syncmethod
     def connect_sessionless(self) -> None: ...
 
     def disconnect_sessionless(self) -> None:
-        try:
-            self.tloop.post(self.aio_obj.disconnect_sessionless())
-        finally:
-            if self.close_tloop:
-                self.tloop.stop()
+        self.tloop.post(self.aio_obj.disconnect_sessionless())
 
     @syncmethod
     def connect_socket(self) -> None: ...
 
     def disconnect_socket(self) -> None:
+        self.aio_obj.disconnect_socket()
+
+    def close(self) -> None:
+        """Disconnect and stop the internally owned ThreadLoop, if any."""
+        if not self.tloop.is_alive():
+            return
         try:
-            self.aio_obj.disconnect_socket()
+            if self.aio_obj.state is not UaClientState.DISCONNECTED:
+                self.tloop.post(self.aio_obj.disconnect())
         finally:
-            if self.close_tloop:
-                self.tloop.stop()
+            self._stop_owned_tloop()
 
     def set_user(self, username: str) -> None:
         self.aio_obj.set_user(username)
@@ -499,15 +505,15 @@ class Client:
     def __enter__(self) -> Client:
         try:
             self.connect()
-        except Exception as ex:
-            self.disconnect()
-            raise ex
+        except Exception:
+            self.close()
+            raise
         return self
 
     def __exit__(
         self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None
     ) -> None:
-        self.disconnect()
+        self.close()
 
 
 class Shortcuts:

--- a/docs/usage/sync/overview.rst
+++ b/docs/usage/sync/overview.rst
@@ -7,3 +7,27 @@ the package in code which is not using ``asyncio``? The :mod:`asyncua.sync` modu
 a convenient wrapper around the client and server and provides synchronous versions of
 the node and subscription classes. This allows direct usage of the package, using the same
 interface as for ``async`` code, without writing custom wrappers.
+
+Client lifecycle
+================
+
+Disconnecting a sync Client keeps its ThreadLoop running so that the Client can connect
+again later. Close the Client explicitly when it is no longer needed:
+
+.. code-block:: python
+
+   from asyncua.sync import Client
+
+   client = Client("opc.tcp://localhost:4840")
+   try:
+       client.connect()
+       value = client.nodes.server_state.read_value()
+       client.disconnect()
+
+       client.connect()
+       value = client.nodes.server_state.read_value()
+       client.disconnect()
+   finally:
+       client.close()
+
+A ThreadLoop supplied by the caller is never stopped by the Client.

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -257,6 +257,68 @@ def test_sync_client_no_tl(client_no_tloop, idx):
     test_sync_meth(client_no_tloop, idx)
 
 
+def test_sync_client_reuses_owned_tloop_across_disconnects(server):
+    client = Client(f"opc.tcp://admin@localhost:{port_num}/freeopcua/server")
+    tloop = client.tloop
+    try:
+        client.connect()
+        server_state = client.nodes.server_state
+        assert server_state.read_value() == ua.ServerState.Running
+
+        client.disconnect()
+        assert client.tloop is tloop
+        assert tloop.is_alive()
+
+        client.connect()
+        assert client.tloop is tloop
+        assert server_state.read_value() == ua.ServerState.Running
+
+        client.disconnect()
+        assert tloop.is_alive()
+    finally:
+        client.close()
+
+    client.close()
+    assert not tloop.is_alive()
+
+
+def test_sync_client_context_manager_closes_owned_tloop(server):
+    client = Client(f"opc.tcp://admin@localhost:{port_num}/freeopcua/server")
+
+    with client:
+        assert client.tloop.is_alive()
+
+    assert not client.tloop.is_alive()
+
+
+def test_sync_client_close_does_not_stop_external_tloop(tloop, server):
+    client = Client(
+        f"opc.tcp://admin@localhost:{port_num}/freeopcua/server",
+        tloop=tloop,
+    )
+
+    client.connect()
+    client.close()
+    assert tloop.is_alive()
+
+
+@pytest.mark.parametrize(
+    ("connect_method", "disconnect_method"),
+    [
+        ("connect_sessionless", "disconnect_sessionless"),
+        ("connect_socket", "disconnect_socket"),
+    ],
+)
+def test_sync_client_partial_disconnect_keeps_owned_tloop(server, connect_method, disconnect_method):
+    client = Client(f"opc.tcp://admin@localhost:{port_num}/freeopcua/server")
+    try:
+        getattr(client, connect_method)()
+        getattr(client, disconnect_method)()
+        assert client.tloop.is_alive()
+    finally:
+        client.close()
+
+
 def test_sync_call_meth(client, idx):
     methodid = client.nodes.objects.get_child(f"{idx}:Divide")
     res = call_method_full(client.tloop, client.nodes.objects, methodid, 4, 2)


### PR DESCRIPTION
Fixes #1364.
Supersedes #1503.

`sync.Client.disconnect()` currently also stops an internally created
`ThreadLoop`, so connecting the same Client again raises
`ThreadLoopNotRunning`.

This PR separates the connection lifecycle from the sync-wrapper lifecycle:

- `disconnect()` tears down the OPC UA connection but keeps the ThreadLoop alive
- `close()` disconnects and stops an internally owned ThreadLoop
- caller-provided ThreadLoops remain owned by the caller
- the Client context manager performs final cleanup through `close()`

Keeping the same ThreadLoop also preserves the loop references held by existing
`SyncNode` and other sync wrapper objects.