### PR TITLE
Keep aggregate ServerStatus timestamps consistent with components

### DIFF
--- a/asyncua/server/internal_server.py
+++ b/asyncua/server/internal_server.py
@@ -103,6 +103,7 @@ class InternalServer:
             self, self.aspace, self.subscription_service, "Internal", user=User(role=UserRole.Admin)
         )
         self.current_time_node = Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus_CurrentTime))
+        self.server_status_node = Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus))
         self.time_task: asyncio.Task[None] | None = None
         self._time_task_stop = False
         self.match_discovery_endpoint_url: bool = True
@@ -223,12 +224,14 @@ class InternalServer:
         self.logger.info("starting internal server")
         for edp in self.endpoints:
             self._known_servers[edp.Server.ApplicationUri] = ServerDesc(edp.Server)
+        status = copy(await self.server_status_node.read_value()) or ua.ServerStatusDataType()
+        status.State = ua.ServerState.Running
+        status.StartTime = datetime.now(timezone.utc)
+        await self.server_status_node.write_value(status)
         await Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus_State)).write_value(
             ua.ServerState.Running, ua.VariantType.Int32
         )
-        await Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus_StartTime)).write_value(
-            datetime.now(timezone.utc)
-        )
+        await Node(self.isession, ua.NodeId(ua.ObjectIds.Server_ServerStatus_StartTime)).write_value(status.StartTime)
         if not self.disabled_clock:
             self.time_task = asyncio.create_task(self._set_current_time_loop())
 
@@ -243,7 +246,10 @@ class InternalServer:
 
     async def _set_current_time_loop(self) -> None:
         while not self._time_task_stop:
-            await self.current_time_node.write_value(datetime.now(timezone.utc))
+            status = copy(await self.server_status_node.read_value())
+            status.CurrentTime = datetime.now(timezone.utc)
+            await self.server_status_node.write_value(status)
+            await self.current_time_node.write_value(status.CurrentTime)
             await asyncio.sleep(1)
 
     def get_new_channel_id(self) -> int:

--- a/tests/test_server_status.py
+++ b/tests/test_server_status.py
@@ -1,0 +1,82 @@
+import asyncio
+from copy import deepcopy
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from asyncua import Server, ua
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("field", ["StartTime", "CurrentTime"])
+async def test_server_status_timestamps_match_components(opc: Any, field: str) -> None:
+    status_node = opc.opc.get_node(ua.ObjectIds.Server_ServerStatus)
+    component = await status_node.get_child(f"0:{field}")
+    for _ in range(30):
+        value = await status_node.read_data_value()
+        assert value.StatusCode.is_good()
+        assert value.Value is not None
+        status = value.Value.Value
+        assert value.SourceTimestamp >= status.CurrentTime
+        component_value = await component.read_value()
+        if getattr(status, field) == component_value:
+            break
+        await asyncio.sleep(0.1)
+    assert getattr(status, field) == component_value
+
+
+async def test_server_status_clock_updates_preserve_fields(server: Server) -> None:
+    status_node = server.get_node(ua.ObjectIds.Server_ServerStatus)
+    await server.set_build_info("urn:test", "Manufacturer", "Product", "2.0", "42", datetime.now(timezone.utc))
+    before = deepcopy(await status_node.read_value())
+    for _ in range(30):
+        current = await status_node.read_value()
+        if current.CurrentTime > before.CurrentTime:
+            break
+        await asyncio.sleep(0.1)
+    assert current.CurrentTime > before.CurrentTime
+    assert current.StartTime == before.StartTime
+    assert current.BuildInfo == before.BuildInfo
+    assert current.State == before.State
+    assert current.SecondsTillShutdown == before.SecondsTillShutdown
+    assert current.ShutdownReason == before.ShutdownReason
+
+
+@pytest.mark.parametrize("disabled_clock", [False, True])
+async def test_server_status_start_time_and_clock_shutdown(disabled_clock: bool) -> None:
+    server = Server()
+    await server.init()
+    server.iserver.disabled_clock = disabled_clock
+    before = datetime.now(timezone.utc)
+    await server.iserver.start()
+    try:
+        status = await server.get_node(ua.ObjectIds.Server_ServerStatus).read_value()
+        start = await server.get_node(ua.ObjectIds.Server_ServerStatus_StartTime).read_value()
+        assert before <= status.StartTime <= datetime.now(timezone.utc)
+        assert status.StartTime == start
+        assert (server.iserver.time_task is None) == disabled_clock
+    finally:
+        await server.iserver.stop()
+    if server.iserver.time_task is not None:
+        assert server.iserver.time_task.done()
+
+
+async def test_server_status_subscription_receives_clock_updates(opc: Any) -> None:
+    values: asyncio.Queue[ua.ServerStatusDataType] = asyncio.Queue()
+
+    class Handler:
+        def datachange_notification(self, node: Any, value: ua.ServerStatusDataType, data: Any) -> None:
+            values.put_nowait(deepcopy(value))
+
+    subscription = await opc.opc.create_subscription(20, Handler())
+    try:
+        await subscription.subscribe_data_change(opc.opc.get_node(ua.ObjectIds.Server_ServerStatus))
+        before = await asyncio.wait_for(values.get(), 3)
+        after = await asyncio.wait_for(values.get(), 3)
+        assert after.CurrentTime > before.CurrentTime
+        assert after.StartTime == before.StartTime
+        assert after.BuildInfo == before.BuildInfo
+    finally:
+        await subscription.delete()


### PR DESCRIPTION
Fixes #1469.

Update the aggregate ServerStatus value alongside its StartTime and CurrentTime nodes. Each clock tick writes a copy so subscriptions observe the update without mutating the previous stored value. BuildInfo, disabled-clock startup and shutdown behavior are preserved. Separate node reads are not atomic.

Nine regressions failed on unchanged upstream and passed with the patch. They cover local/TCP reads, timestamps, BuildInfo, disabled clocks, shutdown and aggregate subscriptions. Ruff and targeted mypy passed on Python 3.12.

The existing selected suite passed 148 tests with one skip. Other runs hit an intermittent `test_too_many_publish[client]` task-identity assertion, also reproduced on pristine upstream; it is not fixed by this change. Validation used local loopback servers.

Focused command: `uv run pytest tests/test_server_status.py -q`.

Codex assisted with implementation, tests, baseline comparison and this description.
