### PR TITLE
fix(server): await node deletion callbacks

### DIFF
--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -414,11 +414,21 @@ class NodeManagementService:
         self, deletenodeitems: ua.DeleteNodesParameters, user: User = User(role=UserRole.Admin)
     ) -> list[ua.StatusCode]:
         results: list[ua.StatusCode] = []
+        callbacks: list[tuple[int, Callable[..., Any]]] = []
         for item in deletenodeitems.NodesToDelete:
-            results.append(await self._delete_node(item, user))
+            results.append(self._delete_node(item, user, callbacks))
+        # Complete the whole request's address-space changes before any callback
+        # can yield control to another request. Notification does not need a lock.
+        for handle, callback in callbacks:
+            try:
+                await callback(handle, None, ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown))
+            except Exception:
+                self.logger.exception("Error calling delete node callback %s", handle)
         return results
 
-    async def _delete_node(self, item: ua.DeleteNodesItem, user: User) -> ua.StatusCode:
+    def _delete_node(
+        self, item: ua.DeleteNodesItem, user: User, callbacks: list[tuple[int, Callable[..., Any]]]
+    ) -> ua.StatusCode:
         if user.role != UserRole.Admin:
             return ua.StatusCode(ua.StatusCodes.BadUserAccessDenied)
 
@@ -432,23 +442,19 @@ class NodeManagementService:
                     if rdesc.NodeId == item.NodeId:
                         self._aspace[elem].references.remove(rdesc)
 
-        await self._delete_node_callbacks(self._aspace[item.NodeId])
+        callbacks.extend(self._delete_node_callbacks(self._aspace[item.NodeId]))
 
         del self._aspace[item.NodeId]
 
         return ua.StatusCode()
 
-    async def _delete_node_callbacks(self, nodedata: NodeData) -> None:
+    def _delete_node_callbacks(self, nodedata: NodeData) -> list[tuple[int, Callable[..., Any]]]:
+        callbacks: list[tuple[int, Callable[..., Any]]] = []
         if ua.AttributeIds.Value in nodedata.attributes:
-            for handle, callback in list(nodedata.attributes[ua.AttributeIds.Value].datachange_callbacks.items()):
-                try:
-                    await callback(handle, None, ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown))
-                except Exception as ex:
-                    self.logger.exception(
-                        "Error calling delete node callback callback %s, %s, %s", nodedata, ua.AttributeIds.Value, ex
-                    )
-                finally:
-                    self._aspace.delete_datachange_callback(handle)
+            callbacks = list(nodedata.attributes[ua.AttributeIds.Value].datachange_callbacks.items())
+            for handle, _ in callbacks:
+                self._aspace.delete_datachange_callback(handle)
+        return callbacks
 
     def add_references(
         self, refs: list[ua.AddReferencesItem], user: User = User(role=UserRole.Admin)

--- a/asyncua/server/address_space.py
+++ b/asyncua/server/address_space.py
@@ -410,15 +410,15 @@ class NodeManagementService:
         addref.TargetNodeClass = ua.NodeClass.Unspecified
         self._add_reference_no_check(nodedata, addref)  # FIXME return StatusCode is not evaluated
 
-    def delete_nodes(
+    async def delete_nodes(
         self, deletenodeitems: ua.DeleteNodesParameters, user: User = User(role=UserRole.Admin)
     ) -> list[ua.StatusCode]:
         results: list[ua.StatusCode] = []
         for item in deletenodeitems.NodesToDelete:
-            results.append(self._delete_node(item, user))
+            results.append(await self._delete_node(item, user))
         return results
 
-    def _delete_node(self, item: ua.DeleteNodesItem, user: User) -> ua.StatusCode:
+    async def _delete_node(self, item: ua.DeleteNodesItem, user: User) -> ua.StatusCode:
         if user.role != UserRole.Admin:
             return ua.StatusCode(ua.StatusCodes.BadUserAccessDenied)
 
@@ -432,22 +432,23 @@ class NodeManagementService:
                     if rdesc.NodeId == item.NodeId:
                         self._aspace[elem].references.remove(rdesc)
 
-        self._delete_node_callbacks(self._aspace[item.NodeId])
+        await self._delete_node_callbacks(self._aspace[item.NodeId])
 
         del self._aspace[item.NodeId]
 
         return ua.StatusCode()
 
-    def _delete_node_callbacks(self, nodedata: NodeData) -> None:
+    async def _delete_node_callbacks(self, nodedata: NodeData) -> None:
         if ua.AttributeIds.Value in nodedata.attributes:
             for handle, callback in list(nodedata.attributes[ua.AttributeIds.Value].datachange_callbacks.items()):
                 try:
-                    callback(handle, None, ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown))
-                    self._aspace.delete_datachange_callback(handle)
+                    await callback(handle, None, ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown))
                 except Exception as ex:
                     self.logger.exception(
                         "Error calling delete node callback callback %s, %s, %s", nodedata, ua.AttributeIds.Value, ex
                     )
