### PR TITLE
Fully migrate to `cryptography` from `pyOpenSSL`

### DIFF
--- a/asyncua/crypto/truststore.py
+++ b/asyncua/crypto/truststore.py
@@ -3,46 +3,57 @@ Functionality for checking a certificate based on:
 - trusted (ca) certificates
 - crl
 
-Use of cryptography module is prefered, but  doesn't provide functionality for truststores yet, so for some we rely on using pyOpenSSL.
-
 """
 
 import logging
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 
+import anyio
 from cryptography import x509
-from OpenSSL import crypto
 
 from asyncua.crypto.uacrypto import get_content, load_certificate
 
 _logger = logging.getLogger("asyncuagds.validate")
 
 
+def basic_ca_validator(_policy: x509.verification.Policy, _cert: x509.Certificate, ext: x509.BasicConstraints) -> None:
+    if not ext.ca:
+        raise ValueError("CA certificate must contain a basicConstraints extension with ca=true")
+
+
 class TrustStore:
     """
     TrustStore is used to validate certificates in two ways:
     - Based on being absent in provided certificate revocation lists
-    - The certificate or its issuer being  present in a list of trusted certificates
+    - The certificate or its issuer being present in a list of trusted certificates
 
-    It doesn't check other content of extensions of the certificate
+    It doesn't check other content of extensions of the certificate.
     """
 
-    def __init__(self, trust_locations: list[Path], crl_locations: list[Path]):
-        """Constructor of the TrustStore
+    def __init__(self, trust_locations: list[Path], crl_locations: list[Path]) -> None:
+        """Constructor of the TrustStore.
 
         Args:
-            trust_locations (list[Path]): one or multiple locations that contain trusted (ca) certificates. Type should be DER.
-            crl_locations (list[Path]): one or multiple locations that contain CRL. TYpe should be DER.
+            trust_locations (list[Path]): one or multiple locations that contain trusted (ca) certificates.
+                Type should be PEM or DER.
+            crl_locations (list[Path]): one or multiple locations that contain CRL. Type should be PEM or DER.
         """
 
         self._trust_locations: list[Path] = trust_locations
         self._crl_locations: list[Path] = crl_locations
 
-        self._trust_store: crypto.X509Store = crypto.X509Store()
-
+        self._trust_store: x509.verification.Store | None = None
         self._revoked_list: list[x509.RevokedCertificate] = []
+
+        self.policy_builder = x509.verification.PolicyBuilder().extension_policies(
+            ca_policy=x509.verification.ExtensionPolicy.permit_all().require_present(
+                x509.BasicConstraints,
+                x509.verification.Criticality.AGNOSTIC,
+                basic_ca_validator,
+            ),
+            ee_policy=x509.verification.ExtensionPolicy.permit_all(),
+        )
 
     @property
     def trust_locations(self) -> list[Path]:
@@ -52,138 +63,121 @@ class TrustStore:
     def crl_locations(self) -> list[Path]:
         return self._crl_locations
 
-    async def load(self):
-        """(re)load both the trusted certificates and revoctions lists"""
+    async def load(self) -> None:
+        """(Re)load both the trusted certificates and revocation lists."""
         await self.load_trust()
         await self.load_crl()
 
-    async def load_trust(self):
-        """(re)load the trusted certificates"""
-        self._trust_store = crypto.X509Store()
+    async def load_trust(self) -> None:
+        """(Re)load the trusted certificates."""
+        certs: list[x509.Certificate] = []
         for location in self._trust_locations:
-            await self._load_trust_location(location)
+            certs.extend(await self._load_trust_location(location))
+        self._trust_store = x509.verification.Store(certs)
 
-    async def load_crl(self):
-        """(re)load the certificate revocation lists"""
-        self._revoked_list.clear()
+    async def load_crl(self) -> None:
+        """(Re)load the certificate revocation lists."""
+        revoked: list[x509.RevokedCertificate] = []
         for location in self._crl_locations:
-            await self._load_crl_location(location)
+            revoked.extend(await self._load_crl_location(location))
+        self._revoked_list = revoked
 
     def validate(self, certificate: x509.Certificate) -> bool:
-        """Validates if a certificate is trusted, not revoked and lays in valid datarange
+        """Validates if a certificate is trusted, not revoked and lays in valid date range.
 
         Args:
-            certificate (x509.Certificate): Certificate to check
-
-        Returns:
-            bool: Returns True when the certificate is valid
+            certificate (x509.Certificate): Certificate to check.
         """
 
-        return (
-            self.is_trusted(certificate)
-            and self.is_revoked(certificate) is False
-            and self.check_date_range(certificate)
-        )
-
-    def check_date_range(self, certificate: x509.Certificate) -> bool:
-        """Checks if the certificate not_valid_before_utc and not_valid_after_utc are valid.
-
-        Args:
-            certificate (x509.Certificate): Certificate to check
-
-        Returns:
-            bool: Returns True when the now lays in valid range of the certificate
-        """
-        valid: bool = True
-        now = datetime.now(timezone.utc)
-        if certificate.not_valid_after_utc < now:
-            _logger.error("certificate is no longer valid: valid until %s", certificate.not_valid_after_utc)
-            valid = False
-        if certificate.not_valid_before_utc > now:
-            _logger.error("certificate is not yet vaild: valid after %s", certificate.not_valid_before_utc)
-            valid = False
-        return valid
+        return self.is_trusted(certificate) and not self.is_revoked(certificate)
 
     def is_revoked(self, certificate: x509.Certificate) -> bool:
-        """Check if the provided certifcate is in the revocation lists
+        """Check if the certificate is in the revocation lists.
 
-        when not CRLs are present it the certificate is considere not revoked.
+        If no CRL is present, the certificate is not considered revoked.
 
         Args:
-            certificate (x509.Certificate): Certificate to check
-
-        Returns:
-            bool: True when it is on a revocation list. If no list is present also return False.
+            certificate (x509.Certificate): Certificate to check.
         """
         is_revoked = False
         for revoked in self._revoked_list:
             if revoked.serial_number == certificate.serial_number:
-                subject_cn = certificate.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)[0].value
+                subject_cn = (
+                    cn[0].value
+                    if (cn := certificate.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME))
+                    else None
+                )
                 _logger.warning('Found revoked serial "%s" [CN=%s]', hex(certificate.serial_number), subject_cn)
                 is_revoked = True
                 break
         return is_revoked
 
     def is_trusted(self, certificate: x509.Certificate) -> bool:
-        """Check if the provided certifcate is considered trusted
+        """Check if the provided certificate is considered trusted.
+
         For a self-signed to be trusted is must be placed in the trusted location
+
         Args:
             certificate (x509.Certificate): Certificate to check
-
-        Returns:
-            bool: True when it is trusted or the trust store is empty.
         """
-        # TODO: return True when trust store is empty
-        _certificate: crypto.X509 = crypto.X509.from_cryptography(certificate)
-        store_ctx = crypto.X509StoreContext(self._trust_store, _certificate)
+        if not self._trust_store:
+            return False
+
+        verifier = self.policy_builder.store(self._trust_store).build_client_verifier()
         try:
-            store_ctx.verify_certificate()
-            _logger.debug("Use trusted certificate : '%s'", _certificate.get_subject().CN)
+            verifier.verify(certificate, [])
+            _logger.debug(
+                "Use trusted certificate: [CN=%s]",
+                cn[0].value if (cn := certificate.subject.get_attributes_for_oid(x509.OID_COMMON_NAME)) else None,
+            )
             return True
-        except crypto.X509StoreContextError:
-            _logger.exception('Not trusted certificate used: "%s"', _certificate.get_subject().CN)
+        except x509.verification.VerificationError:
+            _logger.exception(
+                "Not trusted certificate used: [CN=%s]",
+                cn[0].value if (cn := certificate.subject.get_attributes_for_oid(x509.OID_COMMON_NAME)) else None,
+            )
         return False
 
-    async def _load_trust_location(self, location: Path):
-        """Load from a single directory location the certificates and add those to the truststore
+    async def _load_trust_location(self, location: Path) -> list[x509.Certificate]:
+        """Load from a single directory location the certificates and return them.
 
         Args:
-            location (Path): location to scan for certificates
+            location (Path): location to scan for certificates.
         """
-        files = Path(location).glob("*.*")  # noqa: ASYNC240
-        for file_name in files:
+        certs: list[x509.Certificate] = []
+        files = anyio.Path(location).glob("*.*")
+        async for file_name in files:
             if re.match(".*(der|pem)", file_name.name.lower()):
                 _logger.debug("Add certificate to TrustStore : '%s'", file_name)
-                trusted_cert: crypto.X509 = crypto.X509.from_cryptography(await load_certificate(file_name))
-                self._trust_store.add_cert(trusted_cert)
+                certs.append(await load_certificate(Path(file_name)))
+        return certs
 
-    async def _load_crl_location(self, location: Path):
-        """Load from a single directory location the CRLs and add the revoked serials to the central CRL list.
+    async def _load_crl_location(self, location: Path) -> list[x509.RevokedCertificate]:
+        """Load from a single directory location the CRLs and return certificates revoked by them.
 
         Args:
-            location (Path): location to scan for crls
+            location (Path): location to scan for crls.
         """
-        files = Path(location).glob("*.*")  # noqa: ASYNC240
-        for file_name in files:
+        revoked: list[x509.RevokedCertificate] = []
+        files = anyio.Path(location).glob("*.*")
+        async for file_name in files:
             if re.match(".*(der|pem)", file_name.name.lower()):
                 _logger.debug("Add CRL to list : '%s'", file_name)
-                crl = await self._load_crl(file_name)
-
-                for revoked in crl:
-                    self._revoked_list.append(revoked)
+                crl = await self._load_crl(Path(file_name))
+                revoked.extend(crl)
+        return revoked
 
     @staticmethod
     async def _load_crl(crl_file_name: Path) -> x509.CertificateRevocationList:
-        """Load a single crl from file
+        """Load a single CRL from file.
 
         Args:
             crl_file_name (Path): file to load
 
         Returns:
-            x509.CertificateRevocationList: Return loaded CRL
+            x509.CertificateRevocationList: Loaded CRL
         """
         content = await get_content(crl_file_name)
         if crl_file_name.suffix.lower() == ".der":
             return x509.load_der_x509_crl(content)
