### PR TITLE
fix(server): honor MaxNotificationsPerPublish

### DIFF
--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -8,12 +8,14 @@ import asyncio
 import logging
 import time
 from collections.abc import Awaitable, Callable, Iterable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from asyncua import ua
 
 from .address_space import AddressSpace
 from .monitored_item_service import MonitoredItemService
+
+NotificationT = TypeVar("NotificationT")
 
 if TYPE_CHECKING:
     from asyncua.server.uaprocessor import PublishRequestData
@@ -40,6 +42,7 @@ class InternalSubscription:
         no_acks_limit: int = 500,
         max_queue_size: int = 10_000,
         publishing_enabled: bool = True,
+        max_notifications_per_publish: int = 0,
     ) -> None:
         """
         :param loop: Event loop instance
@@ -70,6 +73,7 @@ class InternalSubscription:
         self._not_acknowledged_results: dict[int, ua.PublishResult] = {}
         self._startup = True
         self._publishing_enabled = publishing_enabled
+        self.max_notifications_per_publish = max_notifications_per_publish
         self._keep_alive_count = 0
         self._publish_cycles_count = 0
         self._task: asyncio.Task[None] | None = None
@@ -178,26 +182,29 @@ class InternalSubscription:
             if requestdata is None:
                 self._publish_cycles_count += 1
                 return False
-        result = self._pop_publish_result()
-        # self.logger.info('publish_results for %s', self.data.SubscriptionId)
-        if requestdata is None:
-            # Subscription.publish_callback -> server internal subscription
-            await self.pub_result_callback(result)
-        else:
-            # UaProcessor.forward_publish_response -> client subscription
-            await self.pub_result_callback(result, requestdata)
-        return True
+        while True:
+            result = self._pop_publish_result()
+            if requestdata is None:
+                await self.pub_result_callback(result)
+            else:
+                await self.pub_result_callback(result, requestdata)
+            if not result.MoreNotifications:
+                return True
+            if self.pub_request_callback:
+                requestdata = self.pub_request_callback(self.data.SubscriptionId)
+                if requestdata is None:
+                    return True
 
     def _pop_publish_result(self) -> ua.PublishResult:
         """