+                finally:
+                    self._aspace.delete_datachange_callback(handle)
 
     def add_references(
         self, refs: list[ua.AddReferencesItem], user: User = User(role=UserRole.Admin)

--- a/asyncua/server/internal_session.py
+++ b/asyncua/server/internal_session.py
@@ -263,7 +263,7 @@ class InternalSession(AbstractSession):
         return self.iserver.node_mgt_service.add_nodes(params, self.user)
 
     async def delete_nodes(self, params: ua.DeleteNodesParameters) -> list[ua.StatusCode]:
-        return self.iserver.node_mgt_service.delete_nodes(params, self.user)
+        return await self.iserver.node_mgt_service.delete_nodes(params, self.user)
 
     async def add_references(self, params: list[ua.AddReferencesItem]) -> list[ua.StatusCode]:
         return self.iserver.node_mgt_service.add_references(params, self.user)

--- a/asyncua/server/internal_subscription.py
+++ b/asyncua/server/internal_subscription.py
@@ -133,7 +133,11 @@ class InternalSubscription:
             await self._trigger_publish()
 
     def has_published_results(self) -> bool:
-        if self._startup or (self._publishing_enabled and (self._triggered_datachanges or self._triggered_events)):
+        if (
+            self._startup
+            or self._triggered_statuschanges
+            or (self._publishing_enabled and (self._triggered_datachanges or self._triggered_events))
+        ):
             return True
         self._keep_alive_count += 1
         if self._keep_alive_count >= self.data.RevisedMaxKeepAliveCount:

--- a/tests/test_node_deletion_callbacks.py
+++ b/tests/test_node_deletion_callbacks.py
@@ -64,3 +64,43 @@ async def test_delete_node_cleans_up_failed_callback_and_notifies_others(opc: Op
         callback.assert_awaited_once_with(handle, None, ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown))
         assert handle not in aspace._handle_to_attribute_map
     assert node.nodeid not in aspace
+
+
+async def test_delete_batch_finishes_mutation_before_callback_yields(opc: Opc) -> None:
+    parent = await opc.opc.nodes.objects.add_object(2, "AtomicDeletionParent")
+    nodes = [await parent.add_variable(2, f"AtomicDeletion{index}", 42) for index in range(2)]
+    aspace = opc.server.iserver.aspace
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    notifications = []
+
+    async def suspended_callback(handle, value, status):
+        notifications.append(handle)
+        entered.set()
+        await release.wait()
+
+    handles = []
+    for node in nodes:
+        status, handle = aspace.add_datachange_callback(node.nodeid, ua.AttributeIds.Value, suspended_callback)
+        status.check()
+        handles.append(handle)
+
+    deletion = asyncio.create_task(opc.opc.delete_nodes(nodes))
+    try:
+        await asyncio.wait_for(entered.wait(), 2)
+        # The first notification is suspended: another task must already see
+        # the complete batch and handle/reference cleanup, not half a request.
+        deleted_ids = {node.nodeid for node in nodes}
+        assert all(nodeid not in aspace for nodeid in deleted_ids)
+        assert all(handle not in aspace._handle_to_attribute_map for handle in handles)
+        assert all(ref.NodeId not in deleted_ids for ref in aspace[parent.nodeid].references)
+        params = ua.DeleteNodesParameters(
+            NodesToDelete=[ua.DeleteNodesItem(NodeId=node.nodeid, DeleteTargetReferences=True) for node in nodes]
+        )
+        results = await asyncio.wait_for(opc.server.iserver.isession.delete_nodes(params), 2)
+        assert results == [ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown)] * len(nodes)
+    finally:
+        release.set()
+        await asyncio.wait_for(deletion, 2)
+        await parent.delete()
+    assert notifications == handles

