### PR TITLE
fix: set event filter TypeDefinitionId to the defining EventType

### DIFF
--- a/asyncua/common/events.py
+++ b/asyncua/common/events.py
@@ -138,6 +138,7 @@ async def _append_new_attribute_to_select_clauses(
     select_clauses: list[ua.SimpleAttributeOperand],
     already_selected: dict[str, str],
     browse_path: list[ua.QualifiedName],
+    type_definition_id: ua.NodeId,
 ) -> None:
     string_path = "/".join(map(str, browse_path))
     if string_path not in already_selected:
@@ -145,7 +146,7 @@ async def _append_new_attribute_to_select_clauses(
         op = ua.SimpleAttributeOperand()
         op.AttributeId = ua.AttributeIds.Value
         op.BrowsePath = browse_path
-        op.TypeDefinitionId = ua.NodeId(ua.ObjectIds.BaseEventType)
+        op.TypeDefinitionId = type_definition_id
         select_clauses.append(op)
 
 
@@ -155,16 +156,17 @@ async def _select_clause_from_childs(
     select_clauses: list[ua.SimpleAttributeOperand],
     already_selected: dict[str, str],
     browse_path: list[ua.QualifiedName],
+    type_definition_id: ua.NodeId,
 ) -> None:
     for ref in refs:
         if ref.NodeClass == ua.NodeClass.Variable:
             if ref.ReferenceTypeId == ua.ObjectIds.HasProperty:
                 await _append_new_attribute_to_select_clauses(
-                    select_clauses, already_selected, [*browse_path, ref.BrowseName]
+                    select_clauses, already_selected, [*browse_path, ref.BrowseName], type_definition_id
                 )
             else:
                 await _append_new_attribute_to_select_clauses(
-                    select_clauses, already_selected, [*browse_path, ref.BrowseName]
+                    select_clauses, already_selected, [*browse_path, ref.BrowseName], type_definition_id
                 )
                 var = child.new_node(child.session, ref.NodeId)
                 refs = await var.get_references(
@@ -175,7 +177,7 @@ async def _select_clause_from_childs(
                     _BROWSE_MASK,
                 )
                 await _select_clause_from_childs(
-                    var, refs, select_clauses, already_selected, [*browse_path, ref.BrowseName]
+                    var, refs, select_clauses, already_selected, [*browse_path, ref.BrowseName], type_definition_id
                 )
         elif ref.NodeClass == ua.NodeClass.Object:
             obj = child.new_node(child.session, ref.NodeId)
@@ -187,8 +189,25 @@ async def _select_clause_from_childs(
                 _BROWSE_MASK,
             )
             await _select_clause_from_childs(
-                obj, refs, select_clauses, already_selected, [*browse_path, ref.BrowseName]
+                obj, refs, select_clauses, already_selected, [*browse_path, ref.BrowseName], type_definition_id
             )
+
+
+async def _event_type_nodes_up_to_base(evtype: "Node") -> list["Node"]:
+    """Walk HasSubtype inverse from evtype to BaseEventType (inclusive)."""
+    nodes: list["Node"] = []
+    curr_node = evtype
+    while True:
+        nodes.append(curr_node)
+        if curr_node.nodeid == ua.NodeId(ua.ObjectIds.BaseEventType):
+            break
+        parents = await curr_node.get_referenced_nodes(
+            refs=ua.ObjectIds.HasSubtype, direction=ua.BrowseDirection.Inverse
+        )
+        if len(parents) != 1:
+            return []
+        curr_node = parents[0]
+    return nodes
 
 
 async def select_clauses_from_evtype(
@@ -200,18 +219,18 @@ async def select_clauses_from_evtype(
     for evtype in evtypes:
         if not add_condition_id and await is_subtype(evtype, ua.NodeId(ua.ObjectIds.ConditionType)):
             add_condition_id = True
-        refs = await select_event_attributes_from_type_node(
-            evtype,
-            lambda n: n.get_references(
+        type_nodes = await _event_type_nodes_up_to_base(evtype)
+        for type_node in type_nodes:
+            refs = await type_node.get_references(
                 ua.ObjectIds.Aggregates,
                 ua.BrowseDirection.Forward,
                 ua.NodeClass.Object | ua.NodeClass.Variable,
                 True,
                 _BROWSE_MASK,
-            ),
-        )
-        if refs:
-            await _select_clause_from_childs(evtype, refs, select_clauses, already_selected, [])
+            )
+            await _select_clause_from_childs(
+                type_node, refs, select_clauses, already_selected, [], type_node.nodeid
+            )
     if add_condition_id:
         op = ua.SimpleAttributeOperand()
         op.AttributeId = ua.AttributeIds.NodeId

--- a/asyncua/common/events.py
+++ b/asyncua/common/events.py
@@ -194,7 +194,7 @@ async def _select_clause_from_childs(
 
 
 async def _event_type_nodes_up_to_base(evtype: "Node") -> list["Node"]:
-    """Walk HasSubtype inverse from evtype to BaseEventType (inclusive)."""
+    """Return EventTypes from BaseEventType to evtype (introducing types first)."""
     nodes: list["Node"] = []
     curr_node = evtype
     while True:
@@ -207,6 +207,7 @@ async def _event_type_nodes_up_to_base(evtype: "Node") -> list["Node"]:
         if len(parents) != 1:
             return []
         curr_node = parents[0]
+    nodes.reverse()
     return nodes
 
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -732,6 +732,36 @@ async def test_get_event_contains_object(opc):
     assert browsePathId in browsePathList
 
 
+async def test_get_filter_typedefinitionid_is_defining_type(opc):
+    """Select clauses must use the EventType that introduces each field (Part 4 SimpleAttributeOperand)."""
+    alarm_type = opc.opc.get_node(ua.ObjectIds.AlarmConditionType)
+    evfilter = await asyncua.common.events.get_filter_from_event_type([alarm_type])
+    type_by_path = {
+        tuple(bp.Name for bp in op.BrowsePath): op.TypeDefinitionId
+        for op in evfilter.SelectClauses
+        if op.BrowsePath
+    }
+    expected = {
+        ("EventId",): ua.ObjectIds.BaseEventType,
+        ("Message",): ua.ObjectIds.BaseEventType,
+        ("Severity",): ua.ObjectIds.BaseEventType,
+        ("ConditionName",): ua.ObjectIds.ConditionType,
+        ("BranchId",): ua.ObjectIds.ConditionType,
+        ("EnabledState",): ua.ObjectIds.ConditionType,
+        ("EnabledState", "Id"): ua.ObjectIds.ConditionType,
+        ("Quality",): ua.ObjectIds.ConditionType,
+        ("Comment",): ua.ObjectIds.ConditionType,
+        ("AckedState",): ua.ObjectIds.AcknowledgeableConditionType,
+        ("AckedState", "Id"): ua.ObjectIds.AcknowledgeableConditionType,
+        ("ConfirmedState",): ua.ObjectIds.AcknowledgeableConditionType,
+        ("ActiveState",): ua.ObjectIds.AlarmConditionType,
+        ("ActiveState", "Id"): ua.ObjectIds.AlarmConditionType,
+        ("InputNode",): ua.ObjectIds.AlarmConditionType,
+    }
+    for path, type_id in expected.items():
+        assert type_by_path[path] == ua.NodeId(type_id)
+
+
 async def test_get_event_from_type_node_CustomEvent(opc):
     etype = await opc.server.create_custom_event_type(
         2,


### PR DESCRIPTION
Fixes https://github.com/FreeOpcUa/opcua-asyncio/issues/1968.

`get_filter_from_event_type()` hardcoded `SimpleAttributeOperand.TypeDefinitionId` to `BaseEventType` for every select clause. A server validating the declaring EventType can reject fields not defined on `BaseEventType` with `BadFilterOperandInvalid`.

This sets `TypeDefinitionId` to the EventType that introduces each field while walking the `HasSubtype` chain, matching Part 4 SimpleAttributeOperand. Nested browse paths (`EnabledState/Id`) keep the parent EventType. The extra Condition `NodeId` clause is unchanged.

Lenient servers that already ignored `TypeDefinitionId` keep working. A focused test on `AlarmConditionType` checks the mapping from #1968.

### AI/LLM disclosure
AI assistance: Cursor Agent assisted with the original implementation; Codex assisted with attribution cleanup and this description.
