### PR TITLE
fix: bracket IPv6 addresses in discovery endpoint URLs

### DIFF
--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -268,7 +268,10 @@ class InternalServer:
             if netloc:
                 return url._replace(netloc=netloc).geturl()
         if self.match_discovery_source_ip and sockname:
-            return url._replace(netloc=sockname[0] + ":" + str(sockname[1])).geturl()
+            host, port = sockname[0], sockname[1]
+            if ":" in host and not host.startswith("["):
+                host = f"[{host}]"
+            return url._replace(netloc=f"{host}:{port}").geturl()
         return url.geturl()
 
     async def get_endpoints(

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1349,3 +1349,16 @@ def test_keep_alive_triggers_at_max_keep_alive_count(max_keep_alive_count):
     for cycle in range(1, max_keep_alive_count):
         assert not sub.has_published_results(), f"unexpected keep-alive on cycle {cycle}"
     assert sub.has_published_results()
+
+
+def test_mangle_endpoint_url_brackets_ipv6():
+    from asyncua.server.internal_server import InternalServer
+
+    isrv = InternalServer()
+    base = "opc.tcp://localhost:4840/freeopcua/server/"
+    ipv6 = isrv._mangle_endpoint_url(base, sockname=("::1", 4840))
+    assert ipv6 == "opc.tcp://[::1]:4840/freeopcua/server/"
+    ipv4 = isrv._mangle_endpoint_url(base, sockname=("127.0.0.1", 4840))
+    assert ipv4 == "opc.tcp://127.0.0.1:4840/freeopcua/server/"
+    already = isrv._mangle_endpoint_url(base, sockname=("[::1]", 4840))
+    assert already == "opc.tcp://[::1]:4840/freeopcua/server/"


### PR DESCRIPTION
### Summary
When `match_discovery_source_ip` rewrites the endpoint URL from `sockname`, IPv6 hosts were concatenated as `host:port` without RFC 2732 brackets. Wrap IPv6 hosts so clients can parse the URL.

### Validation
- Direct `_mangle_endpoint_url` checks: `::1` → `[::1]:4840`, IPv4 unchanged, already-bracketed host unchanged.

Fixes #1129

### AI/LLM disclosure
- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.

Made with [Cursor](https://cursor.com)