--- a/tests/test_node_deletion_callbacks.py
+++ b/tests/test_node_deletion_callbacks.py
@@ -1,0 +1,66 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from asyncua import ua
+
+from .conftest import Opc
+
+
+@pytest.mark.parametrize("node_count", [1, 2])
+@pytest.mark.parametrize("subscriber_count", [1, 2])
+async def test_delete_monitored_node_notifies_subscriber(opc: Opc, node_count: int, subscriber_count: int) -> None:
+    nodes = [
+        await opc.opc.nodes.objects.add_variable(2, f"DeletedMonitoredVariable{index}", 42)
+        for index in range(node_count)
+    ]
+    handler = AsyncMock()
+    initial_values: asyncio.Queue[None] = asyncio.Queue()
+    received: asyncio.Queue[ua.StatusCode] = asyncio.Queue()
+    handler.datachange_notification.side_effect = lambda *_: initial_values.put_nowait(None)
+
+    async def status_change(notification: ua.StatusChangeNotification) -> None:
+        received.put_nowait(notification.Status)
+
+    handler.status_change_notification.side_effect = status_change
+    subscriptions = []
+    try:
+        for _ in range(subscriber_count):
+            subscription = await opc.opc.create_subscription(10, handler)
+            subscriptions.append(subscription)
+            await subscription.subscribe_data_change(nodes)
+        for _ in range(node_count * subscriber_count):
+            await asyncio.wait_for(initial_values.get(), 2)
+        _, results = await opc.opc.delete_nodes(nodes)
+        assert results == [ua.StatusCode()] * node_count
+        for _ in range(node_count * subscriber_count):
+            assert await asyncio.wait_for(received.get(), 2) == ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown)
+        assert handler.status_change_notification.await_count == node_count * subscriber_count
+        deleted_ids = {node.nodeid for node in nodes}
+        assert all(
+            nodeid not in deleted_ids for nodeid, _ in opc.server.iserver.aspace._handle_to_attribute_map.values()
+        )
+    finally:
+        for subscription in subscriptions:
+            await subscription.delete()
+
+
+async def test_delete_node_cleans_up_failed_callback_and_notifies_others(opc: Opc) -> None:
+    node = await opc.opc.nodes.objects.add_variable(2, "DeletedCallbackVariable", 42)
+    aspace = opc.server.iserver.aspace
+    failed_callback = AsyncMock(side_effect=RuntimeError("callback failed"))
+    completed_callback = AsyncMock()
+    handles = []
+    for callback in (failed_callback, completed_callback):
+        status, handle = aspace.add_datachange_callback(node.nodeid, ua.AttributeIds.Value, callback)
+        status.check()
+        handles.append(handle)
+
+    _, results = await opc.opc.delete_nodes([node])
+
+    assert results == [ua.StatusCode()]
+    for callback, handle in zip((failed_callback, completed_callback), handles):
+        callback.assert_awaited_once_with(handle, None, ua.StatusCode(ua.StatusCodes.BadNodeIdUnknown))
+        assert handle not in aspace._handle_to_attribute_map
+    assert node.nodeid not in aspace


### PR DESCRIPTION
## Summary

Fixes #1771 by awaiting asynchronous node-deletion notifications after the entire batch finishes mutating the address space. Node/reference removal and callback-handle cleanup remain synchronous, so another asyncio task cannot observe a partially deleted batch. A failing callback does not prevent subsequent callbacks from running.

Pending status changes can trigger publishing without waiting for keepalive expiry. This preserves the existing `StatusChangeNotification(BadNodeIdUnknown)` path.

## Validation

- 224 callback, deletion and common tests passed.
- New client/server regression suspends a callback, verifies complete batch cleanup, and retries deletion concurrently. It fails on the previous implementation and passes with this fix.
- Ruff and mypy passed (146 source files).

AI-assisted implementation and tests; code and test evidence reviewed by Codex.