-
         return x509.load_pem_x509_crl(content)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,7 @@ classifiers = [
 dependencies = [
   "aiosqlite",
   "anyio",
-  "cryptography>42.0.0",
-  "pyOpenSSL>23.2.0",
+  "cryptography>=45.0.0",
   "python-dateutil",
   "pytz",
   "sortedcontainers",
@@ -65,7 +64,6 @@ dev = [
   "pytest-mock",
   "pytest-repeat",
   "ruff",
-  "types-pyOpenSSL",
   "types-python-dateutil",
   "types-pytz",
 ]

--- a/tests/test_truststore.py
+++ b/tests/test_truststore.py
@@ -175,7 +175,27 @@ async def test_ca_in_trust_store(cert_files, trust_store) -> None:
     await trust_store.load()
 
     cert_server: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_FILE)
-    assert trust_store.is_trusted(cert_server) is True
+    assert trust_store.is_trusted(cert_server)
+
+
+async def test_cert_expired(cert_files: Path, trust_store: TrustStore) -> None:
+    shutil.copyfile(cert_files / CA_CERT_FILE, trust_store.trust_locations[0] / CA_CERT_FILE)
+    trust_store.policy_builder = trust_store.policy_builder.time(
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=20 * 365)  # ~20 years
+    )
+
+    cert_server: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_FILE)
+    assert not trust_store.is_trusted(cert_server)
+
+
+async def test_cert_not_yet_valid(cert_files: Path, trust_store: TrustStore) -> None:
+    shutil.copyfile(cert_files / CA_CERT_FILE, trust_store.trust_locations[0] / CA_CERT_FILE)
+    trust_store.policy_builder = trust_store.policy_builder.time(
+        datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=20 * 365)  # ~20 years
+    )
+
+    cert_server: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_FILE)
+    assert not trust_store.is_trusted(cert_server)
 
 
 async def test_empty_crl(cert_files, trust_store) -> None:
@@ -185,11 +205,9 @@ async def test_empty_crl(cert_files, trust_store) -> None:
 
     cert_server: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_FILE)
 
-    assert trust_store.is_trusted(cert_server) is True
-    assert trust_store.is_revoked(cert_server) is False
-    assert trust_store.check_date_range(cert_server) is True
-
-    assert trust_store.validate(cert_server) is True
+    assert trust_store.is_trusted(cert_server)
+    assert not trust_store.is_revoked(cert_server)
+    assert trust_store.validate(cert_server)
 
 
 async def test_cert_in_crl(cert_files, trust_store) -> None:
@@ -199,8 +217,7 @@ async def test_cert_in_crl(cert_files, trust_store) -> None:
 
     cert_server: x509.Certificate = await load_certificate(cert_files / SERVER_CERT_FILE)
 
-    assert trust_store.is_trusted(cert_server) is True
-    assert trust_store.is_revoked(cert_server) is True
-    assert trust_store.check_date_range(cert_server) is True
+    assert trust_store.is_trusted(cert_server)
+    assert trust_store.is_revoked(cert_server)
 
-    assert trust_store.validate(cert_server) is False
+    assert not trust_store.validate(cert_server)


### PR DESCRIPTION
# Fully migrate to `cryptography` from `pyOpenSSL`
Replaces remaining usages of `pyOpenSSL` library for trust store handling with the corresponding functionality from `cryptography` library.

The replacement is not absolutely identical as `cryptography` takes a bit different approach to enforcing some constraints, but the changes should be practically the same for most of users.

## Key changes
-  `X509Store` -> `Store`,  `X509StoreContext` -> `ClientVerifier`(created by the `PolicyBuilder`)
- `cryptography`'s verifier checks for basic integrity, signatures, and the _date range_, therefore the manual check is not needed anymore
- `cryptography`'s policy builder by default enforces some extension checks according to the CA/B Forum guidelines. For the sake of compatibility those checks are disabled (see occurrences of `ExtensionPolicy.permit_all()`). But policy builder unconditionally enforces CA certificates to include the `basicConstraint` extension (with any criticality). It seems to me that if CA certificate contains that extension, then it must have the `ca` field set to true, therefore this behavior is also enforced
- policy builder is left as a public field on the trust store object, so that the caller can configure any extra checks on it if they want to do so
- `pyOpenSSL` library dependency is removed
- small modifications on how the certificates and CRLs are read

## Other notes
- as the policy builder can perform all those checks (when configured to), it would be nice to use them instead of the checks in the `CertificateValidator` class, but for now there is no way to reliably programatically distinguish the reason of the failed verification (verifier raises VerificationException for all the errors)
- it would be nice to load the certificates and CRLs here concurrently with the `TaskGroup` since python 3.11