-        Return a `PublishResult` with all enqueued data changes, events and status changes.
-        Clear all queues.
+        Return a `PublishResult` while retaining notifications above the client limit.
         """
         result = ua.PublishResult()
         result.SubscriptionId = self.data.SubscriptionId
         if self._publishing_enabled:
-            self._pop_triggered_datachanges(result)
-            self._pop_triggered_events(result)
+            limit = self.max_notifications_per_publish or None
+            count = self._pop_triggered_datachanges(result, limit)
+            self._pop_triggered_events(result, None if limit is None else limit - count)
         self._pop_triggered_statuschanges(result)
         self._keep_alive_count = 0
         self._publish_cycles_count = 0
@@ -210,24 +217,39 @@ class InternalSubscription:
             while len(self._not_acknowledged_results) > self._no_acks_limit:
                 oldest = next(iter(self._not_acknowledged_results))
                 self._not_acknowledged_results.pop(oldest)
-        result.MoreNotifications = False
+        result.MoreNotifications = self._publishing_enabled and bool(
+            self._triggered_datachanges or self._triggered_events
+        )
         result.AvailableSequenceNumbers = list(self._not_acknowledged_results.keys())
         return result
 
-    def _pop_triggered_datachanges(self, result: ua.PublishResult) -> None:
-        """Append all enqueued data changes to the given `PublishResult` and clear the queue."""
-        if self._triggered_datachanges:
-            notif = ua.DataChangeNotification()
-            notif.MonitoredItems = [item for sublist in self._triggered_datachanges.values() for item in sublist]
-            self._triggered_datachanges = {}
-            result.NotificationMessage.NotificationData.append(notif)
+    @staticmethod
+    def _pop_notifications(queues: dict[int, list[NotificationT]], limit: int | None) -> list[NotificationT]:
+        items: list[NotificationT] = []
+        while queues and (limit is None or len(items) < limit):
+            mid = next(iter(queues))
+            queue = queues[mid]
+            count = len(queue) if limit is None else min(len(queue), limit - len(items))
+            items.extend(queue[:count])
+            if count == len(queue):
+                del queues[mid]
+            else:
+                del queue[:count]
+        return items
 
-    def _pop_triggered_events(self, result: ua.PublishResult) -> None:
-        """Append all enqueued events to the given `PublishResult` and clear the queue."""
-        if self._triggered_events:
+    def _pop_triggered_datachanges(self, result: ua.PublishResult, limit: int | None = None) -> int:
+        items = self._pop_notifications(self._triggered_datachanges, limit)
+        if items:
+            notif = ua.DataChangeNotification()
+            notif.MonitoredItems = items
+            result.NotificationMessage.NotificationData.append(notif)
+        return len(items)
+
+    def _pop_triggered_events(self, result: ua.PublishResult, limit: int | None = None) -> None:
+        items = self._pop_notifications(self._triggered_events, limit)
+        if items:
             notif = ua.EventNotificationList()
-            notif.Events = [item for sublist in self._triggered_events.values() for item in sublist]
-            self._triggered_events = {}
+            notif.Events = items
             result.NotificationMessage.NotificationData.append(notif)
 
     def _pop_triggered_statuschanges(self, result: ua.PublishResult) -> None:

--- a/asyncua/server/subscription_service.py
+++ b/asyncua/server/subscription_service.py
@@ -64,6 +64,7 @@ class SubscriptionService:
             no_acks_limit=no_acks_limit,
             max_queue_size=max_queue_size,
             publishing_enabled=params.PublishingEnabled,
+            max_notifications_per_publish=params.MaxNotificationsPerPublish,
         )
         await internal_sub.start()
         self.subscriptions[result.SubscriptionId] = internal_sub
@@ -82,11 +83,11 @@ class SubscriptionService:
         return min(requested, cap) if requested > 0 else cap
 
     def modify_subscription(self, params: ua.ModifySubscriptionParameters) -> ua.ModifySubscriptionResult:
-        # Requested params are ignored, result = params set during create_subscription.
         self.logger.info("modify subscription")
         result = ua.ModifySubscriptionResult()
         try:
             sub = self.subscriptions[params.SubscriptionId]
+            sub.max_notifications_per_publish = params.MaxNotificationsPerPublish
             result.RevisedPublishingInterval = sub.data.RevisedPublishingInterval
             result.RevisedLifetimeCount = sub.data.RevisedLifetimeCount
             result.RevisedMaxKeepAliveCount = sub.data.RevisedMaxKeepAliveCount

--- a/tests/test_publish_notification_limit.py
+++ b/tests/test_publish_notification_limit.py
@@ -1,0 +1,109 @@
+from typing import Any
+
+import pytest
+
+from asyncua import ua
+from asyncua.server.address_space import AddressSpace
+from asyncua.server.subscription_service import SubscriptionService
+from asyncua.server.uaprocessor import PublishRequestData
+
+
+async def _callback(*args: Any) -> None:
+    pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("limit", [0, 1, 2, 10, 15, 20])
+async def test_publish_notification_limit(limit: int) -> None:
+    service = SubscriptionService(AddressSpace())
+    params = ua.CreateSubscriptionParameters()
+    params.MaxNotificationsPerPublish = limit
+    params.PublishingEnabled = True
+    result = await service.create_subscription(params, _callback, ua.NodeId(1))
+    sub = service.subscriptions[result.SubscriptionId]
+    sub._triggered_datachanges = {
+        1: [ua.MonitoredItemNotification(ClientHandle=i) for i in range(7)],
+        2: [ua.MonitoredItemNotification(ClientHandle=i) for i in range(7, 12)],
+    }
+    sub._triggered_events = {3: [ua.EventFieldList(ClientHandle=i) for i in range(12, 15)]}
+    received = []
+    for _ in range(16):
+        response = sub._pop_publish_result()
+        batch = []
+        for notification in response.NotificationMessage.NotificationData:
+            if isinstance(notification, ua.DataChangeNotification):
+                batch.extend(item.ClientHandle for item in notification.MonitoredItems)
+            elif isinstance(notification, ua.EventNotificationList):
+                batch.extend(item.ClientHandle for item in notification.Events)
+        assert len(batch) <= (limit or 15)
+        received.extend(batch)
+        assert response.MoreNotifications == (len(received) < 15)
+        if not response.MoreNotifications:
+            break
+    assert received == list(range(15))
+    assert not sub._triggered_datachanges
+    assert not sub._triggered_events
+
+
+@pytest.mark.asyncio
+async def test_modify_limit_and_disabled_publishing() -> None:
+    service = SubscriptionService(AddressSpace())
+    params = ua.CreateSubscriptionParameters(PublishingEnabled=False, MaxNotificationsPerPublish=1)
+    result = await service.create_subscription(params, _callback, ua.NodeId(1))
+    sub = service.subscriptions[result.SubscriptionId]
+    sub._triggered_events = {1: [ua.EventFieldList(ClientHandle=i) for i in range(3)]}
+    sub._triggered_statuschanges = [ua.StatusCode()]
+    response = sub._pop_publish_result()
+    assert not response.MoreNotifications
+    assert len(sub._triggered_events[1]) == 3
+    assert isinstance(response.NotificationMessage.NotificationData[0], ua.StatusChangeNotification)
+    service.modify_subscription(
+        ua.ModifySubscriptionParameters(SubscriptionId=result.SubscriptionId, MaxNotificationsPerPublish=2)
+    )
+    sub._publishing_enabled = True
+    response = sub._pop_publish_result()
+    assert len(response.NotificationMessage.NotificationData[0].Events) == 2
+    assert response.MoreNotifications
+    service.modify_subscription(
+        ua.ModifySubscriptionParameters(SubscriptionId=result.SubscriptionId, MaxNotificationsPerPublish=0)
+    )
+    response = sub._pop_publish_result()
+    assert len(response.NotificationMessage.NotificationData[0].Events) == 1
+    assert not response.MoreNotifications
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_requests", [False, True])
+async def test_publish_drains_available_requests(with_requests: bool) -> None:
+    responses: list[ua.PublishResult] = []
+    requests = [PublishRequestData(), PublishRequestData()]
+    consumed: list[PublishRequestData | None] = []
+
+    async def callback(response: ua.PublishResult, request: PublishRequestData | None = None) -> None:
+        responses.append(response)
+        consumed.append(request)
+
+    def request_callback(subscription_id: int) -> PublishRequestData | None:
+        return requests.pop(0) if requests else None
+
+    service = SubscriptionService(AddressSpace())
+    params = ua.CreateSubscriptionParameters(
+        PublishingEnabled=True, MaxNotificationsPerPublish=2, RequestedLifetimeCount=100
+    )
+    result = await service.create_subscription(
+        params, callback, ua.NodeId(1), request_callback if with_requests else None
+    )
+    sub = service.subscriptions[result.SubscriptionId]
+    sub._triggered_datachanges = {1: [ua.MonitoredItemNotification(ClientHandle=i) for i in range(5)]}
+    assert await sub.publish_results()
+    if with_requests:
+        assert len(responses) == 2
+        assert len(sub._triggered_datachanges[1]) == 1
+        assert not await sub.publish_results()
+        assert len(responses) == 2
+        assert await sub.publish_results(PublishRequestData())
+        assert len({id(request) for request in consumed}) == 3
+        assert [response.NotificationMessage.SequenceNumber for response in responses] == [1, 2, 3]
+        assert sub.republish(1).NotificationData[0].MonitoredItems[0].ClientHandle == 0
+    assert [len(response.NotificationMessage.NotificationData[0].MonitoredItems) for response in responses] == [2, 2, 1]
+    assert [response.MoreNotifications for response in responses] == [True, True, False]

--- a/tests/test_publish_notification_limit.py
+++ b/tests/test_publish_notification_limit.py
@@ -1,11 +1,14 @@
+import asyncio
 from typing import Any
 
 import pytest
 
-from asyncua import ua
+from asyncua import Client, Server, ua
 from asyncua.server.address_space import AddressSpace
 from asyncua.server.subscription_service import SubscriptionService
 from asyncua.server.uaprocessor import PublishRequestData
+
+from .conftest import find_free_port
 
 
 async def _callback(*args: Any) -> None:
@@ -107,3 +110,60 @@ async def test_publish_drains_available_requests(with_requests: bool) -> None:
         assert sub.republish(1).NotificationData[0].MonitoredItems[0].ClientHandle == 0
     assert [len(response.NotificationMessage.NotificationData[0].MonitoredItems) for response in responses] == [2, 2, 1]
     assert [response.MoreNotifications for response in responses] == [True, True, False]
+
+
+@pytest.mark.asyncio
+async def test_notification_limit_over_tcp() -> None:
+    server = Server()
+    await server.init()
+    endpoint = f"opc.tcp://127.0.0.1:{find_free_port()}"
+    server.set_endpoint(endpoint)
+    nodes = [await server.nodes.objects.add_variable(2, f"Limited{i}", i) for i in range(5)]
+    batches: list[list[int]] = []
+    more: list[bool] = []
+    complete = asyncio.Event()
+
+    async def callback(response: ua.PublishResult) -> None:
+        for notification in response.NotificationMessage.NotificationData:
+            if isinstance(notification, ua.DataChangeNotification):
+                batches.append([item.ClientHandle for item in notification.MonitoredItems])
+                more.append(response.MoreNotifications)
+                if sum(map(len, batches)) == 5:
+                    complete.set()
+
+    async with server:
+        async with Client(endpoint) as client:
+            subscription = await client.uaclient.create_subscription(
+                ua.CreateSubscriptionParameters(
+                    RequestedPublishingInterval=50,
+                    RequestedLifetimeCount=1000,
+                    RequestedMaxKeepAliveCount=20,
+                    MaxNotificationsPerPublish=2,
+                    PublishingEnabled=False,
+                ),
+                callback,
+            )
+            try:
+                items = [
+                    ua.MonitoredItemCreateRequest(
+                        ItemToMonitor=ua.ReadValueId(NodeId=node.nodeid, AttributeId=ua.AttributeIds.Value),
+                        MonitoringMode=ua.MonitoringMode.Reporting,
+                        RequestedParameters=ua.MonitoringParameters(ClientHandle=i, QueueSize=1),
+                    )
+                    for i, node in enumerate(nodes)
+                ]
+                results = await client.uaclient.create_monitored_items(
+                    ua.CreateMonitoredItemsParameters(SubscriptionId=subscription.SubscriptionId, ItemsToCreate=items)
+                )
+                for result in results:
+                    result.StatusCode.check()
+                await client.uaclient.set_publishing_mode(
+                    ua.SetPublishingModeParameters(
+                        PublishingEnabled=True, SubscriptionIds=[subscription.SubscriptionId]
+                    )
+                )
+                await asyncio.wait_for(complete.wait(), 5)
+                assert batches == [[0, 1], [2, 3], [4]]
+                assert more == [True, True, False]
+            finally:
+                await client.uaclient.delete_subscriptions([subscription.SubscriptionId])


### PR DESCRIPTION
Fixes #1931.

Honor MaxNotificationsPerPublish from CreateSubscription and ModifySubscription. Data changes and events share one budget; excess notifications remain queued and MoreNotifications is set while data remains. Zero means unlimited. Pending batches consume available Publish requests and wait when none remain. Internal subscriptions continue without request tokens.

The behavior follows [OPC UA Part 4, Subscription Service Set](https://reference.opcfoundation.org/specs/OPC-10000-4/5.14) and [Publish](https://reference.opcfoundation.org/specs/OPC-10000-4/5.14.5).

On Python 3.12.11, ten focused cases and the latest selected suite of 194 tests passed. Coverage includes mixed notifications, limits, modification, disabled publishing, token exhaustion, internal publishing and republish content. A loopback TCP case observes batches of 2/2/1 and MoreNotifications true/true/false. Ruff and targeted mypy passed.

An earlier run hit the existing `test_too_many_publish[client]` task-order assertion. Repeated untouched-base tests passed, so that failure has not been conclusively classified as pre-existing. No unrelated test was changed; no full-repository or multi-platform result is claimed.

AI tools assisted with implementation, regression tests and this description.
